### PR TITLE
Sample select clause for ConditionId to use type definition of ConditionType

### DIFF
--- a/Workshop/AlarmCondition/Client/FilterDefinition.cs
+++ b/Workshop/AlarmCondition/Client/FilterDefinition.cs
@@ -125,7 +125,7 @@ namespace Quickstarts.AlarmConditionClient
             // this can be done by specifying an operand with an empty browse path.
             SimpleAttributeOperand operand = new SimpleAttributeOperand();
 
-            operand.TypeDefinitionId = ObjectTypeIds.BaseEventType;
+            operand.TypeDefinitionId = ObjectTypeIds.ConditionType;
             operand.AttributeId = Attributes.NodeId;
             operand.BrowsePath = new QualifiedNameCollection();
 

--- a/Workshop/Common/FilterDefinition.cs
+++ b/Workshop/Common/FilterDefinition.cs
@@ -120,7 +120,7 @@ namespace Quickstarts
             // this can be done by specifying an operand with an empty browse path.
             SimpleAttributeOperand operand = new SimpleAttributeOperand();
 
-            operand.TypeDefinitionId = ObjectTypeIds.BaseEventType;
+            operand.TypeDefinitionId = ObjectTypeIds.ConditionType;
             operand.AttributeId = Attributes.NodeId;
             operand.BrowsePath = new QualifiedNameCollection();
 


### PR DESCRIPTION
…tion of ConditionType

Samples Issue 650

## Proposed changes

The best practice for creating a select clause for ConditionId should be to use the TypeDefinition of ConditionType

## Related Issues

- Fixes [650](https://github.com/OPCFoundation/UA-.NETStandard-Samples/issues/650)

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ x ] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ x ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ x ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

No Changes have been made to the server at this point in time.  More consultation with the spec part nine should happen before any changes are made to the reference server operations.