### PR TITLE
fix GDS ConsoleServer dockerfile to use correct base image

### DIFF
--- a/Samples/GDS/ConsoleServer/Dockerfile
+++ b/Samples/GDS/ConsoleServer/Dockerfile
@@ -1,4 +1,4 @@
-﻿FROM mcr.microsoft.com/dotnet/core/runtime:3.1-buster-slim AS base
+﻿FROM mcr.microsoft.com/dotnet/runtime:6.0-bullseye-slim AS base
 
 COPY ./publish /publish
 WORKDIR /publish


### PR DESCRIPTION
The base for dockerfile only supports 3.1.29 version whereas the required runtime is 6.0.0. The GDS console server requires "6.0-bullseye-slim" tag to run in docker container. Therefore the base image is update to 6.0-bullseye-slim.

Signed-off-by: Muddasir Shakil <muddasir.shakil@linutronix.de>