### PR TITLE
GDS: Make Push Client support TrustListMasks

### DIFF
--- a/Samples/GDS/Client/Controls/ApplicationTrustListControl.Designer.cs
+++ b/Samples/GDS/Client/Controls/ApplicationTrustListControl.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace Opc.Ua.Gds.Client
+namespace Opc.Ua.Gds.Client
 {
     partial class ApplicationTrustListControl
     {
@@ -32,14 +32,18 @@
             this.RegistrationPanel = new System.Windows.Forms.Panel();
             this.CertificateStoreControl = new Opc.Ua.Gds.Client.Controls.CertificateStoreControl();
             this.RegistrationButtonsPanel = new System.Windows.Forms.Panel();
+            this.ApplyChangesButton = new System.Windows.Forms.Button();
             this.PushToServerButton = new System.Windows.Forms.Button();
             this.MergeWithGdsButton = new System.Windows.Forms.Button();
             this.PullFromGdsButton = new System.Windows.Forms.Button();
             this.ReadTrustListButton = new System.Windows.Forms.Button();
+            this.TrustListMasksComboBox = new System.Windows.Forms.ComboBox();
             this.ToolTips = new System.Windows.Forms.ToolTip(this.components);
-            this.ApplyChangesButton = new System.Windows.Forms.Button();
+            this.panel1 = new System.Windows.Forms.Panel();
+            this.label1 = new System.Windows.Forms.Label();
             this.RegistrationPanel.SuspendLayout();
             this.RegistrationButtonsPanel.SuspendLayout();
+            this.panel1.SuspendLayout();
             this.SuspendLayout();
             // 
             // RegistrationPanel
@@ -48,17 +52,19 @@
             this.RegistrationPanel.Controls.Add(this.RegistrationButtonsPanel);
             this.RegistrationPanel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.RegistrationPanel.Location = new System.Drawing.Point(0, 0);
+            this.RegistrationPanel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.RegistrationPanel.Name = "RegistrationPanel";
-            this.RegistrationPanel.Size = new System.Drawing.Size(879, 693);
+            this.RegistrationPanel.Size = new System.Drawing.Size(1318, 1066);
             this.RegistrationPanel.TabIndex = 50;
             // 
             // CertificateStoreControl
             // 
             this.CertificateStoreControl.Dock = System.Windows.Forms.DockStyle.Fill;
             this.CertificateStoreControl.Location = new System.Drawing.Point(0, 0);
+            this.CertificateStoreControl.Margin = new System.Windows.Forms.Padding(6, 8, 6, 8);
             this.CertificateStoreControl.Name = "CertificateStoreControl";
-            this.CertificateStoreControl.Padding = new System.Windows.Forms.Padding(3);
-            this.CertificateStoreControl.Size = new System.Drawing.Size(879, 661);
+            this.CertificateStoreControl.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.CertificateStoreControl.Size = new System.Drawing.Size(1318, 1017);
             this.CertificateStoreControl.TabIndex = 14;
             // 
             // RegistrationButtonsPanel
@@ -69,11 +75,28 @@
             this.RegistrationButtonsPanel.Controls.Add(this.MergeWithGdsButton);
             this.RegistrationButtonsPanel.Controls.Add(this.PullFromGdsButton);
             this.RegistrationButtonsPanel.Controls.Add(this.ReadTrustListButton);
+            this.RegistrationButtonsPanel.Controls.Add(this.panel1);
             this.RegistrationButtonsPanel.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.RegistrationButtonsPanel.Location = new System.Drawing.Point(0, 661);
+            this.RegistrationButtonsPanel.Location = new System.Drawing.Point(0, 1017);
+            this.RegistrationButtonsPanel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.RegistrationButtonsPanel.Name = "RegistrationButtonsPanel";
-            this.RegistrationButtonsPanel.Size = new System.Drawing.Size(879, 32);
+            this.RegistrationButtonsPanel.Size = new System.Drawing.Size(1318, 49);
             this.RegistrationButtonsPanel.TabIndex = 13;
+            // 
+            // ApplyChangesButton
+            // 
+            this.ApplyChangesButton.BackColor = System.Drawing.Color.MidnightBlue;
+            this.ApplyChangesButton.Dock = System.Windows.Forms.DockStyle.Left;
+            this.ApplyChangesButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.ApplyChangesButton.ForeColor = System.Drawing.Color.White;
+            this.ApplyChangesButton.Location = new System.Drawing.Point(1101, 0);
+            this.ApplyChangesButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.ApplyChangesButton.Name = "ApplyChangesButton";
+            this.ApplyChangesButton.Size = new System.Drawing.Size(194, 49);
+            this.ApplyChangesButton.TabIndex = 5;
+            this.ApplyChangesButton.Text = "Apply Changes";
+            this.ApplyChangesButton.UseVisualStyleBackColor = false;
+            this.ApplyChangesButton.Click += new System.EventHandler(this.ApplyChangesButton_Click);
             // 
             // PushToServerButton
             // 
@@ -81,9 +104,10 @@
             this.PushToServerButton.Dock = System.Windows.Forms.DockStyle.Left;
             this.PushToServerButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.PushToServerButton.ForeColor = System.Drawing.Color.White;
-            this.PushToServerButton.Location = new System.Drawing.Point(387, 0);
+            this.PushToServerButton.Location = new System.Drawing.Point(907, 0);
+            this.PushToServerButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.PushToServerButton.Name = "PushToServerButton";
-            this.PushToServerButton.Size = new System.Drawing.Size(129, 32);
+            this.PushToServerButton.Size = new System.Drawing.Size(194, 49);
             this.PushToServerButton.TabIndex = 3;
             this.PushToServerButton.Text = "Push To Server";
             this.ToolTips.SetToolTip(this.PushToServerButton, "Updates the Trust List on the remote Server.");
@@ -98,9 +122,10 @@
             this.MergeWithGdsButton.Dock = System.Windows.Forms.DockStyle.Left;
             this.MergeWithGdsButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.MergeWithGdsButton.ForeColor = System.Drawing.Color.White;
-            this.MergeWithGdsButton.Location = new System.Drawing.Point(258, 0);
+            this.MergeWithGdsButton.Location = new System.Drawing.Point(713, 0);
+            this.MergeWithGdsButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.MergeWithGdsButton.Name = "MergeWithGdsButton";
-            this.MergeWithGdsButton.Size = new System.Drawing.Size(129, 32);
+            this.MergeWithGdsButton.Size = new System.Drawing.Size(194, 49);
             this.MergeWithGdsButton.TabIndex = 4;
             this.MergeWithGdsButton.Text = "Merge with GDS";
             this.ToolTips.SetToolTip(this.MergeWithGdsButton, "Adds the Certificsates and CRLs provided by the GDS to the Trust List.");
@@ -115,9 +140,10 @@
             this.PullFromGdsButton.Dock = System.Windows.Forms.DockStyle.Left;
             this.PullFromGdsButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.PullFromGdsButton.ForeColor = System.Drawing.Color.White;
-            this.PullFromGdsButton.Location = new System.Drawing.Point(129, 0);
+            this.PullFromGdsButton.Location = new System.Drawing.Point(519, 0);
+            this.PullFromGdsButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.PullFromGdsButton.Name = "PullFromGdsButton";
-            this.PullFromGdsButton.Size = new System.Drawing.Size(129, 32);
+            this.PullFromGdsButton.Size = new System.Drawing.Size(194, 49);
             this.PullFromGdsButton.TabIndex = 0;
             this.PullFromGdsButton.Text = "Replace with GDS";
             this.ToolTips.SetToolTip(this.PullFromGdsButton, "Replaces all Certificates and CRLs in the Trust Lsts with the contents of the Tru" +
@@ -133,9 +159,10 @@
             this.ReadTrustListButton.Dock = System.Windows.Forms.DockStyle.Left;
             this.ReadTrustListButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.ReadTrustListButton.ForeColor = System.Drawing.Color.White;
-            this.ReadTrustListButton.Location = new System.Drawing.Point(0, 0);
+            this.ReadTrustListButton.Location = new System.Drawing.Point(325, 0);
+            this.ReadTrustListButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.ReadTrustListButton.Name = "ReadTrustListButton";
-            this.ReadTrustListButton.Size = new System.Drawing.Size(129, 32);
+            this.ReadTrustListButton.Size = new System.Drawing.Size(194, 49);
             this.ReadTrustListButton.TabIndex = 2;
             this.ReadTrustListButton.Text = "Reload";
             this.ToolTips.SetToolTip(this.ReadTrustListButton, "Reloads the Trust List from disk or by reading it from the remote Server.");
@@ -144,30 +171,49 @@
             this.ReadTrustListButton.MouseEnter += new System.EventHandler(this.Button_MouseEnter);
             this.ReadTrustListButton.MouseLeave += new System.EventHandler(this.Button_MouseLeave);
             // 
-            // ApplyChangesButton
+            // TrustListMasksComboBox
             // 
-            this.ApplyChangesButton.BackColor = System.Drawing.Color.MidnightBlue;
-            this.ApplyChangesButton.Dock = System.Windows.Forms.DockStyle.Left;
-            this.ApplyChangesButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.ApplyChangesButton.ForeColor = System.Drawing.Color.White;
-            this.ApplyChangesButton.Location = new System.Drawing.Point(516, 0);
-            this.ApplyChangesButton.Name = "ApplyChangesButton";
-            this.ApplyChangesButton.Size = new System.Drawing.Size(129, 32);
-            this.ApplyChangesButton.TabIndex = 5;
-            this.ApplyChangesButton.Text = "Apply Changes";
-            this.ApplyChangesButton.UseVisualStyleBackColor = false;
-            this.ApplyChangesButton.Click += new System.EventHandler(this.ApplyChangesButton_Click);
+            this.TrustListMasksComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.TrustListMasksComboBox.DropDownWidth = 250;
+            this.TrustListMasksComboBox.FormattingEnabled = true;
+            this.TrustListMasksComboBox.Location = new System.Drawing.Point(137, 11);
+            this.TrustListMasksComboBox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 1);
+            this.TrustListMasksComboBox.Name = "TrustListMasksComboBox";
+            this.TrustListMasksComboBox.Size = new System.Drawing.Size(168, 28);
+            this.TrustListMasksComboBox.TabIndex = 6;
+            // 
+            // panel1
+            // 
+            this.panel1.BackColor = System.Drawing.SystemColors.Control;
+            this.panel1.Controls.Add(this.label1);
+            this.panel1.Controls.Add(this.TrustListMasksComboBox);
+            this.panel1.Dock = System.Windows.Forms.DockStyle.Left;
+            this.panel1.Location = new System.Drawing.Point(0, 0);
+            this.panel1.Name = "panel1";
+            this.panel1.Size = new System.Drawing.Size(325, 49);
+            this.panel1.TabIndex = 7;
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(3, 14);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(128, 20);
+            this.label1.TabIndex = 7;
+            this.label1.Text = "Trust List Masks:";
             // 
             // ApplicationTrustListControl
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.RegistrationPanel);
             this.Margin = new System.Windows.Forms.Padding(0);
             this.Name = "ApplicationTrustListControl";
-            this.Size = new System.Drawing.Size(879, 693);
+            this.Size = new System.Drawing.Size(1318, 1066);
             this.RegistrationPanel.ResumeLayout(false);
             this.RegistrationButtonsPanel.ResumeLayout(false);
+            this.panel1.ResumeLayout(false);
+            this.panel1.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -183,5 +229,8 @@
         private System.Windows.Forms.Button MergeWithGdsButton;
         private System.Windows.Forms.ToolTip ToolTips;
         private System.Windows.Forms.Button ApplyChangesButton;
+        private System.Windows.Forms.ComboBox TrustListMasksComboBox;
+        private System.Windows.Forms.Panel panel1;
+        private System.Windows.Forms.Label label1;
     }
 }

