### PR TITLE
Fix utility method to continue browsing when BrowseNext returns another continuation point

### DIFF
--- a/ComIOP/Common/Server/Ae2/ComAeUtils.cs
+++ b/ComIOP/Common/Server/Ae2/ComAeUtils.cs
@@ -114,7 +114,7 @@ namespace Opc.Ua.Com.Server
                     }
 
                     // process continuation points.
-                    ByteStringCollection revisedContiuationPoints = new ByteStringCollection();
+                    ByteStringCollection revisedContinuationPoints = new ByteStringCollection();
 
                     while (continuationPoints.Count > 0)
                     {
@@ -149,12 +149,12 @@ namespace Opc.Ua.Com.Server
                             // check for continuation point.
                             if (results[ii].ContinuationPoint != null)
                             {
-                                revisedContiuationPoints.Add(results[ii].ContinuationPoint);
+                                revisedContinuationPoints.Add(results[ii].ContinuationPoint);
                             }
                         }
 
                         // check if browsing must continue;
-                        revisedContiuationPoints = continuationPoints;
+                        continuationPoints = revisedContinuationPoints;
                     }
 
                     // check if unprocessed results exist.

--- a/Samples/ClientControls.Net4/ClientUtils.cs
+++ b/Samples/ClientControls.Net4/ClientUtils.cs
@@ -368,7 +368,7 @@ namespace Opc.Ua.Client.Controls
                     }
 
                     // process continuation points.
-                    ByteStringCollection revisedContiuationPoints = new ByteStringCollection();
+                    ByteStringCollection revisedContinuationPoints = new ByteStringCollection();
 
                     while (continuationPoints.Count > 0)
                     {
@@ -403,12 +403,12 @@ namespace Opc.Ua.Client.Controls
                             // check for continuation point.
                             if (results[ii].ContinuationPoint != null)
                             {
-                                revisedContiuationPoints.Add(results[ii].ContinuationPoint);
+                                revisedContinuationPoints.Add(results[ii].ContinuationPoint);
                             }
                         }
 
                         // check if browsing must continue;
-                        revisedContiuationPoints = continuationPoints;
+                        continuationPoints = revisedContinuationPoints;
                     }
 
                     // check if unprocessed results exist.

--- a/Samples/ClientControls/ClientUtils.cs
+++ b/Samples/ClientControls/ClientUtils.cs
@@ -484,7 +484,7 @@ namespace Opc.Ua.Client.Controls
                     }
 
                     // process continuation points.
-                    ByteStringCollection revisedContiuationPoints = new ByteStringCollection();
+                    ByteStringCollection revisedContinuationPoints = new ByteStringCollection();
 
                     while (continuationPoints.Count > 0)
                     {
@@ -519,12 +519,12 @@ namespace Opc.Ua.Client.Controls
                             // check for continuation point.
                             if (results[ii].ContinuationPoint != null)
                             {
-                                revisedContiuationPoints.Add(results[ii].ContinuationPoint);
+                                revisedContinuationPoints.Add(results[ii].ContinuationPoint);
                             }
                         }
 
                         // check if browsing must continue;
-                        revisedContiuationPoints = continuationPoints;
+                        continuationPoints = revisedContinuationPoints;
                     }
 
                     // check if unprocessed results exist.

--- a/Workshop/Common/FormUtils.cs
+++ b/Workshop/Common/FormUtils.cs
@@ -471,7 +471,7 @@ namespace Quickstarts
                     }
 
                     // process continuation points.
-                    ByteStringCollection revisedContiuationPoints = new ByteStringCollection();
+                    ByteStringCollection revisedContinuationPoints = new ByteStringCollection();
 
                     while (continuationPoints.Count > 0)
                     {
@@ -506,12 +506,12 @@ namespace Quickstarts
                             // check for continuation point.
                             if (results[ii].ContinuationPoint != null)
                             {
-                                revisedContiuationPoints.Add(results[ii].ContinuationPoint);
+                                revisedContinuationPoints.Add(results[ii].ContinuationPoint);
                             }
                         }
 
                         // check if browsing must continue;
-                        revisedContiuationPoints = continuationPoints;
+                        continuationPoints = revisedContinuationPoints;
                     }
 
                     // check if unprocessed results exist.


### PR DESCRIPTION
Several browse utility methods do not continue browsing when calling the BrowseNext service returns another continuation point, because the assignment is reversed.