### PR TITLE
fix core samples reverse connect config and reconnect handlers

### DIFF
--- a/Samples/NetCoreComplexClient/NetCoreComplexClient.csproj
+++ b/Samples/NetCoreComplexClient/NetCoreComplexClient.csproj
@@ -24,11 +24,13 @@
       <Choose>
         <When Condition="'$(Configuration)'=='Release'">
           <ItemGroup>
+            <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="1.4.363.49" />
             <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client.ComplexTypes" Version="1.4.363.49" />
           </ItemGroup>
         </When>
         <Otherwise>
           <ItemGroup>
+            <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Symbols" Version="1.4.363.49" />
             <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client.ComplexTypes.Symbols" Version="1.4.363.49" />
           </ItemGroup>
         </Otherwise>
@@ -42,9 +44,6 @@
 
   <ItemGroup>
     <PackageReference Include="Mono.Options" Version="5.3.0.1" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="1.4.363.49" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client.ComplexTypes" Version="1.4.363.49" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Symbols" Version="1.4.363.49" />
     <PackageReference Include="System.Runtime.Extensions" Version="4.3.1" />
   </ItemGroup>
 

--- a/Samples/NetCoreComplexClient/Opc.Ua.ComplexClient.Config.xml
+++ b/Samples/NetCoreComplexClient/Opc.Ua.ComplexClient.Config.xml
@@ -74,6 +74,17 @@
       This ensures subscriptions are not set to expire too quickly. The requesed lifetime count
       and keep alive count are calculated using this value and the request publishing interval -->
     <MinSubscriptionLifetime>10000</MinSubscriptionLifetime>
+
+    <ReverseConnect>
+      <ClientEndpoints>
+        <ClientEndpoint>
+          <!--<EndpointUrl>opc.tcp://localhost:65300</EndpointUrl>-->
+        </ClientEndpoint>
+      </ClientEndpoints>
+      <HoldTime>15000</HoldTime>
+      <WaitTimeout>20000</WaitTimeout>
+    </ReverseConnect>
+
   </ClientConfiguration>
   
   <TraceConfiguration>

--- a/Samples/NetCoreConsoleServer/NetCoreConsoleServer.csproj
+++ b/Samples/NetCoreConsoleServer/NetCoreConsoleServer.csproj
@@ -25,8 +25,19 @@
 
   <ItemGroup>
     <PackageReference Include="Mono.Options" Version="5.3.0.1" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="1.4.363.49" />
   </ItemGroup>
+  <Choose>
+    <When Condition="'$(Configuration)'=='Release'">
+      <ItemGroup>
+        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="1.4.363.49" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Symbols" Version="1.4.363.49" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
 
   <ItemGroup>
     <None Update="Opc.Ua.SampleServer.Config.xml">


### PR DESCRIPTION
- workaround for an issue in the reverse connect manager if no config is present hit an exception even in the latest nuget. Added <ReverseConnect> fields to config to preset config variable.
- minor improvements of csproj files
- fix sessionreconnecthandler in client 

to test NetCoreComplexClient with NetCoreConsoleServer:

The client and host use the reverse connect port 65300.  
```
NetCoreComplexClient: -a -rc opc.tcp://localhost:65300 opc.tcp://localhost:51210/UA/SampleServer
NetCoreConsoleServer: -a -r opc.tcp://localhost:65300 
```
