### PR TITLE
Fix deadlock 

### DIFF
--- a/ComIOP/Common/Client/ComClientNodeManager.cs
+++ b/ComIOP/Common/Client/ComClientNodeManager.cs
@@ -122,14 +122,8 @@ namespace Opc.Ua.Com.Client
 
                 if (availableLocales != null)
                 {
-                    lock (Server.DiagnosticsLock)
+                    lock (Server.DiagnosticsNodeManager.Lock)
                     {
-                        // check if the server is running.
-                        if (!Server.IsRunning)
-                        {
-                            return;
-                        }
-
                         // get the LocaleIdArray property.
                         BaseVariableState localeArray = Server.DiagnosticsNodeManager.Find(Opc.Ua.VariableIds.Server_ServerCapabilities_LocaleIdArray) as BaseVariableState;
 

--- a/ComIOP/Common/Client/Hda/ComHdaClientNodeManager.cs
+++ b/ComIOP/Common/Client/Hda/ComHdaClientNodeManager.cs
@@ -1478,7 +1478,7 @@ namespace Opc.Ua.Com.Client
                     }
                 }
 
-                lock (Server.DiagnosticsLock)
+                lock (Server.DiagnosticsNodeManager.Lock)
                 {
                     HistoryServerCapabilitiesState capabilities = Server.DiagnosticsNodeManager.GetDefaultHistoryCapabilities();
 


### PR DESCRIPTION
Used Server.DiagnosticsNodeManager.Lock instead of Server.DiagnosticsLock to prevent deadlock
Related to https://github.com/OPCFoundation/UA-.NETStandard/issues/1635