### PR TITLE
Fixing unused parameters in calling of RequestNewCertificatePushMode and UpdateCertificate method.

### DIFF
--- a/Samples/GDS/Client/Controls/ApplicationCertificateControl.cs
+++ b/Samples/GDS/Client/Controls/ApplicationCertificateControl.cs
@@ -183,12 +183,13 @@ namespace Opc.Ua.Gds.Client
         {
             try
             {
+                byte[] unusedNonce = new byte[0];
                 byte[] certificateRequest = m_server.CreateSigningRequest(
-                    null,
+                    NodeId.Null,
                     m_server.ApplicationCertificateType,
-                    null,
+                    string.Empty,
                     false,
-                    null);
+                    unusedNonce);
                 var domainNames = m_application.GetDomainNames(m_certificate);
                 NodeId requestId = m_gds.StartSigningRequest(
                     m_application.ApplicationId,
@@ -448,12 +449,13 @@ namespace Opc.Ua.Gds.Client
                         var x509 = new X509Certificate2(privateKeyPFX, m_certificatePassword, X509KeyStorageFlags.Exportable);
                         privateKeyPFX = x509.Export(X509ContentType.Pfx);
                     }
+                    byte[] unusedPrivateKey = new byte[0];
                     bool applyChanges = m_server.UpdateCertificate(
-                        null,
+                        NodeId.Null,
                         m_server.ApplicationCertificateType,
                         certificate,
-                        (privateKeyPFX != null) ? "PFX" : null,
-                        privateKeyPFX,
+                        (privateKeyPFX != null) ? "pfx" : String.Empty,
+                        (privateKeyPFX != null) ? privateKeyPFX : unusedPrivateKey,
                         issuerCertificates);
                     if (applyChanges)
                     {


### PR DESCRIPTION
There was fixed the format of unused parameters in calling of RequestNewCertificatePushMode and UpdateCertificate method.
Null values of parameters were exchanged with empty variables of correct type.
The null parameters cause that the OPC UA service doesn't contain correct types in methods call, there are 0 value of type, but there should be correct type event it's not used in the concrete calling of the method. Some clients doesn't accept this behavior.