### PR TITLE
Initialize FILETIME with DateTimeKind.Utc

### DIFF
--- a/ComIOP/Common/Common/ComUtils.cs
+++ b/ComIOP/Common/Common/ComUtils.cs
@@ -163,7 +163,7 @@ namespace Opc.Ua.Com
 		/// <summary>
 		/// The base for the WIN32 FILETIME structure.
 		/// </summary>
-		private static readonly DateTime FILETIME_BaseTime = new DateTime(1601, 1, 1);
+		private static readonly DateTime FILETIME_BaseTime = new DateTime(1601, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
 		/// <summary>
 		/// WIN32 GUID struct declaration.


### PR DESCRIPTION
## Proposed changes

The FILETIME variable shall be initialized with DateTimeKind.Utc. 
OPC UA expects timestamps to be in UTC: https://reference.opcfoundation.org/Core/Part3/v104/docs/8.38
The Kind property of DateTime is initialized to Unspecified and needs to be explicitly set to UTC.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [X] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [X] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [X] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [X] Any dependent changes have been merged and published in downstream modules.

## Further comments

Straight forward fix.
