### PR TITLE
Avoid a possible XmlException `Illegal characters in path` for HistoricalAccess Server.

### DIFF
--- a/Workshop/HistoricalAccess/Server/UnderlyingSystem/DataFileReader.cs
+++ b/Workshop/HistoricalAccess/Server/UnderlyingSystem/DataFileReader.cs
@@ -665,7 +665,8 @@ namespace Quickstarts.HistoricalAccessServer
             builder.Append("</Value>");
 
             XmlDocument document = new XmlDocument { XmlResolver = null };
-            using (XmlReader reader = XmlReader.Create(builder.ToString(), new XmlReaderSettings() { XmlResolver = null }))
+            using (StringReader sr = new StringReader(builder.ToString()))
+            using (XmlReader reader = XmlReader.Create(sr, new XmlReaderSettings() { XmlResolver = null }))
             {
                 document.Load(reader);
             }


### PR DESCRIPTION
# Avoid a possible XmlException `Illegal characters in path` for HistoricalAccess Server.

## Proposed changes

When Historical Access Server starts, the exception **'Illegal characters in path'** occurs in the `ExtractField(int lineCount, ref string line, ServiceMessageContext context, BuiltInType valueType, out Variant value)` method of the `UnderlyingSystem\DataFileReader.cs` file during the loading of *.txt files from \Data\Sample. This is typical behavior of the `XmlReader.Create` function when using `builder.ToString()` as the first argument (in this case, the function expects the file URI, not its text content).

To correct this behavior a `StringReader` object could be created and passing as the first parameter to the `XmlReader.Create` function call. In this case, the function expects the text content, not the file URI, and executes without errors.

## Links

- https://learn.microsoft.com/en-us/dotnet/api/System.Xml.XmlReader.Create?view=netframework-4.8
- https://stackoverflow.com/questions/1374729/illegal-characters-in-path-error-while-parsing-xml-in-c-sharp

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.