--- a/Samples/GDS/Client/Controls/ApplicationTrustListControl.Designer.cs
+++ b/Samples/GDS/Client/Controls/ApplicationTrustListControl.Designer.cs
@@ -174,7 +174,7 @@ namespace Opc.Ua.Gds.Client
             // TrustListMasksComboBox
             // 
             this.TrustListMasksComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.TrustListMasksComboBox.DropDownWidth = 250;
+            this.TrustListMasksComboBox.DropDownWidth = 168;
             this.TrustListMasksComboBox.FormattingEnabled = true;
             this.TrustListMasksComboBox.Location = new System.Drawing.Point(137, 11);
             this.TrustListMasksComboBox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 1);

--- a/Samples/GDS/Client/Controls/ApplicationTrustListControl.cs
+++ b/Samples/GDS/Client/Controls/ApplicationTrustListControl.cs
@@ -43,6 +43,8 @@ namespace Opc.Ua.Gds.Client
         public ApplicationTrustListControl()
         {
             InitializeComponent();
+            TrustListMasksComboBox.DataSource = Enum.GetValues(typeof(TrustListMasks));
+            TrustListMasksComboBox.SelectedItem = TrustListMasks.All;
         }
 
         private GlobalDiscoveryServerClient m_gds;
@@ -77,7 +79,11 @@ namespace Opc.Ua.Gds.Client
                 {
                     if (m_application.RegistrationType == RegistrationType.ServerPush)
                     {
-                        var trustList = m_server.ReadTrustList();
+                        TrustListMasks masks;
+
+                        if (!Enum.TryParse(TrustListMasksComboBox.SelectedItem.ToString(), out masks))
+                            masks = TrustListMasks.All;
+                        var trustList = m_server.ReadTrustList(masks);
                         var rejectedList = m_server.GetRejectedList();
                         CertificateStoreControl.Initialize(trustList, rejectedList, true);
                     }

--- a/Samples/GDS/Client/Controls/ApplicationTrustListControl.resx
+++ b/Samples/GDS/Client/Controls/ApplicationTrustListControl.resx
@@ -120,4 +120,7 @@
   <metadata name="ToolTips.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="ToolTips.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>


### PR DESCRIPTION
## Proposed changes

Adds the necessary UI & Logic to call Server Push ReadTrustList with appropriate TrustListMasks.
This change is needed, as some gds push enabled servers (eg. Siemens S7 1500) only return the Trust List with masks and not the full trust list.

<img width="661" alt="Screenshot 2024-02-28 070751" src="https://github.com/OPCFoundation/UA-.NETStandard-Samples/assets/7413710/3ab90ba4-0c2a-4098-a780-29ac94557829">


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

