### PR TITLE
Bugfix for Quickstart Server: Convert RootId to NodeId explicitly with namespace

### DIFF
--- a/Workshop/Common/NodeHandle.cs
+++ b/Workshop/Common/NodeHandle.cs
@@ -88,6 +88,24 @@ namespace Quickstarts
         }
 
         /// <summary>
+        /// A unique identifier for the root of a complex object tree.
+        /// Like <see cref="RootId"/>, but combined with the namespace.
+        /// </summary>
+        public NodeId RootNodeId
+        {
+            get
+            {
+                if (ParsedNodeId != null)
+                {
+                    // the RootId does not contain a namespace, so it has to be re-constructed to be used as a NodeId
+                    return new NodeId(ParsedNodeId.RootId, ParsedNodeId.NamespaceIndex);
+                }
+
+                return null;
+            }
+        }
+
+        /// <summary>
         /// A path to a component within the tree identified by the root id.
         /// </summary>
         public string ComponentPath

--- a/Workshop/Common/QuickstartNodeManager.cs
+++ b/Workshop/Common/QuickstartNodeManager.cs
@@ -4060,7 +4060,7 @@ namespace Quickstarts
 
                 if (!String.IsNullOrEmpty(handle.ComponentPath))
                 {
-                    if (m_componentCache.TryGetValue(handle.RootId, out entry))
+                    if (m_componentCache.TryGetValue(handle.RootNodeId, out entry))
                     {
                         return entry.Entry.FindChildBySymbolicName(context, handle.ComponentPath);
                     }
@@ -4095,7 +4095,7 @@ namespace Quickstarts
 
                     if (!String.IsNullOrEmpty(handle.ComponentPath))
                     {
-                        nodeId = handle.RootId;
+                        nodeId = handle.RootNodeId;
                     }
 
                     CacheEntry entry = null;
@@ -4135,7 +4135,7 @@ namespace Quickstarts
                 {
                     CacheEntry entry = null;
 
-                    if (m_componentCache.TryGetValue(handle.RootId, out entry))
+                    if (m_componentCache.TryGetValue(handle.RootNodeId, out entry))
                     {
                         entry.RefCount++;
 
@@ -4154,7 +4154,7 @@ namespace Quickstarts
                         entry = new CacheEntry();
                         entry.RefCount = 1;
                         entry.Entry = root;
-                        m_componentCache.Add(handle.RootId, entry);
+                        m_componentCache.Add(handle.RootNodeId, entry);
                     }
                 }
 


### PR DESCRIPTION
## Proposed changes

The Quickstart Server's NodeHandle class parses a "RootId" from a component's NodeId. The QuickstartNodeManager then tries to use that string as a NodeId. This fails, because the string does not contains a namespace.

This bugfix adds a property "RootNodeId" to the NodeHandle class, which converts the "RootId" to a valid NodeId within the component's namespace. It can be used wherever the root NodeId is needed.

## Related Issues

- Fixes the exception that occurs when a client subscribes to an "Asset" node.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [x] I fixed all failing tests in the CI pipelines. 
- [x] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
