### PR TITLE
Complete OPC UA 2.0 obsolete-API migration and remove migration analyzer

### DIFF
--- a/Samples/ClientControls.Net4/Browse/AttributeListCtrl.cs
+++ b/Samples/ClientControls.Net4/Browse/AttributeListCtrl.cs
@@ -154,7 +154,7 @@ namespace Opc.Ua.Client.Controls
         /// </summary>
         private async Task UpdateValuesAsync(CancellationToken ct = default)
         {
-            ReadValueIdCollection valuesToRead = new ReadValueIdCollection();
+            List<ReadValueId> valuesToRead = new List<ReadValueId>();
 
             foreach (ListViewItem item in ItemsLV.Items)
             {
@@ -399,7 +399,7 @@ namespace Opc.Ua.Client.Controls
                 }
                 else
                 {
-                    listItem.SubItems[1].Text = await FormatAttributeValueAsync(info.AttributeId, info.Value.Value, ct);
+                    listItem.SubItems[1].Text = await FormatAttributeValueAsync(info.AttributeId, info.Value.WrappedValue.AsBoxedObject(), ct);
                 }
 
                 if (info.AttributeId != Attributes.Value)

--- a/Samples/ClientControls.Net4/Browse/BrowseTreeCtrl.cs
+++ b/Samples/ClientControls.Net4/Browse/BrowseTreeCtrl.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -149,12 +149,12 @@ namespace Opc.Ua.Client.Controls
                 return;
             }
 
-            if (NodeId.IsNull(m_rootId))
+            if ((m_rootId).IsNull)
             {
                 m_rootId = (NodeId)Objects.RootFolder;
             }
 
-            if (NodeId.IsNull(m_referenceTypeId))
+            if ((m_referenceTypeId).IsNull)
             {
                 m_referenceTypeId = ReferenceTypeIds.HierarchicalReferences;
             }
@@ -216,12 +216,12 @@ namespace Opc.Ua.Client.Controls
             nodeToBrowse.NodeClassMask = 0;
             nodeToBrowse.ResultMask = (uint)(int)BrowseResultMask.All;
 
-            BrowseDescriptionCollection nodesToBrowse = new BrowseDescriptionCollection();
+            List<BrowseDescription> nodesToBrowse = new List<BrowseDescription>();
             nodesToBrowse.Add(nodeToBrowse);
 
             ViewDescription view = null;
 
-            if (NodeId.IsNull(m_viewId))
+            if ((m_viewId).IsNull)
             {
                 view = new ViewDescription();
                 view.ViewId = m_viewId;
@@ -431,7 +431,7 @@ namespace Opc.Ua.Client.Controls
 
                     if (reference != null)
                     {
-                        ReferenceDescriptionCollection collection = new ReferenceDescriptionCollection();
+                        List<ReferenceDescription> collection = new List<ReferenceDescription>();
                         collection.Add(reference);
                         m_nodesSelected(this, new NodesSelectedEventArgs(collection));
                     }
@@ -454,7 +454,7 @@ namespace Opc.Ua.Client.Controls
                         return;
                     }
 
-                    ReferenceDescriptionCollection collection = new ReferenceDescriptionCollection();
+                    List<ReferenceDescription> collection = new List<ReferenceDescription>();
 
                     foreach (TreeNode child in NodesTV.SelectedNode.Nodes)
                     {

--- a/Samples/ClientControls.Net4/ClientUtils.cs
+++ b/Samples/ClientControls.Net4/ClientUtils.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -223,7 +223,7 @@ namespace Opc.Ua.Client.Controls
                 case Attributes.AccessLevel:
                 case Attributes.UserAccessLevel:
                 {
-                    byte? field = value.Value as byte?;
+                    byte? field = value.AsBoxedObject() as byte?;
 
                     if (field != null)
                     {
@@ -235,7 +235,7 @@ namespace Opc.Ua.Client.Controls
 
                 case Attributes.EventNotifier:
                 {
-                    byte? field = value.Value as byte?;
+                    byte? field = value.AsBoxedObject() as byte?;
 
                     if (field != null)
                     {
@@ -247,13 +247,13 @@ namespace Opc.Ua.Client.Controls
 
                 case Attributes.DataType:
                 {
-                    NodeId dataTypeId = value.Value is NodeId dt ? dt : NodeId.Null;
+                    NodeId dataTypeId = value.AsBoxedObject() is NodeId dt ? dt : NodeId.Null;
                     return await session.NodeCache.GetDisplayTextAsync(dataTypeId, ct);
                 }
 
                 case Attributes.ValueRank:
                 {
-                    int? field = value.Value as int?;
+                    int? field = value.AsBoxedObject() as int?;
 
                     if (field != null)
                     {
@@ -265,7 +265,7 @@ namespace Opc.Ua.Client.Controls
 
                 case Attributes.NodeClass:
                 {
-                    int? field = value.Value as int?;
+                    int? field = value.AsBoxedObject() as int?;
 
                     if (field != null)
                     {
@@ -277,7 +277,7 @@ namespace Opc.Ua.Client.Controls
 
                 case Attributes.NodeId:
                 {
-                    if (value.Value is NodeId field && !field.IsNull)
+                    if (value.AsBoxedObject() is NodeId field && !field.IsNull)
                     {
                         return field.ToString();
                     }
@@ -287,7 +287,7 @@ namespace Opc.Ua.Client.Controls
 
                 case Attributes.DataTypeDefinition:
                 {
-                    if (value.Value is ExtensionObject field)
+                    if (value.AsBoxedObject() is ExtensionObject field)
                     {
                         return field.ToString();
                     }
@@ -296,9 +296,9 @@ namespace Opc.Ua.Client.Controls
             }
 
             // check for byte strings.
-            if (value.Value is byte[])
+            if (value.AsBoxedObject() is byte[])
             {
-                return Utils.ToHexString(value.Value as byte[]);
+                return Utils.ToHexString(value.AsBoxedObject() as byte[]);
             }
 
             // use default format.
@@ -348,7 +348,7 @@ namespace Opc.Ua.Client.Controls
                     ClientBase.ValidateDiagnosticInfos(diagnosticInfos, nodesToBrowse);
 
                     List<ByteString> continuationPoints = new List<ByteString>();
-                    BrowseDescriptionCollection unprocessedOperations = new BrowseDescriptionCollection();
+                    List<BrowseDescription> unprocessedOperations = new List<BrowseDescription>();
 
                     for (int ii = 0; ii < nodesToBrowse.Count; ii++)
                     {
@@ -466,7 +466,7 @@ namespace Opc.Ua.Client.Controls
         public static Task<List<ReferenceDescription>> BrowseAsync(ISession session, ViewDescription view, BrowseDescription nodeToBrowse, bool throwOnError, CancellationToken ct = default)
         {
             // construct browse request.
-            BrowseDescriptionCollection nodesToBrowse = new BrowseDescriptionCollection {
+            List<BrowseDescription> nodesToBrowse = new List<BrowseDescription> {
                 nodeToBrowse
             };
 
@@ -548,7 +548,7 @@ namespace Opc.Ua.Client.Controls
             params string[] relativePaths)
         {
             // build the list of browse paths to follow by parsing the relative paths.
-            BrowsePathCollection browsePaths = new BrowsePathCollection();
+            List<BrowsePath> browsePaths = new List<BrowsePath>();
 
             if (relativePaths != null)
             {
@@ -645,7 +645,7 @@ namespace Opc.Ua.Client.Controls
 
                     if (clause.BrowsePath.Count == 1 && clause.BrowsePath[0] == BrowseNames.EventType)
                     {
-                        return notification.EventFields[ii].Value is NodeId nodeId ? nodeId : NodeId.Null;
+                        return notification.EventFields[ii].AsBoxedObject() is NodeId nodeId ? nodeId : NodeId.Null;
                     }
                 }
             }
@@ -850,7 +850,7 @@ namespace Opc.Ua.Client.Controls
                 child.BrowseName = reference.BrowseName;
                 child.NodeClass = reference.NodeClass;
 
-                if (!LocalizedText.IsNullOrEmpty(reference.DisplayName))
+                if (!(reference.DisplayName).IsNullOrEmpty)
                 {
                     child.DisplayName = reference.DisplayName.Text;
                 }
@@ -905,7 +905,7 @@ namespace Opc.Ua.Client.Controls
                     children[ii].ModellingRule = modellingRules[ii];
 
                     // if the modelling rule is null then the instance is not part of the type declaration.
-                    if (NodeId.IsNull(modellingRules[ii]))
+                    if ((modellingRules[ii]).IsNull)
                     {
                         map.Remove(children[ii].BrowsePathDisplayText);
                     }
@@ -918,7 +918,7 @@ namespace Opc.Ua.Client.Controls
             // recusively collect instance declarations for the tree below.
             for (int ii = 0; ii < children.Count; ii++)
             {
-                if (!NodeId.IsNull(children[ii].ModellingRule))
+                if (!(children[ii].ModellingRule).IsNull)
                 {
                     instances.Add(children[ii]);
                     await CollectInstanceDeclarationsAsync(session, typeId, children[ii], instances, map, ct);
@@ -934,7 +934,7 @@ namespace Opc.Ua.Client.Controls
             try
             {
                 // construct browse request.
-                BrowseDescriptionCollection nodesToBrowse = new BrowseDescriptionCollection();
+                List<BrowseDescription> nodesToBrowse = new List<BrowseDescription>();
 
                 for (int ii = 0; ii < nodeIds.Count; ii++)
                 {
@@ -984,7 +984,7 @@ namespace Opc.Ua.Client.Controls
                     // get the node id.
                     if (results[ii].References.Count > 0)
                     {
-                        if (NodeId.IsNull(results[ii].References[0].NodeId) || results[ii].References[0].NodeId.IsAbsolute)
+                        if ((results[ii].References[0].NodeId).IsNull || results[ii].References[0].NodeId.IsAbsolute)
                         {
                             continue;
                         }
@@ -1030,7 +1030,7 @@ namespace Opc.Ua.Client.Controls
         {
             try
             {
-                ReadValueIdCollection nodesToRead = new ReadValueIdCollection();
+                List<ReadValueId> nodesToRead = new List<ReadValueId>();
 
                 for (int ii = 0; ii < instances.Count; ii++)
                 {
@@ -1073,7 +1073,7 @@ namespace Opc.Ua.Client.Controls
                     instance.DataType = results[ii + 1].GetValue<NodeId>(NodeId.Null);
                     instance.ValueRank = results[ii + 2].GetValue<int>(ValueRanks.Any);
 
-                    if (!NodeId.IsNull(instance.DataType))
+                    if (!(instance.DataType).IsNull)
                     {
                         instance.BuiltInType = TypeInfo.GetBuiltInType(instance.DataType, session.TypeTree);
                         instance.DataTypeDisplayText = await session.NodeCache.GetDisplayTextAsync(instance.DataType, ct);

--- a/Samples/ClientControls.Net4/Common/BrowseNodeCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/BrowseNodeCtrl.cs
@@ -75,7 +75,7 @@ namespace Opc.Ua.Client.Controls
             params NodeId[] referenceTypeIds)
         {
             // set default root.
-            if (NodeId.IsNull(rootId))
+            if ((rootId).IsNull)
             {
                 rootId = Opc.Ua.ObjectIds.ObjectsFolder;
             }
@@ -224,7 +224,7 @@ namespace Opc.Ua.Client.Controls
         private void ReadAttributes(NodeId nodeId)
         {
             // build list of attributes to read.
-            ReadValueIdCollection nodesToRead = new ReadValueIdCollection();
+            List<ReadValueId> nodesToRead = new List<ReadValueId>();
 
             foreach (uint attributeId in Attributes.GetIdentifiers())
             {
@@ -235,7 +235,7 @@ namespace Opc.Ua.Client.Controls
             }
 
             // read the attributes.
-            DataValueCollection results = null;
+            List<DataValue> results = null;
             DiagnosticInfoCollection diagnosticInfos = null;
 
             m_session.Read(
@@ -300,7 +300,7 @@ namespace Opc.Ua.Client.Controls
         private void ReadProperties(NodeId nodeId)
         {
             // build list of references to browse.
-            BrowseDescriptionCollection nodesToBrowse = new BrowseDescriptionCollection();
+            List<BrowseDescription> nodesToBrowse = new List<BrowseDescription>();
 
             BrowseDescription nodeToBrowse = new BrowseDescription();
 
@@ -314,10 +314,10 @@ namespace Opc.Ua.Client.Controls
             nodesToBrowse.Add(nodeToBrowse);
 
             // find properties.
-            ReferenceDescriptionCollection references = ClientUtils.Browse(m_session, View, nodesToBrowse, false);
+            List<ReferenceDescription> references = ClientUtils.Browse(m_session, View, nodesToBrowse, false);
 
             // build list of properties to read.
-            ReadValueIdCollection nodesToRead = new ReadValueIdCollection();
+            List<ReadValueId> nodesToRead = new List<ReadValueId>();
 
             for (int ii = 0; references != null && ii < references.Count; ii++)
             {
@@ -342,7 +342,7 @@ namespace Opc.Ua.Client.Controls
             }
             
             // read the properties.
-            DataValueCollection results = null;
+            List<DataValue> results = null;
             DiagnosticInfoCollection diagnosticInfos = null;
 
             m_session.Read(
@@ -448,7 +448,7 @@ namespace Opc.Ua.Client.Controls
                 e.Node.Nodes.Clear();
 
                 // build list of references to browse.
-                BrowseDescriptionCollection nodesToBrowse = new BrowseDescriptionCollection();
+                List<BrowseDescription> nodesToBrowse = new List<BrowseDescription>();
 
                 for (int ii = 0; ii < m_referenceTypeIds.Length; ii++)
                 {
@@ -470,7 +470,7 @@ namespace Opc.Ua.Client.Controls
                 }
 
                 // add the childen to the control.
-                ReferenceDescriptionCollection references = ClientUtils.Browse(m_session, View, nodesToBrowse, false);
+                List<ReferenceDescription> references = ClientUtils.Browse(m_session, View, nodesToBrowse, false);
 
                 for (int ii = 0; references != null && ii < references.Count; ii++)
                 {

--- a/Samples/ClientControls.Net4/Common/Client/AttrributesListViewCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/AttrributesListViewCtrl.cs
@@ -1,4 +1,4 @@
-/* ========================================================================
+﻿/* ========================================================================
  * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -316,7 +316,7 @@ namespace Opc.Ua.Client.Controls
 
                 AttributeInfo info = AttributesLV.SelectedItems[0].Tag as AttributeInfo;
 
-                if (info == null || info.Value == null)
+                if (info == null || info.Value.IsNull)
                 {
                     return;
                 }

--- a/Samples/ClientControls.Net4/Common/Client/AttrributesListViewCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/AttrributesListViewCtrl.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -114,13 +114,13 @@ namespace Opc.Ua.Client.Controls
         {
             AttributesLV.Items.Clear();
 
-            if (NodeId.IsNull(nodeId))
+            if ((nodeId).IsNull)
             {
                 return;
             }
 
             // build list of attributes to read.
-            ReadValueIdCollection nodesToRead = new ReadValueIdCollection();
+            List<ReadValueId> nodesToRead = new List<ReadValueId>();
 
             foreach (uint attributeId in Attributes.Identifiers)
             {
@@ -177,7 +177,7 @@ namespace Opc.Ua.Client.Controls
                 }
 
                 item.Tag = new AttributeInfo() { NodeToRead = nodesToRead[ii], Value = results[ii] };
-                item.ImageIndex = ClientUtils.GetImageIndex(nodesToRead[ii].AttributeId, results[ii].Value);
+                item.ImageIndex = ClientUtils.GetImageIndex(nodesToRead[ii].AttributeId, results[ii].WrappedValue.AsBoxedObject());
 
                 // display in list.
                 AttributesLV.Items.Add(item);
@@ -214,7 +214,7 @@ namespace Opc.Ua.Client.Controls
         private async Task ReadPropertiesAsync(NodeId nodeId, CancellationToken ct = default)
         {
             // build list of references to browse.
-            BrowseDescriptionCollection nodesToBrowse = new BrowseDescriptionCollection();
+            List<BrowseDescription> nodesToBrowse = new List<BrowseDescription>();
 
             BrowseDescription nodeToBrowse = new BrowseDescription();
 
@@ -231,7 +231,7 @@ namespace Opc.Ua.Client.Controls
             List<ReferenceDescription> references = await ClientUtils.BrowseAsync(m_session, View, nodesToBrowse, false, ct);
 
             // build list of properties to read.
-            ReadValueIdCollection nodesToRead = new ReadValueIdCollection();
+            List<ReadValueId> nodesToRead = new List<ReadValueId>();
 
             for (int ii = 0; references != null && ii < references.Count; ii++)
             {
@@ -274,7 +274,7 @@ namespace Opc.Ua.Client.Controls
             {
                 ReferenceDescription reference = (ReferenceDescription)nodesToRead[ii].Handle;
 
-                TypeInfo typeInfo = TypeInfo.Construct(results[ii].Value);
+                TypeInfo typeInfo = TypeInfo.Construct(results[ii].WrappedValue.AsBoxedObject());
 
                 // add the metadata for the attribute.
                 ListViewItem item = new ListViewItem(reference.ToString());
@@ -328,7 +328,7 @@ namespace Opc.Ua.Client.Controls
                     info.NodeToRead.NodeId,
                     info.NodeToRead.AttributeId,
                     null,
-                    info.Value.Value,
+                    info.Value.WrappedValue.AsBoxedObject(),
                     true,
                     "View Attribute Value");
             }

--- a/Samples/ClientControls.Net4/Common/Client/BrowseTreeViewCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/BrowseTreeViewCtrl.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -97,7 +97,7 @@ namespace Opc.Ua.Client.Controls
             params NodeId[] referenceTypeIds)
         {
             // set default root.
-            if (NodeId.IsNull(rootId))
+            if ((rootId).IsNull)
             {
                 rootId = Opc.Ua.ObjectIds.ObjectsFolder;
             }
@@ -388,7 +388,7 @@ namespace Opc.Ua.Client.Controls
                 e.Node.Nodes.Clear();
 
                 // build list of references to browse.
-                BrowseDescriptionCollection nodesToBrowse = new BrowseDescriptionCollection();
+                List<BrowseDescription> nodesToBrowse = new List<BrowseDescription>();
 
                 for (int ii = 0; ii < m_referenceTypeIds.Length; ii++)
                 {
@@ -445,7 +445,7 @@ namespace Opc.Ua.Client.Controls
                                 if (nodeIds.Count > 0 && !nodeIds[0].IsNull)
                                 {
                                     DataValue value = await m_session.ReadValueAsync(nodeIds[0]);
-                                    byte[] bytes = value.Value as byte[];
+                                    byte[] bytes = value.WrappedValue.AsBoxedObject() as byte[];
 
                                     if (bytes != null)
                                     {

--- a/Samples/ClientControls.Net4/Common/Client/CallRequestListViewCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/CallRequestListViewCtrl.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -120,7 +120,7 @@ namespace Opc.Ua.Client.Controls
         public async Task CallAsync(CancellationToken ct = default)
         {
             // build list of methods to call.
-            CallMethodRequestCollection methodsToCall = new CallMethodRequestCollection();
+            List<CallMethodRequest> methodsToCall = new List<CallMethodRequest>();
 
             CallMethodRequest methodToCall = new CallMethodRequest();
 
@@ -133,7 +133,7 @@ namespace Opc.Ua.Client.Controls
             {
                 Argument argument = (Argument)row[0];
                 Variant value = (Variant)row[4];
-                argument.Value = value.Value;
+                argument.Value = value.AsBoxedObject();
                 inputArguments.Add(value);
             }
 
@@ -255,7 +255,7 @@ namespace Opc.Ua.Client.Controls
             }
 
             row[0] = argument;
-            row[1] = ImageList.Images[ClientUtils.GetImageIndex(isOutputArgument, value.Value)];
+            row[1] = ImageList.Images[ClientUtils.GetImageIndex(isOutputArgument, value.AsBoxedObject())];
             row[2] = argument.Name;
             row[3] = dataType;
             row[4] = value;
@@ -271,7 +271,7 @@ namespace Opc.Ua.Client.Controls
             m_outputArguments = null;
 
             // build list of references to browse.
-            BrowseDescriptionCollection nodesToBrowse = new BrowseDescriptionCollection();
+            List<BrowseDescription> nodesToBrowse = new List<BrowseDescription>();
 
             BrowseDescription nodeToBrowse = new BrowseDescription();
 
@@ -288,7 +288,7 @@ namespace Opc.Ua.Client.Controls
             List<ReferenceDescription> references = await ClientUtils.BrowseAsync(m_session, null, nodesToBrowse, false, ct);
 
             // build list of properties to read.
-            ReadValueIdCollection nodesToRead = new ReadValueIdCollection();
+            List<ReadValueId> nodesToRead = new List<ReadValueId>();
 
             for (int ii = 0; references != null && ii < references.Count; ii++)
             {

--- a/Samples/ClientControls.Net4/Common/Client/CallRequestListViewCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/CallRequestListViewCtrl.cs
@@ -1,4 +1,4 @@
-/* ========================================================================
+﻿/* ========================================================================
  * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -236,7 +236,7 @@ namespace Opc.Ua.Client.Controls
                 foreach (Argument argument in m_inputArguments)
                 {
                     DataRow row = m_dataset.Tables[0].NewRow();
-                    await UpdateRowAsync(row, argument, new Variant(argument.Value), false, ct);
+                    await UpdateRowAsync(row, argument, ClientUtils.ToVariant(argument.Value), false, ct);
                     m_dataset.Tables[0].Rows.Add(row);
                 }
             }
@@ -342,12 +342,12 @@ namespace Opc.Ua.Client.Controls
                 {
                     if (reference.BrowseName == Opc.Ua.BrowseNames.InputArguments)
                     {
-                        m_inputArguments = (Argument[])ExtensionObject.ToArray(results[ii].GetValue<ExtensionObject[]>(null), typeof(Argument));
+                        m_inputArguments = ExtensionObject.ToArray<Argument>(results[ii].GetValue<ExtensionObject[]>(null)).ToArray();
                     }
 
                     if (reference.BrowseName == Opc.Ua.BrowseNames.OutputArguments)
                     {
-                        m_outputArguments = (Argument[])ExtensionObject.ToArray(results[ii].GetValue<ExtensionObject[]>(null), typeof(Argument));
+                        m_outputArguments = ExtensionObject.ToArray<Argument>(results[ii].GetValue<ExtensionObject[]>(null)).ToArray();
                     }
                 }
             }
@@ -386,7 +386,7 @@ namespace Opc.Ua.Client.Controls
                     if (result != null)
                     {
                         argument.Value = result;
-                        await UpdateRowAsync(source.Row, argument, new Variant(result), false);
+                        await UpdateRowAsync(source.Row, argument, ClientUtils.ToVariant(result), false);
                     }
 
                     break;

--- a/Samples/ClientControls.Net4/Common/Client/EditComplexValue2Dlg.cs
+++ b/Samples/ClientControls.Net4/Common/Client/EditComplexValue2Dlg.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -113,10 +113,10 @@ namespace Opc.Ua.Client.Controls
 
             if (sourceType == null)
             {
-                sourceType = TypeInfo.Construct(value.Value);
+                sourceType = TypeInfo.Construct(value.AsBoxedObject());
             }
 
-            m_value = new Variant(value.Value, sourceType);
+            m_value = new Variant(value.AsBoxedObject(), sourceType);
 
             // display value as text.
             StringBuilder buffer = new StringBuilder();
@@ -140,12 +140,12 @@ namespace Opc.Ua.Client.Controls
 
                 if (sourceType.ValueRank == ValueRanks.Scalar)
                 {
-                    extension = (ExtensionObject)m_value.Value;
+                    extension = (ExtensionObject)m_value.AsBoxedObject();
                 }
                 else
                 {
                     // only use the first item in the list for arrays.
-                    ExtensionObject[] list = (ExtensionObject[])m_value.Value;
+                    ExtensionObject[] list = (ExtensionObject[])m_value.AsBoxedObject();
 
                     if (list.Length > 0)
                     {
@@ -294,7 +294,7 @@ namespace Opc.Ua.Client.Controls
                 nodeToRead.DataEncoding = m_encodingName;
 
 
-                ReadValueIdCollection nodesToRead = new ReadValueIdCollection();
+                List<ReadValueId> nodesToRead = new List<ReadValueId>();
                 nodesToRead.Add(nodeToRead);
 
                 // read the attributes.
@@ -337,7 +337,7 @@ namespace Opc.Ua.Client.Controls
                 nodeToWrite.AttributeId = Attributes.Value;
                 nodeToWrite.Value = new DataValue(GetValue());
 
-                WriteValueCollection nodesToWrite = new WriteValueCollection();
+                List<WriteValue> nodesToWrite = new List<WriteValue>();
                 nodesToWrite.Add(nodeToWrite);
 
                 // read the attributes.

--- a/Samples/ClientControls.Net4/Common/Client/EditComplexValue2Dlg.cs
+++ b/Samples/ClientControls.Net4/Common/Client/EditComplexValue2Dlg.cs
@@ -1,4 +1,4 @@
-/* ========================================================================
+﻿/* ========================================================================
  * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -111,12 +111,12 @@ namespace Opc.Ua.Client.Controls
             // get the source type.
             TypeInfo sourceType = value.TypeInfo;
 
-            if (sourceType == null)
+            if (sourceType.IsUnknown)
             {
                 sourceType = TypeInfo.Construct(value.AsBoxedObject());
             }
 
-            m_value = new Variant(value.AsBoxedObject(), sourceType);
+            m_value = ClientUtils.ToVariant(value.AsBoxedObject());
 
             // display value as text.
             StringBuilder buffer = new StringBuilder();

--- a/Samples/ClientControls.Net4/Common/Client/EditComplexValueCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/EditComplexValueCtrl.cs
@@ -168,7 +168,7 @@ namespace Opc.Ua.Client.Controls.Common
 
                     if (info != null)
                     {
-                        return info.Parent != null && info.Parent.TypeInfo != null && info.Parent.TypeInfo.BuiltInType == BuiltInType.Variant;
+                        return info.Parent != null && !info.Parent.TypeInfo.IsUnknown && info.Parent.TypeInfo.BuiltInType == BuiltInType.Variant;
                     }
                 }
 
@@ -191,7 +191,7 @@ namespace Opc.Ua.Client.Controls.Common
                     {
                         Variant? value = info.Value as Variant?;
 
-                        if (value != null && value.Value.TypeInfo != null)
+                        if (value != null && !value.Value.TypeInfo.IsUnknown)
                         {
                             return value.Value.TypeInfo.BuiltInType;
                         }
@@ -261,7 +261,7 @@ namespace Opc.Ua.Client.Controls.Common
                 {
                     currentType = variant.TypeInfo;
 
-                    if (currentType == null)
+                    if (currentType.IsUnknown)
                     {
                         currentType = TypeInfo.Construct(currentValue);
                     }
@@ -412,7 +412,7 @@ namespace Opc.Ua.Client.Controls.Common
                 {
                     currentType = variant.TypeInfo;
 
-                    if (currentType == null)
+                    if (currentType.IsUnknown)
                     {
                         currentType = TypeInfo.Construct(currentValue);
                     }
@@ -440,7 +440,7 @@ namespace Opc.Ua.Client.Controls.Common
             {
                 try
                 {
-                    newValue = new Variant(oldValue, oldType).ConvertTo(newType.BuiltInType).Value;
+                    newValue = ClientUtils.ToVariant(oldValue).ConvertTo(newType.BuiltInType).AsBoxedObject();
                 }
                 catch (Exception e)
                 {
@@ -621,7 +621,7 @@ namespace Opc.Ua.Client.Controls.Common
             NavigationMENU.Items.Clear();
 
             // assign a type.
-            if (expectedType == null)
+            if (expectedType.IsUnknown)
             {
                 if (value == null)
                 {
@@ -649,7 +649,7 @@ namespace Opc.Ua.Client.Controls.Common
             }
 
             // ensure value is the target type.
-            info.Value = new Variant(info.Value).ConvertTo(expectedType.BuiltInType).Value;
+            info.Value = ClientUtils.ToVariant(info.Value).ConvertTo(expectedType.BuiltInType).AsBoxedObject();
 
             info.Name = name;
             m_value = info;
@@ -684,7 +684,7 @@ namespace Opc.Ua.Client.Controls.Common
             }
 
             AccessInfo info = NavigationMENU.Items[NavigationMENU.Items.Count - 1].Tag as AccessInfo;
-            object newValue = new Variant(TextValueTB.Text).ConvertTo(info.TypeInfo.BuiltInType).Value;
+            object newValue = Variant.From(TextValueTB.Text).ConvertTo(info.TypeInfo.BuiltInType).AsBoxedObject();
             info.Value = newValue;
             UpdateParent(info);
         }
@@ -724,7 +724,7 @@ namespace Opc.Ua.Client.Controls.Common
                 {
                     parent.TypeInfo = typeInfo = variant.TypeInfo;
 
-                    if (typeInfo == null)
+                    if (typeInfo.IsUnknown)
                     {
                         parent.TypeInfo = typeInfo = TypeInfo.Construct(value);
                     }
@@ -826,7 +826,7 @@ namespace Opc.Ua.Client.Controls.Common
             // check for extension object.
             if (structure is ExtensionObject extension)
             {
-                structure = extension.Body;
+                structure = GetExtensionObjectBody(extension);
             }
 
             // check for XmlElements.
@@ -1017,12 +1017,32 @@ namespace Opc.Ua.Client.Controls.Common
             return typeof(object);
         }
 
+        private static object GetExtensionObjectBody(ExtensionObject extension)
+        {
+            if (extension.TryGetAsBinary(out ByteString bytes, ServiceMessageContext.CreateEmpty(null)))
+            {
+                return bytes.ToArray();
+            }
+
+            if (extension.TryGetAsXml(out XmlElement xml, ServiceMessageContext.CreateEmpty(null)))
+            {
+                return xml;
+            }
+
+            if (extension.TryGetValue(out IEncodeable encodeable, ServiceMessageContext.CreateEmpty(null)))
+            {
+                return encodeable;
+            }
+
+            return null;
+        }
+
         /// <summary>
         /// Returns the data type of the value.
         /// </summary>
         private Type GetDataType(AccessInfo accessInfo)
         {
-            if (accessInfo == null || accessInfo.TypeInfo == null)
+            if (accessInfo == null || accessInfo.TypeInfo.IsUnknown)
             {
                 return null;
             }
@@ -1221,7 +1241,7 @@ namespace Opc.Ua.Client.Controls.Common
                 {
                     typeInfo = variant.TypeInfo;
 
-                    if (typeInfo == null)
+                    if (typeInfo.IsUnknown)
                     {
                         typeInfo = TypeInfo.Construct(value);
                     }
@@ -1305,19 +1325,21 @@ namespace Opc.Ua.Client.Controls.Common
 
                     if (value is ExtensionObject extension)
                     {
-                        if (extension.Body is byte[])
+                        object body = GetExtensionObjectBody(extension);
+
+                        if (body is byte[])
                         {
-                            return ValueToString(extension.Body, new TypeInfo(BuiltInType.ByteString, ValueRanks.Scalar));
+                            return ValueToString(body, new TypeInfo(BuiltInType.ByteString, ValueRanks.Scalar));
                         }
 
-                        if (extension.Body is XmlElement)
+                        if (body is XmlElement)
                         {
-                            return ValueToString(extension.Body, new TypeInfo(BuiltInType.XmlElement, ValueRanks.Scalar));
+                            return ValueToString(body, new TypeInfo(BuiltInType.XmlElement, ValueRanks.Scalar));
                         }
 
-                        if (extension.Body is IEncodeable)
+                        if (body is IEncodeable)
                         {
-                            text = new Variant(extension).ToString();
+                            text = Variant.From(extension).ToString();
                         }
                     }
 
@@ -1327,7 +1349,7 @@ namespace Opc.Ua.Client.Controls.Common
 
                         if (encodeable != null)
                         {
-                            text = new Variant(encodeable).ToString();
+                            text = Variant.From(new ExtensionObject(encodeable)).ToString();
                         }
                     }
 
@@ -1340,7 +1362,7 @@ namespace Opc.Ua.Client.Controls.Common
                 }
             }
 
-            return (string)new Variant(value).ConvertTo(BuiltInType.String).Value;
+            return (string)ClientUtils.ToVariant(value).ConvertTo(BuiltInType.String).AsBoxedObject();
         }
 
         /// <summary>
@@ -1348,7 +1370,7 @@ namespace Opc.Ua.Client.Controls.Common
         /// </summary>
         private bool IsSimpleValue(AccessInfo info)
         {
-            if (info == null || info.TypeInfo == null)
+            if (info == null || info.TypeInfo.IsUnknown)
             {
                 return true;
             }
@@ -1362,7 +1384,7 @@ namespace Opc.Ua.Client.Controls.Common
                 typeInfo = variant.TypeInfo;
                 value = variant.AsBoxedObject();
 
-                if (typeInfo == null)
+                if (typeInfo.IsUnknown)
                 {
                     typeInfo = TypeInfo.Construct(value);
                 }
@@ -1469,7 +1491,7 @@ namespace Opc.Ua.Client.Controls.Common
 
                     if (IsSimpleValue(info))
                     {
-                        new Variant(e.FormattedValue).ConvertTo(info.TypeInfo.BuiltInType);
+                        ClientUtils.ToVariant(e.FormattedValue).ConvertTo(info.TypeInfo.BuiltInType);
                     }
                 }
             }
@@ -1491,7 +1513,7 @@ namespace Opc.Ua.Client.Controls.Common
 
                     if (IsSimpleValue(info))
                     {
-                        object newValue = new Variant((string)source.Row[3]).ConvertTo(info.TypeInfo.BuiltInType).Value;
+                        object newValue = Variant.From((string)source.Row[3]).ConvertTo(info.TypeInfo.BuiltInType).AsBoxedObject();
                         info.Value = newValue;
                         UpdateParent(info);
                     }
@@ -1524,7 +1546,7 @@ namespace Opc.Ua.Client.Controls.Common
             {
                 if (parentValue is ExtensionObject extension)
                 {
-                    parentValue = extension.Body;
+                    parentValue = GetExtensionObjectBody(extension);
                 }
 
                 info.PropertyInfo.SetValue(parentValue, info.Value, null);
@@ -1556,7 +1578,7 @@ namespace Opc.Ua.Client.Controls.Common
                 {
                     if (info.Parent.TypeInfo.BuiltInType == BuiltInType.Variant && info.Parent.TypeInfo.ValueRank >= 0)
                     {
-                        array.SetValue(new Variant(info.Value), indexes);
+                        array.SetValue(ClientUtils.ToVariant(info.Value), indexes);
                     }
                     else
                     {
@@ -1569,7 +1591,7 @@ namespace Opc.Ua.Client.Controls.Common
 
                     if (info.Parent.TypeInfo.BuiltInType == BuiltInType.Variant && info.Parent.TypeInfo.ValueRank >= 0)
                     {
-                        list[indexes[0]] = new Variant(info.Value);
+                        list[indexes[0]] = ClientUtils.ToVariant(info.Value);
                     }
                     else
                     {

--- a/Samples/ClientControls.Net4/Common/Client/EditComplexValueCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/EditComplexValueCtrl.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -255,7 +255,7 @@ namespace Opc.Ua.Client.Controls.Common
             if (info.Value is Variant)
             {
                 Variant variant = (Variant)info.Value;
-                currentValue = variant.Value;
+                currentValue = variant.AsBoxedObject();
 
                 if (currentValue != null)
                 {
@@ -406,7 +406,7 @@ namespace Opc.Ua.Client.Controls.Common
             if (info.Value is Variant)
             {
                 Variant variant = (Variant)info.Value;
-                currentValue = variant.Value;
+                currentValue = variant.AsBoxedObject();
 
                 if (currentValue != null)
                 {
@@ -512,7 +512,7 @@ namespace Opc.Ua.Client.Controls.Common
             }
 
             // determine the expected data type for value attributes.
-            else if (!NodeId.IsNull(nodeId))
+            else if (!(nodeId).IsNull)
             {
                 IVariableBase variable = await m_session.NodeCache.FindAsync(nodeId, ct) as IVariableBase;
 
@@ -718,7 +718,7 @@ namespace Opc.Ua.Client.Controls.Common
             if (value is Variant)
             {
                 Variant variant = (Variant)value;
-                value = variant.Value;
+                value = variant.AsBoxedObject();
 
                 if (value != null)
                 {
@@ -1215,7 +1215,7 @@ namespace Opc.Ua.Client.Controls.Common
             if (value is Variant)
             {
                 Variant variant = (Variant)value;
-                value = variant.Value;
+                value = variant.AsBoxedObject();
 
                 if (value != null)
                 {
@@ -1360,7 +1360,7 @@ namespace Opc.Ua.Client.Controls.Common
             {
                 Variant variant = (Variant)info.Value;
                 typeInfo = variant.TypeInfo;
-                value = variant.Value;
+                value = variant.AsBoxedObject();
 
                 if (typeInfo == null)
                 {
@@ -1517,7 +1517,7 @@ namespace Opc.Ua.Client.Controls.Common
 
             if (info.Parent.TypeInfo.BuiltInType == BuiltInType.Variant && info.Parent.TypeInfo.ValueRank < 0)
             {
-                parentValue = ((Variant)info.Parent.Value).Value;
+                parentValue = ((Variant)info.Parent.Value).AsBoxedObject();
             }
 
             if (info.PropertyInfo != null && info.Parent.TypeInfo.ValueRank < 0)

--- a/Samples/ClientControls.Net4/Common/Client/EditValueCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/EditValueCtrl.cs
@@ -111,7 +111,7 @@ namespace Opc.Ua.Client.Controls
             #pragma warning restore CA2000
                 m_value.TypeInfo,
                 null,
-                m_value.Value,
+                m_value.AsBoxedObject(),
                 "Edit Value");
 
             if (value == null)

--- a/Samples/ClientControls.Net4/Common/Client/EditValueCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/EditValueCtrl.cs
@@ -119,7 +119,7 @@ namespace Opc.Ua.Client.Controls
                 return;
             }
 
-            Value = new Variant(value);
+            Value = ClientUtils.ToVariant(value);
 
             m_ValueChanged?.Invoke(this, e);
         }

--- a/Samples/ClientControls.Net4/Common/Client/EditWriteValueDlg.cs
+++ b/Samples/ClientControls.Net4/Common/Client/EditWriteValueDlg.cs
@@ -1,4 +1,4 @@
-/* ========================================================================
+﻿/* ========================================================================
  * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -82,19 +82,19 @@ namespace Opc.Ua.Client.Controls
 
             if (nodeToWrite.Value.StatusCode != StatusCodes.Good)
             {
-                StatusCodeTB.Text = (string)new Variant(nodeToWrite.Value.StatusCode).ConvertTo(BuiltInType.String).Value;
+                StatusCodeTB.Text = (string)Variant.From(nodeToWrite.Value.StatusCode).ConvertTo(BuiltInType.String).AsBoxedObject();
                 StatusCodeCK.Checked = true;
             }
 
             if (nodeToWrite.Value.SourceTimestamp != DateTime.MinValue)
             {
-                SourceTimestampTB.Text = (string)new Variant(nodeToWrite.Value.SourceTimestamp).ConvertTo(BuiltInType.String).Value;
+                SourceTimestampTB.Text = (string)Variant.From(nodeToWrite.Value.SourceTimestamp).ConvertTo(BuiltInType.String).AsBoxedObject();
                 SourceTimestampCK.Checked = true;
             }
 
             if (nodeToWrite.Value.ServerTimestamp != DateTime.MinValue)
             {
-                ServerTimestampTB.Text = (string)new Variant(nodeToWrite.Value.ServerTimestamp).ConvertTo(BuiltInType.String).Value;
+                ServerTimestampTB.Text = (string)Variant.From(nodeToWrite.Value.ServerTimestamp).ConvertTo(BuiltInType.String).AsBoxedObject();
                 ServerTimestampCK.Checked = true;
             }
 
@@ -113,17 +113,17 @@ namespace Opc.Ua.Client.Controls
 
             if (StatusCodeCK.Checked)
             {
-                dataValue = dataValue.WithStatus((StatusCode)new Variant(StatusCodeTB.Text).ConvertTo(BuiltInType.StatusCode).Value);
+                dataValue = dataValue.WithStatus((StatusCode)Variant.From(StatusCodeTB.Text).ConvertTo(BuiltInType.StatusCode).AsBoxedObject());
             }
 
             if (SourceTimestampCK.Checked)
             {
-                dataValue = dataValue.WithSourceTimestamp((DateTimeUtc)new Variant(SourceTimestampTB.Text).ConvertTo(BuiltInType.DateTime).Value);
+                dataValue = dataValue.WithSourceTimestamp((DateTimeUtc)Variant.From(SourceTimestampTB.Text).ConvertTo(BuiltInType.DateTime).AsBoxedObject());
             }
 
             if (ServerTimestampCK.Checked)
             {
-                dataValue = dataValue.WithServerTimestamp((DateTimeUtc)new Variant(ServerTimestampTB.Text).ConvertTo(BuiltInType.DateTime).Value);
+                dataValue = dataValue.WithServerTimestamp((DateTimeUtc)Variant.From(ServerTimestampTB.Text).ConvertTo(BuiltInType.DateTime).AsBoxedObject());
             }
 
             result.Value = dataValue;
@@ -157,21 +157,21 @@ namespace Opc.Ua.Client.Controls
 
                 if (StatusCodeCK.Checked)
                 {
-                    new Variant(StatusCodeTB.Text).ConvertTo(BuiltInType.StatusCode);
+                    Variant.From(StatusCodeTB.Text).ConvertTo(BuiltInType.StatusCode);
                 }
 
                 SourceTimestampTB.Text = SourceTimestampTB.Text.Trim();
 
                 if (SourceTimestampCK.Checked)
                 {
-                    new Variant(SourceTimestampTB.Text).ConvertTo(BuiltInType.DateTime);
+                    Variant.From(SourceTimestampTB.Text).ConvertTo(BuiltInType.DateTime);
                 }
 
                 ServerTimestampTB.Text = ServerTimestampTB.Text.Trim();
 
                 if (ServerTimestampCK.Checked)
                 {
-                    new Variant(ServerTimestampTB.Text).ConvertTo(BuiltInType.DateTime);
+                    Variant.From(ServerTimestampTB.Text).ConvertTo(BuiltInType.DateTime);
                 }
 
                 DialogResult = DialogResult.OK;

--- a/Samples/ClientControls.Net4/Common/Client/EventFilterListViewCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/EventFilterListViewCtrl.cs
@@ -194,7 +194,7 @@ namespace Opc.Ua.Client.Controls
                         source.Row[5] = field.FilterEnabled;
                         source.Row[6] = field.FilterOperator;
 
-                        field.FilterValue = new Variant(result);
+                        field.FilterValue = ClientUtils.ToVariant(result);
                         source.Row[7] = field.FilterValue;
                     }
 

--- a/Samples/ClientControls.Net4/Common/Client/EventFilterListViewCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/EventFilterListViewCtrl.cs
@@ -185,7 +185,7 @@ namespace Opc.Ua.Client.Controls
                         declaration.DisplayName,
                         declaration.DataType,
                         declaration.ValueRank,
-                        field.FilterValue.Value,
+                        field.FilterValue.AsBoxedObject(),
                         "Edit Filter Value");
 
                     if (result != null)

--- a/Samples/ClientControls.Net4/Common/Client/EventListViewCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/EventListViewCtrl.cs
@@ -149,7 +149,7 @@ namespace Opc.Ua.Client.Controls
         /// </summary>
         private async Task ReadHistoryAsync(ReadEventDetails details, NodeId areaId, CancellationToken ct = default)
         {
-            HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+            List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
             HistoryReadValueId nodeToRead = new HistoryReadValueId();
             nodeToRead.NodeId = areaId;
             nodesToRead.Add(nodeToRead);
@@ -163,7 +163,7 @@ namespace Opc.Ua.Client.Controls
                 nodesToRead,
                 ct);
 
-            HistoryReadResultCollection results = new HistoryReadResultCollection(response.Results.ToArray());
+            List<HistoryReadResult> results = new List<HistoryReadResult>(response.Results.ToArray());
             List<DiagnosticInfo> diagnosticInfos = new List<DiagnosticInfo>(response.DiagnosticInfos.ToArray());
 
             ClientBase.ValidateResponse(results, nodesToRead);
@@ -194,7 +194,7 @@ namespace Opc.Ua.Client.Controls
                     nodesToRead,
                     ct);
 
-                results = new HistoryReadResultCollection(response.Results.ToArray());
+                results = new List<HistoryReadResult>(response.Results.ToArray());
                 diagnosticInfos = new List<DiagnosticInfo>(response.DiagnosticInfos.ToArray());
             }
         }
@@ -235,7 +235,7 @@ namespace Opc.Ua.Client.Controls
 
                 if (e.Count > index)
                 {
-                    eventId = e[index].Value as byte[];
+                    eventId = e[index].AsBoxedObject() as byte[];
                 }
 
                 eventIds.Add(eventId.ToByteString());
@@ -253,7 +253,7 @@ namespace Opc.Ua.Client.Controls
                 nodesToUpdate,
                 ct);
 
-            HistoryUpdateResultCollection results = new HistoryUpdateResultCollection(response.Results.ToArray());
+            List<HistoryUpdateResult> results = new List<HistoryUpdateResult>(response.Results.ToArray());
             List<DiagnosticInfo> diagnosticInfos = new List<DiagnosticInfo>(response.DiagnosticInfos.ToArray());
 
             ClientBase.ValidateResponse(results, nodesToUpdate);

--- a/Samples/ClientControls.Net4/Common/Client/GdsDiscoverServersDlg.cs
+++ b/Samples/ClientControls.Net4/Common/Client/GdsDiscoverServersDlg.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -328,7 +328,7 @@ namespace Opc.Ua.Client.Controls
 
             if (outputArguments != null && outputArguments.Count == 1)
             {
-                ExtensionObject[] extensions = outputArguments[0].Value as ExtensionObject[];
+                ExtensionObject[] extensions = outputArguments[0].AsBoxedObject() as ExtensionObject[];
                 ApplicationDescription[] descriptions = (ApplicationDescription[])ExtensionObject.ToArray(extensions, typeof(ApplicationDescription));
                 await UpdateResultsAsync(descriptions, ct);
             }
@@ -359,7 +359,7 @@ namespace Opc.Ua.Client.Controls
                 ct,
                 browsePaths);
 
-            ReadValueIdCollection nodesToRead = new ReadValueIdCollection();
+            List<ReadValueId> nodesToRead = new List<ReadValueId>();
 
             foreach (NodeId propertyId in propertyIds)
             {

--- a/Samples/ClientControls.Net4/Common/Client/GdsDiscoverServersDlg.cs
+++ b/Samples/ClientControls.Net4/Common/Client/GdsDiscoverServersDlg.cs
@@ -1,4 +1,4 @@
-/* ========================================================================
+﻿/* ========================================================================
  * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -329,7 +329,7 @@ namespace Opc.Ua.Client.Controls
             if (outputArguments != null && outputArguments.Count == 1)
             {
                 ExtensionObject[] extensions = outputArguments[0].AsBoxedObject() as ExtensionObject[];
-                ApplicationDescription[] descriptions = (ApplicationDescription[])ExtensionObject.ToArray(extensions, typeof(ApplicationDescription));
+                ApplicationDescription[] descriptions = ExtensionObject.ToArray<ApplicationDescription>(extensions).ToArray();
                 await UpdateResultsAsync(descriptions, ct);
             }
         }

--- a/Samples/ClientControls.Net4/Common/Client/HistoryDataListView.cs
+++ b/Samples/ClientControls.Net4/Common/Client/HistoryDataListView.cs
@@ -266,7 +266,7 @@ namespace Opc.Ua.Client.Controls
             }
             else
             {
-                if (NodeId.IsNull(m_nodeId))
+                if ((m_nodeId).IsNull)
                 {
                     NodeIdTB.Text = String.Empty;
                 }
@@ -427,7 +427,7 @@ namespace Opc.Ua.Client.Controls
 
             set
             {
-                if (NodeId.IsNull(value))
+                if ((value).IsNull)
                 {
                     AggregateCB.SelectedIndex = -1;
                     return;
@@ -567,7 +567,7 @@ namespace Opc.Ua.Client.Controls
             m_dataset.Clear();
             NodeIdTB.Text = await m_session.NodeCache.GetDisplayTextAsync(m_nodeId, ct);
 
-            if (!NodeId.IsNull(nodeId))
+            if (!(nodeId).IsNull)
             {
                 m_properties = await FindPropertiesWithHistoryAsync(ct);
 
@@ -748,7 +748,7 @@ namespace Opc.Ua.Client.Controls
 
             List<ReferenceDescription> references = await ClientUtils.BrowseAsync(m_session, nodeToBrowse, false, ct);
 
-            ReadValueIdCollection nodesToRead = new ReadValueIdCollection();
+            List<ReadValueId> nodesToRead = new List<ReadValueId>();
 
             for (int ii = 0; ii < references.Count; ii++)
             {
@@ -853,7 +853,7 @@ namespace Opc.Ua.Client.Controls
             ClientBase.ValidateDiagnosticInfos(diagnosticInfos, pathsToTranslate);
 
             // build list of values to read.
-            ReadValueIdCollection valuesToRead = new ReadValueIdCollection();
+            List<ReadValueId> valuesToRead = new List<ReadValueId>();
 
             for (int ii = 0; ii < pathsToTranslate.Count; ii++)
             {
@@ -935,7 +935,7 @@ namespace Opc.Ua.Client.Controls
             HistoryReadValueId nodeToRead = new HistoryReadValueId();
             nodeToRead.NodeId = m_nodeId;
 
-            HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+            List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
             nodesToRead.Add(nodeToRead);
 
             HistoryReadResponse response = await m_session.HistoryReadAsync(
@@ -1006,7 +1006,7 @@ namespace Opc.Ua.Client.Controls
             HistoryReadValueId nodeToRead = new HistoryReadValueId();
             nodeToRead.NodeId = m_nodeId;
 
-            HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+            List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
             nodesToRead.Add(nodeToRead);
 
             HistoryReadResponse response = await m_session.HistoryReadAsync(
@@ -1255,7 +1255,7 @@ namespace Opc.Ua.Client.Controls
                 return;
             }
 
-            HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+            List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
             nodesToRead.Add(m_nodeToContinue);
 
             HistoryReadResponse response = await m_session.HistoryReadAsync(
@@ -1311,7 +1311,7 @@ namespace Opc.Ua.Client.Controls
             details.IsReadModified = isReadModified;
             details.ReturnBounds = (isReadModified) ? false : ReturnBoundsCK.Checked;
 
-            HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+            List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
             HistoryReadValueId nodeToRead = new HistoryReadValueId();
             nodeToRead.NodeId = GetSelectedNode();
             nodesToRead.Add(nodeToRead);
@@ -1364,7 +1364,7 @@ namespace Opc.Ua.Client.Controls
 
             details.ReqTimes = reqTimes;
 
-            HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+            List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
             HistoryReadValueId nodeToRead = new HistoryReadValueId();
             nodeToRead.NodeId = GetSelectedNode();
             nodesToRead.Add(nodeToRead);
@@ -1416,7 +1416,7 @@ namespace Opc.Ua.Client.Controls
             details.AggregateType = new List<NodeId> { aggregate.NodeId };
             details.AggregateConfiguration.UseServerCapabilitiesDefaults = true;
 
-            HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+            List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
             HistoryReadValueId nodeToRead = new HistoryReadValueId();
             nodeToRead.NodeId = m_nodeId;
             nodesToRead.Add(nodeToRead);
@@ -1455,7 +1455,7 @@ namespace Opc.Ua.Client.Controls
             // clear existing continuation point.
             if (m_nodeToContinue != null)
             {
-                HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+                List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
                 nodesToRead.Add(m_nodeToContinue);
 
                 HistoryReadResponse response = await m_session.HistoryReadAsync(
@@ -1506,7 +1506,7 @@ namespace Opc.Ua.Client.Controls
         /// </summary>
         private async Task InsertReplaceAsync(PerformUpdateType updateType, CancellationToken ct = default)
         {
-            DataValueCollection values = new DataValueCollection();
+            List<DataValue> values = new List<DataValue>();
 
             foreach (DataRowView row in m_dataset.Tables[0].DefaultView)
             {
@@ -1559,7 +1559,7 @@ namespace Opc.Ua.Client.Controls
                 details = details2;
             }
 
-            ExtensionObjectCollection nodesToUpdate = new ExtensionObjectCollection();
+            List<ExtensionObject> nodesToUpdate = new List<ExtensionObject>();
             nodesToUpdate.Add(new ExtensionObject(details));
 
             HistoryUpdateResponse response = await m_session.HistoryUpdateAsync(
@@ -1592,7 +1592,7 @@ namespace Opc.Ua.Client.Controls
             details.StartTime = StartTimeDP.Value;
             details.EndTime = EndTimeDP.Value;
 
-            ExtensionObjectCollection nodesToUpdate = new ExtensionObjectCollection();
+            List<ExtensionObject> nodesToUpdate = new List<ExtensionObject>();
             nodesToUpdate.Add(new ExtensionObject(details));
 
             HistoryUpdateResponse response = await m_session.HistoryUpdateAsync(
@@ -1633,7 +1633,7 @@ namespace Opc.Ua.Client.Controls
 
             details.ReqTimes = reqTimes;
 
-            ExtensionObjectCollection nodesToUpdate = new ExtensionObjectCollection();
+            List<ExtensionObject> nodesToUpdate = new List<ExtensionObject>();
             nodesToUpdate.Add(new ExtensionObject(details));
 
             HistoryUpdateResponse response = await m_session.HistoryUpdateAsync(

--- a/Samples/ClientControls.Net4/Common/Client/HistoryDataListView.cs
+++ b/Samples/ClientControls.Net4/Common/Client/HistoryDataListView.cs
@@ -1,4 +1,4 @@
-/* ========================================================================
+﻿/* ========================================================================
  * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -1110,7 +1110,7 @@ namespace Opc.Ua.Client.Controls
                 filter.ProcessingInterval = (double)ProcessingIntervalNP.Value;
                 filter.AggregateType = ((AvailableAggregate)AggregateCB.SelectedItem).NodeId;
 
-                if (filter.AggregateType != null)
+                if (!filter.AggregateType.IsNull)
                 {
                     m_monitoredItem.Filter = filter;
                 }

--- a/Samples/ClientControls.Net4/Common/Client/HistoryEventCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/HistoryEventCtrl.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -223,7 +223,7 @@ namespace Opc.Ua.Client.Controls
             }
             else
             {
-                if (NodeId.IsNull(m_nodeId))
+                if ((m_nodeId).IsNull)
                 {
                     NodeIdTB.Text = String.Empty;
                 }

--- a/Samples/ClientControls.Net4/Common/Client/ReadRequestListViewCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/ReadRequestListViewCtrl.cs
@@ -1,4 +1,4 @@
-/* ========================================================================
+﻿/* ========================================================================
  * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -197,7 +197,7 @@ namespace Opc.Ua.Client.Controls
         public void UpdateRow(DataRow row, DataValue value)
         {
             row[6] = value;
-            row[7] = (value.WrappedValue.TypeInfo != null) ? value.WrappedValue.TypeInfo.ToString() : String.Empty;
+            row[7] = (!value.WrappedValue.TypeInfo.IsUnknown) ? value.WrappedValue.TypeInfo.ToString() : String.Empty;
             row[8] = value.WrappedValue;
             row[9] = value.StatusCode;
             row[10] = (value.SourceTimestamp != DateTime.MinValue) ? Utils.Format("{0:hh:mm:ss.fff}", value.SourceTimestamp.ToLocalTime()) : String.Empty;

--- a/Samples/ClientControls.Net4/Common/Client/ReadRequestListViewCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/ReadRequestListViewCtrl.cs
@@ -127,7 +127,7 @@ namespace Opc.Ua.Client.Controls
             }
 
             // build list of values to read.
-            ReadValueIdCollection nodesToRead = new ReadValueIdCollection();
+            List<ReadValueId> nodesToRead = new List<ReadValueId>();
 
             foreach (DataGridViewRow row in ResultsDV.Rows)
             {

--- a/Samples/ClientControls.Net4/Common/Client/SelectLocaleDlg.cs
+++ b/Samples/ClientControls.Net4/Common/Client/SelectLocaleDlg.cs
@@ -1,4 +1,4 @@
-/* ========================================================================
+﻿/* ========================================================================
  * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -73,7 +73,7 @@ namespace Opc.Ua.Client.Controls
             // get the locales from the server.
             DataValue value = await m_session.ReadValueAsync(VariableIds.Server_ServerCapabilities_LocaleIdArray, ct);
 
-            if (value != null)
+            if (!value.IsNull)
             {
                 string[] availableLocales = value.GetValue<string[]>(null);
 

--- a/Samples/ClientControls.Net4/Common/Client/SelectNodeCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/SelectNodeCtrl.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -165,13 +165,13 @@ namespace Opc.Ua.Client.Controls
                 {
                     NodeControl.Text = null;
 
-                    if (value != null && !NodeId.IsNull(value.NodeId))
+                    if (value != null && !(value.NodeId).IsNull)
                     {
                         NodeControl.Text = value.ToString();
                     }
                 }
 
-                if (value == null || NodeId.IsNull(value.NodeId))
+                if (value == null || (value.NodeId).IsNull)
                 {
                     m_selectedNode = null;
                     return;

--- a/Samples/ClientControls.Net4/Common/Client/SelectNodeDlg.cs
+++ b/Samples/ClientControls.Net4/Common/Client/SelectNodeDlg.cs
@@ -76,7 +76,7 @@ namespace Opc.Ua.Client.Controls
             }
 
             // set default root.
-            if (NodeId.IsNull(rootId))
+            if ((rootId).IsNull)
             {
                 rootId = Opc.Ua.ObjectIds.ObjectsFolder;
             }
@@ -126,7 +126,7 @@ namespace Opc.Ua.Client.Controls
             }
 
             // set default root.
-            if (NodeId.IsNull(rootId))
+            if ((rootId).IsNull)
             {
                 rootId = Opc.Ua.ObjectIds.ObjectsFolder;
             }

--- a/Samples/ClientControls.Net4/Common/Client/SubscribeDataListViewCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/SubscribeDataListViewCtrl.cs
@@ -431,7 +431,7 @@ namespace Opc.Ua.Client.Controls
 
             if (value != null)
             {
-                row[1] = ImageList.Images[ClientUtils.GetImageIndex(Attributes.Value, value.Value)];
+                row[1] = ImageList.Images[ClientUtils.GetImageIndex(Attributes.Value, value.WrappedValue.AsBoxedObject())];
                 row[12] = (value.WrappedValue.TypeInfo != null) ? value.WrappedValue.TypeInfo.ToString() : String.Empty;
                 row[13] = value.WrappedValue;
                 row[14] = value.StatusCode;
@@ -531,7 +531,7 @@ namespace Opc.Ua.Client.Controls
 
                     if (m_EditComplexValueDlg != null && Object.ReferenceEquals(m_EditComplexValueDlg.Tag, monitoredItem))
                     {
-                        await m_EditComplexValueDlg.UpdateValueAsync(monitoredItem.ResolvedNodeId, monitoredItem.AttributeId, null, itemNotification.Value.Value);
+                        await m_EditComplexValueDlg.UpdateValueAsync(monitoredItem.ResolvedNodeId, monitoredItem.AttributeId, null, itemNotification.Value.WrappedValue.AsBoxedObject());
                     }
                 }
             }
@@ -669,7 +669,7 @@ namespace Opc.Ua.Client.Controls
                     monitoredItem.ResolvedNodeId,
                     monitoredItem.AttributeId,
                     null,
-                    value.Value,
+                    value.WrappedValue.AsBoxedObject(),
                     true,
                     "View Data Change");
 

--- a/Samples/ClientControls.Net4/Common/Client/SubscribeDataListViewCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/SubscribeDataListViewCtrl.cs
@@ -429,10 +429,10 @@ namespace Opc.Ua.Client.Controls
 
             row[11] = value;
 
-            if (value != null)
+            if (!value.IsNull)
             {
                 row[1] = ImageList.Images[ClientUtils.GetImageIndex(Attributes.Value, value.WrappedValue.AsBoxedObject())];
-                row[12] = (value.WrappedValue.TypeInfo != null) ? value.WrappedValue.TypeInfo.ToString() : String.Empty;
+                row[12] = (!value.WrappedValue.TypeInfo.IsUnknown) ? value.WrappedValue.TypeInfo.ToString() : String.Empty;
                 row[13] = value.WrappedValue;
                 row[14] = value.StatusCode;
                 row[15] = value.SourceTimestamp.ToLocalTime().ToString("hh:mm:ss.fff");

--- a/Samples/ClientControls.Net4/Common/Client/SubscribeEventsDlg.cs
+++ b/Samples/ClientControls.Net4/Common/Client/SubscribeEventsDlg.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -786,7 +786,7 @@ namespace Opc.Ua.Client.Controls
             {
                 ReferenceDescription reference = BrowseCTRL.SelectedNode;
 
-                if (reference == null || NodeId.IsNull(reference.NodeId) || reference.NodeId.IsAbsolute)
+                if (reference == null || (reference.NodeId).IsNull || reference.NodeId.IsAbsolute)
                 {
                     await EventTypeCTRL.ShowTypeAsync(NodeId.Null);
                     return;

--- a/Samples/ClientControls.Net4/Common/Client/TypeFieldsListViewCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/TypeFieldsListViewCtrl.cs
@@ -94,7 +94,7 @@ namespace Opc.Ua.Client.Controls
         /// </summary>
         public async Task ShowTypeAsync(NodeId typeId, CancellationToken ct = default)
         {
-            if (NodeId.IsNull(typeId))
+            if ((typeId).IsNull)
             {
                 m_dataset.Tables[0].Rows.Clear();
                 return;
@@ -178,7 +178,7 @@ namespace Opc.Ua.Client.Controls
             }
 
             // build list of values to read.
-            ReadValueIdCollection nodesToRead = new ReadValueIdCollection();
+            List<ReadValueId> nodesToRead = new List<ReadValueId>();
 
             foreach (DataGridViewRow row in ResultsDV.Rows)
             {

--- a/Samples/ClientControls.Net4/Common/Client/ViewEventDetailsDlg.cs
+++ b/Samples/ClientControls.Net4/Common/Client/ViewEventDetailsDlg.cs
@@ -71,7 +71,7 @@ namespace Opc.Ua.Client.Controls
                 string text = null;
 
                 // check for missing fields.
-                if (fields.Count <= ii + 1 || fields[ii + 1].Value == null)
+                if (fields.Count <= ii + 1 || fields[ii + 1].AsBoxedObject() == null)
                 {
                     text = String.Empty;
                 }

--- a/Samples/ClientControls.Net4/Common/Client/WriteRequestListViewCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/WriteRequestListViewCtrl.cs
@@ -1,4 +1,4 @@
-/* ========================================================================
+﻿/* ========================================================================
  * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -266,7 +266,7 @@ namespace Opc.Ua.Client.Controls
         /// </summary>
         public void UpdateRow(DataRow row, DataValue value)
         {
-            row[5] = (value.WrappedValue.TypeInfo != null) ? value.WrappedValue.TypeInfo.ToString() : String.Empty;
+            row[5] = (!value.WrappedValue.TypeInfo.IsUnknown) ? value.WrappedValue.TypeInfo.ToString() : String.Empty;
             row[6] = value.WrappedValue;
             row[7] = value.StatusCode;
             row[8] = (value.SourceTimestamp != DateTime.MinValue) ? Utils.Format("{0:hh:mm:ss.fff}", value.SourceTimestamp.ToLocalTime()) : String.Empty;
@@ -404,7 +404,7 @@ namespace Opc.Ua.Client.Controls
                         {
                             DataRowView source = row.DataBoundItem as DataRowView;
                             nodeToWrite = (WriteValue)source.Row[0];
-                            nodeToWrite.Value = new DataValue(new Variant(value));
+                            nodeToWrite.Value = new DataValue(ClientUtils.ToVariant(value));
                             await UpdateRowAsync(source.Row, nodeToWrite);
                         }
                     }

--- a/Samples/ClientControls.Net4/Common/Client/WriteRequestListViewCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/WriteRequestListViewCtrl.cs
@@ -125,7 +125,7 @@ namespace Opc.Ua.Client.Controls
             }
 
             // build list of values to read.
-            ReadValueIdCollection nodesToRead = new ReadValueIdCollection();
+            List<ReadValueId> nodesToRead = new List<ReadValueId>();
 
             if (nodesToWrite == null || nodesToWrite.Length == 0)
             {
@@ -197,7 +197,7 @@ namespace Opc.Ua.Client.Controls
             }
 
             // build list of values to write.
-            WriteValueCollection nodesToWrite = new WriteValueCollection();
+            List<WriteValue> nodesToWrite = new List<WriteValue>();
 
             foreach (DataGridViewRow row in ResultsDV.Rows)
             {
@@ -393,7 +393,7 @@ namespace Opc.Ua.Client.Controls
                         nodeToWrite.NodeId,
                         nodeToWrite.AttributeId,
                         null,
-                        nodeToWrite.Value.Value,
+                        nodeToWrite.Value.WrappedValue.AsBoxedObject(),
                         false,
                         "Edit Value");
 

--- a/Samples/ClientControls.Net4/Common/ClientUtils.cs
+++ b/Samples/ClientControls.Net4/Common/ClientUtils.cs
@@ -103,7 +103,7 @@ namespace Opc.Ua.Client.Controls
 
                     if (typeInfo == null)
                     {
-                        typeInfo = TypeInfo.Construct(((Variant)value).Value);
+                        typeInfo = TypeInfo.Construct(((Variant)value).AsBoxedObject());
                     }
                 }
 

--- a/Samples/ClientControls.Net4/Common/ClientUtils.cs
+++ b/Samples/ClientControls.Net4/Common/ClientUtils.cs
@@ -1,4 +1,4 @@
-/* ========================================================================
+﻿/* ========================================================================
  * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -77,6 +77,29 @@ namespace Opc.Ua.Client.Controls
         }
 
         /// <summary>
+        /// Creates a Variant from a boxed value using the value's runtime type.
+        /// </summary>
+        public static Variant ToVariant(object value)
+        {
+            if (value == null)
+            {
+                return Variant.Null;
+            }
+
+            if (value is Variant variant)
+            {
+                return variant;
+            }
+
+            if (value is IEncodeable encodeable)
+            {
+                return Variant.From(new ExtensionObject(encodeable));
+            }
+
+            return Variant.From((dynamic)value);
+        }
+
+        /// <summary>
         /// Returns an image index for the specified attribute.
         /// </summary>
 #pragma warning disable 0162
@@ -101,7 +124,7 @@ namespace Opc.Ua.Client.Controls
                 {
                     typeInfo = ((Variant)value).TypeInfo;
 
-                    if (typeInfo == null)
+                    if (typeInfo.IsUnknown)
                     {
                         typeInfo = TypeInfo.Construct(((Variant)value).AsBoxedObject());
                     }
@@ -147,9 +170,6 @@ namespace Opc.Ua.Client.Controls
             return ClientUtils.Attribute;
         }
 
-        /// <summary>
-        /// Returns an image index for the specified attribute.
-        /// </summary>
         public static async Task<int> GetImageIndexAsync(ISession session, NodeClass nodeClass, ExpandedNodeId typeDefinitionId, bool selected, CancellationToken ct = default)
         {
             if (nodeClass == NodeClass.Variable)

--- a/Samples/ClientControls.Net4/Common/DiscoverServerDlg.cs
+++ b/Samples/ClientControls.Net4/Common/DiscoverServerDlg.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -122,7 +122,7 @@ namespace Opc.Ua.Client.Controls
                 // Connect to the local discovery server and find the available servers.
                 using (DiscoveryClient client = await DiscoveryClient.CreateAsync(new Uri(Utils.Format("opc.tcp://{0}:4840", hostName)), configuration, m_telemetry, DiagnosticsMasks.None, ct))
                 {
-                    ApplicationDescriptionCollection servers = new ApplicationDescriptionCollection();
+                    List<ApplicationDescription> servers = new List<ApplicationDescription>();
                     servers.AddRange(await client.FindServersAsync(ArrayOf<string>.Null, ct));
 
                     // populate the drop down list with the discovery URLs for the available servers.

--- a/Samples/ClientControls.Net4/Common/DiscoveredServerListCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/DiscoveredServerListCtrl.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -179,7 +179,7 @@ namespace Opc.Ua.Client.Controls
 
             ItemsLV.Items.Clear();
 
-            ApplicationDescriptionCollection servers = state as ApplicationDescriptionCollection;
+            List<ApplicationDescription> servers = state as List<ApplicationDescription>;
 
             if (servers != null)
             {
@@ -265,7 +265,7 @@ namespace Opc.Ua.Client.Controls
                     DiagnosticsMasks.None,
                     ct);
 
-                ApplicationDescriptionCollection servers = new ApplicationDescriptionCollection();
+                List<ApplicationDescription> servers = new List<ApplicationDescription>();
                 servers.AddRange(await client.FindServersAsync(ArrayOf<string>.Null, ct));
                 m_discoveryUrl = discoveryUrl.ToString();
                 OnUpdateServers(servers);

--- a/Samples/ClientControls.Net4/Common/DiscoveredServerOnNetworkListCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/DiscoveredServerOnNetworkListCtrl.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -167,7 +167,7 @@ namespace Opc.Ua.Client.Controls
 
             ItemsLV.Items.Clear();
 
-            ServerOnNetworkCollection servers = state as ServerOnNetworkCollection;
+            List<ServerOnNetwork> servers = state as List<ServerOnNetwork>;
 
             if (servers != null)
             {
@@ -274,7 +274,7 @@ namespace Opc.Ua.Client.Controls
                 (servers, lastReset) = await client.FindServersOnNetworkAsync(startingRecordId, maxRecordsToReturn, serverCapabilityFilter, ct);
                 lastCounterResetTime = (DateTime)lastReset;
                 m_discoveryUrl = discoveryUrl.ToString();
-                OnUpdateServers(new ServerOnNetworkCollection(servers.ToArray()));
+                OnUpdateServers(new List<ServerOnNetwork>(servers.ToArray()));
                 return true;
             }
             catch (Exception e)

--- a/Samples/ClientControls.Net4/Common/EditArrayDlg.cs
+++ b/Samples/ClientControls.Net4/Common/EditArrayDlg.cs
@@ -102,7 +102,7 @@ namespace Opc.Ua.Client.Controls
                 for (int ii = 0; ii < value.Length; ii++)
                 {
                     DataRow row = m_dataset.Tables[0].NewRow();
-                    row[0] = new Variant(value.GetValue(ii)).ToString();
+                    row[0] = ClientUtils.ToVariant(value.GetValue(ii)).ToString();
                     row[1] = ii;
                     m_dataset.Tables[0].Rows.Add(row);
                 }
@@ -124,7 +124,7 @@ namespace Opc.Ua.Client.Controls
                 for (int ii = 0; ii < m_dataset.Tables[0].DefaultView.Count; ii++)
                 {
                     string oldValue = m_dataset.Tables[0].DefaultView[ii].Row[0] as string;
-                    object newValue = new Variant(oldValue, TypeInfo.Scalars.String).ConvertTo(m_dataType).Value;
+                    object newValue = ClientUtils.ToVariant(oldValue).ConvertTo(m_dataType).AsBoxedObject();
                     value.SetValue(newValue, ii);
                 }
             }
@@ -150,7 +150,7 @@ namespace Opc.Ua.Client.Controls
         {
             try
             {
-                object newValue = new Variant(e.FormattedValue, TypeInfo.Scalars.String).ConvertTo(m_dataType).Value;
+                object newValue = ClientUtils.ToVariant(e.FormattedValue).ConvertTo(m_dataType).AsBoxedObject();
             }
             catch (Exception exception)
             {
@@ -200,7 +200,7 @@ namespace Opc.Ua.Client.Controls
                     }
 
                     DataRow row = m_dataset.Tables[0].NewRow();
-                    row[0] = new Variant(TypeInfo.GetDefaultValue(m_dataType));
+                    row[0] = ClientUtils.ToVariant(TypeInfo.GetDefaultValue(m_dataType));
                     row[1] = index;
                     m_dataset.Tables[0].Rows.Add(row);
                 }

--- a/Samples/ClientControls.Net4/Common/EditComplexValueDlg.cs
+++ b/Samples/ClientControls.Net4/Common/EditComplexValueDlg.cs
@@ -299,11 +299,11 @@ namespace Opc.Ua.Client.Controls
                 nodeToRead.DataEncoding = m_encodingName;
 
 
-                ReadValueIdCollection nodesToRead = new ReadValueIdCollection();
+                List<ReadValueId> nodesToRead = new List<ReadValueId>();
                 nodesToRead.Add(nodeToRead);
 
                 // read the attributes.
-                DataValueCollection results = null;
+                List<DataValue> results = null;
                 DiagnosticInfoCollection diagnosticInfos = null;
 
                 m_session.Read(
@@ -344,7 +344,7 @@ namespace Opc.Ua.Client.Controls
                 nodeToWrite.Value = new DataValue();
                 nodeToWrite.Value.WrappedValue = GetValue();
 
-                WriteValueCollection nodesToWrite = new WriteValueCollection();
+                List<WriteValue> nodesToWrite = new List<WriteValue>();
                 nodesToWrite.Add(nodeToWrite);
 
                 // read the attributes.

--- a/Samples/ClientControls.Net4/Common/EditDataValueCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/EditDataValueCtrl.cs
@@ -144,7 +144,7 @@ namespace Opc.Ua.Client.Controls
             // allow data type to be changed by default.
             DataTypeCB.Enabled = true;
 
-            if (targetType != null)
+            if (!targetType.IsUnknown)
             {
                 DataType = targetType.BuiltInType;
                 ValueRank = targetType.ValueRank;
@@ -317,9 +317,9 @@ namespace Opc.Ua.Client.Controls
             }
 
             // cast the value to the requested data type.
-            object value = new Variant(ValueTB.Text, TypeInfo.Scalars.String).ConvertTo(targetType).Value;
+            object value = Variant.From(ValueTB.Text).ConvertTo(targetType).AsBoxedObject();
 
-            return new Variant(value, new TypeInfo(targetType, valueRank));
+            return ClientUtils.ToVariant(value);
         }
 
         /// <summary>
@@ -330,7 +330,7 @@ namespace Opc.Ua.Client.Controls
             BuiltInType targetType = BuiltInType.Null;
             int valueRank = ValueRanks.Scalar;
 
-            if (value.TypeInfo != null && value.TypeInfo.BuiltInType != BuiltInType.Null)
+            if (!value.TypeInfo.IsUnknown && value.TypeInfo.BuiltInType != BuiltInType.Null)
             {
                 targetType = value.TypeInfo.BuiltInType;
                 valueRank = value.TypeInfo.ValueRank;
@@ -354,7 +354,7 @@ namespace Opc.Ua.Client.Controls
             }
 
             // cast the value to the requested data type.
-            ValueTB.Text = (string)new Variant(value.AsBoxedObject(), value.TypeInfo).ConvertTo(BuiltInType.String).Value;
+            ValueTB.Text = (string)ClientUtils.ToVariant(value.AsBoxedObject()).ConvertTo(BuiltInType.String).AsBoxedObject();
             ValueTB.ReadOnly = false;
         }
 

--- a/Samples/ClientControls.Net4/Common/EditDataValueCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/EditDataValueCtrl.cs
@@ -339,7 +339,7 @@ namespace Opc.Ua.Client.Controls
             DataTypeCB.SelectedItem = targetType;
             ValueRankCB.SelectedItem = (ValueRankOptions)valueRank;
 
-            if (value.Value == null)
+            if (value.AsBoxedObject() == null)
             {
                 ValueTB.Text = String.Empty;
                 return;
@@ -354,7 +354,7 @@ namespace Opc.Ua.Client.Controls
             }
 
             // cast the value to the requested data type.
-            ValueTB.Text = (string)new Variant(value.Value, value.TypeInfo).ConvertTo(BuiltInType.String).Value;
+            ValueTB.Text = (string)new Variant(value.AsBoxedObject(), value.TypeInfo).ConvertTo(BuiltInType.String).Value;
             ValueTB.ReadOnly = false;
         }
 

--- a/Samples/ClientControls.Net4/Common/EditValueCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/EditValueCtrl.cs
@@ -88,8 +88,8 @@ namespace Opc.Ua.Client.Controls
             // check if the value needs to be updated.
             if (m_textChanged)
             {
-                object value = new Variant(ValueTB.Text, TypeInfo.Scalars.String).ConvertTo(sourceType.BuiltInType).Value;
-                m_value = new Variant(value, sourceType);
+                object value = Variant.From(ValueTB.Text).ConvertTo(sourceType.BuiltInType).AsBoxedObject();
+                m_value = ClientUtils.ToVariant(value);
             }
 
             return m_value;
@@ -112,20 +112,20 @@ namespace Opc.Ua.Client.Controls
             // get the source type.
             TypeInfo sourceType = value.TypeInfo;
 
-            if (sourceType == null)
+            if (sourceType.IsUnknown)
             {
                 sourceType = TypeInfo.Construct(value.AsBoxedObject());
             }
 
             // convert to target type.
-            if (TargetType != null && TargetType.BuiltInType != sourceType.BuiltInType)
+            if (!TargetType.IsUnknown && TargetType.BuiltInType != sourceType.BuiltInType)
             {
-                m_value = new Variant(new Variant(value.AsBoxedObject(), sourceType).ConvertTo(TargetType.BuiltInType).Value, TargetType);
+                m_value = ClientUtils.ToVariant(ClientUtils.ToVariant(value.AsBoxedObject()).ConvertTo(TargetType.BuiltInType).AsBoxedObject());
                 sourceType = TargetType;
             }
             else
             {
-                m_value = new Variant(value.AsBoxedObject(), sourceType);
+                m_value = ClientUtils.ToVariant(value.AsBoxedObject());
             }
 
             m_textChanged = false;
@@ -139,7 +139,7 @@ namespace Opc.Ua.Client.Controls
             }
 
             // display as editable text.
-            ValueTB.Text = (string)new Variant(m_value.AsBoxedObject(), sourceType).ConvertTo(BuiltInType.String).Value;
+            ValueTB.Text = (string)ClientUtils.ToVariant(m_value.AsBoxedObject()).ConvertTo(BuiltInType.String).AsBoxedObject();
             ValueTB.Enabled = true;
         }
 

--- a/Samples/ClientControls.Net4/Common/EditValueCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/EditValueCtrl.cs
@@ -114,18 +114,18 @@ namespace Opc.Ua.Client.Controls
 
             if (sourceType == null)
             {
-                sourceType = TypeInfo.Construct(value.Value);
+                sourceType = TypeInfo.Construct(value.AsBoxedObject());
             }
 
             // convert to target type.
             if (TargetType != null && TargetType.BuiltInType != sourceType.BuiltInType)
             {
-                m_value = new Variant(new Variant(value.Value, sourceType).ConvertTo(TargetType.BuiltInType).Value, TargetType);
+                m_value = new Variant(new Variant(value.AsBoxedObject(), sourceType).ConvertTo(TargetType.BuiltInType).Value, TargetType);
                 sourceType = TargetType;
             }
             else
             {
-                m_value = new Variant(value.Value, sourceType);
+                m_value = new Variant(value.AsBoxedObject(), sourceType);
             }
 
             m_textChanged = false;
@@ -139,7 +139,7 @@ namespace Opc.Ua.Client.Controls
             }
 
             // display as editable text.
-            ValueTB.Text = (string)new Variant(m_value.Value, sourceType).ConvertTo(BuiltInType.String).Value;
+            ValueTB.Text = (string)new Variant(m_value.AsBoxedObject(), sourceType).ConvertTo(BuiltInType.String).Value;
             ValueTB.Enabled = true;
         }
 

--- a/Samples/ClientControls.Net4/Common/EventListView.cs
+++ b/Samples/ClientControls.Net4/Common/EventListView.cs
@@ -385,7 +385,7 @@ namespace Opc.Ua.Client.Controls
             {
                 NodeId conditionId = NodeId.Null;
 
-                if (fieldValues[0].Value is NodeId nodeId)
+                if (fieldValues[0].AsBoxedObject() is NodeId nodeId)
                 {
                     conditionId = nodeId;
                 }
@@ -396,7 +396,7 @@ namespace Opc.Ua.Client.Controls
                     {
                         List<Variant> fields = EventsLV.Items[ii].Tag as List<Variant>;
 
-                        if (fields != null && Utils.IsEqual(conditionId, fields[0].Value))
+                        if (fields != null && Utils.IsEqual(conditionId, fields[0].AsBoxedObject()))
                         {
                             item = EventsLV.Items[ii];
                             break;
@@ -426,7 +426,7 @@ namespace Opc.Ua.Client.Controls
                 Variant value = fieldValues[ii + 1];
 
                 // check for missing fields.
-                if (value.Value == null)
+                if (value.AsBoxedObject() == null)
                 {
                     text = String.Empty;
                 }
@@ -434,7 +434,7 @@ namespace Opc.Ua.Client.Controls
                 // display the name of a node instead of the node id.
                 else if (value.TypeInfo.BuiltInType == BuiltInType.NodeId)
                 {
-                    INode node = await m_session.NodeCache.FindAsync((NodeId)value.Value, ct);
+                    INode node = await m_session.NodeCache.FindAsync((NodeId)value.AsBoxedObject(), ct);
 
                     if (node != null)
                     {
@@ -445,7 +445,7 @@ namespace Opc.Ua.Client.Controls
                 // display local time for any time fields.
                 else if (value.TypeInfo.BuiltInType == BuiltInType.DateTime)
                 {
-                    DateTime datetime = (DateTime)value.Value;
+                    DateTime datetime = (DateTime)value.AsBoxedObject();
 
                     if (m_filter.Fields[ii].InstanceDeclaration.DisplayName.Contains("Time", StringComparison.Ordinal))
                     {
@@ -584,7 +584,7 @@ namespace Opc.Ua.Client.Controls
         /// </summary>
         private async Task ReadHistoryAsync(ReadEventDetails details, NodeId areaId, CancellationToken ct = default)
         {
-            HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+            List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
             HistoryReadValueId nodeToRead = new HistoryReadValueId();
             nodeToRead.NodeId = areaId;
             nodesToRead.Add(nodeToRead);
@@ -663,11 +663,11 @@ namespace Opc.Ua.Client.Controls
 
                 if (e.Count > index)
                 {
-                    if (e[index].Value is ByteString byteString)
+                    if (e[index].AsBoxedObject() is ByteString byteString)
                     {
                         eventId = byteString;
                     }
-                    else if (e[index].Value is byte[] bytes)
+                    else if (e[index].AsBoxedObject() is byte[] bytes)
                     {
                         eventId = bytes.ToByteString();
                     }

--- a/Samples/ClientControls.Net4/Common/FilterDeclaration.cs
+++ b/Samples/ClientControls.Net4/Common/FilterDeclaration.cs
@@ -1,4 +1,4 @@
-/* ========================================================================
+﻿/* ========================================================================
  * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -465,8 +465,8 @@ namespace Opc.Ua.Client.Controls
                     LiteralOperand operand2 = new LiteralOperand();
                     operand2.Value = field.FilterValue;
 
-                    ContentFilterElement element2 = whereClause.Push(field.FilterOperator, new Variant(operand1), new Variant(operand2));
-                    element1 = whereClause.Push(FilterOperator.And, new Variant(element1), new Variant(element2));
+                    ContentFilterElement element2 = whereClause.Push(field.FilterOperator, Variant.From(new ExtensionObject(operand1)), Variant.From(new ExtensionObject(operand2)));
+                    element1 = whereClause.Push(FilterOperator.And, Variant.From(new ExtensionObject(element1)), Variant.From(new ExtensionObject(element2)));
                 }
             }
 

--- a/Samples/ClientControls.Net4/Common/FilterDeclaration.cs
+++ b/Samples/ClientControls.Net4/Common/FilterDeclaration.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -284,7 +284,7 @@ namespace Opc.Ua.Client.Controls
                     continue;
                 }
 
-                if (NodeId.IsNull(instanceDeclaration.ModellingRule))
+                if ((instanceDeclaration.ModellingRule).IsNull)
                 {
                     continue;
                 }
@@ -421,7 +421,7 @@ namespace Opc.Ua.Client.Controls
         /// </summary>
         public List<SimpleAttributeOperand> GetSelectClause()
         {
-            SimpleAttributeOperandCollection selectClause = new SimpleAttributeOperandCollection();
+            List<SimpleAttributeOperand> selectClause = new List<SimpleAttributeOperand>();
 
             SimpleAttributeOperand operand = new SimpleAttributeOperand();
             operand.TypeDefinitionId = Opc.Ua.ObjectTypeIds.BaseEventType;
@@ -497,7 +497,7 @@ namespace Opc.Ua.Client.Controls
                         return defaultValue;
                     }
 
-                    object value = fields[ii + 1].Value;
+                    object value = fields[ii + 1].AsBoxedObject();
 
                     if (typeof(T).IsInstanceOfType(value))
                     {

--- a/Samples/ClientControls.Net4/Common/HistoryDataListView.cs
+++ b/Samples/ClientControls.Net4/Common/HistoryDataListView.cs
@@ -256,7 +256,7 @@ namespace Opc.Ua.Client.Controls
                 }
                 else
                 {
-                    if (NodeId.IsNull(m_nodeId))
+                    if ((m_nodeId).IsNull)
                     {
                         NodeIdTB.Text = String.Empty;
                     }
@@ -412,7 +412,7 @@ namespace Opc.Ua.Client.Controls
 
             set
             {
-                if (NodeId.IsNull(value))
+                if ((value).IsNull)
                 {
                     AggregateCB.SelectedIndex = -1;
                     return;
@@ -597,7 +597,7 @@ namespace Opc.Ua.Client.Controls
             m_dataset.Clear();
             NodeIdTB.Text = m_session.NodeCache.GetDisplayText(m_nodeId);
 
-            if (!NodeId.IsNull(nodeId))
+            if (!(nodeId).IsNull)
             {
                 m_properties = FindPropertiesWithHistory();
 
@@ -722,7 +722,7 @@ namespace Opc.Ua.Client.Controls
             NodeId rootId,
             NodeState parent,
             RelativePath parentPath,
-            BrowsePathCollection browsePaths)
+            List<BrowsePath> browsePaths)
         {
             List<BaseInstanceState> children = new List<BaseInstanceState>();
             parent.GetChildren(context, children);
@@ -770,9 +770,9 @@ namespace Opc.Ua.Client.Controls
             nodeToBrowse.NodeClassMask = 0;
             nodeToBrowse.ResultMask = (uint)(BrowseResultMask.DisplayName | BrowseResultMask.BrowseName);
 
-            ReferenceDescriptionCollection references = ClientUtils.Browse(m_session, nodeToBrowse, false);
+            List<ReferenceDescription> references = ClientUtils.Browse(m_session, nodeToBrowse, false);
 
-            ReadValueIdCollection nodesToRead = new ReadValueIdCollection();
+            List<ReadValueId> nodesToRead = new List<ReadValueId>();
 
             for (int ii = 0; ii < references.Count; ii++)
             {
@@ -793,7 +793,7 @@ namespace Opc.Ua.Client.Controls
 
             if (nodesToRead.Count > 0)
             {
-                DataValueCollection values = null;
+                List<DataValue> values = null;
                 DiagnosticInfoCollection diagnosticInfos = null;
 
                 m_session.Read(
@@ -854,7 +854,7 @@ namespace Opc.Ua.Client.Controls
             RelativePath relativePath = new RelativePath();
             relativePath.Elements.Add(element);
 
-            BrowsePathCollection pathsToTranslate = new BrowsePathCollection();
+            List<BrowsePath> pathsToTranslate = new List<BrowsePath>();
 
             GetBrowsePathFromNodeState(
                 m_session.SystemContext,
@@ -877,7 +877,7 @@ namespace Opc.Ua.Client.Controls
             ClientBase.ValidateDiagnosticInfos(diagnosticInfos, pathsToTranslate);
 
             // build list of values to read.
-            ReadValueIdCollection valuesToRead = new ReadValueIdCollection();
+            List<ReadValueId> valuesToRead = new List<ReadValueId>();
 
             for (int ii = 0; ii < pathsToTranslate.Count; ii++)
             {
@@ -905,7 +905,7 @@ namespace Opc.Ua.Client.Controls
             // read the values.
             if (valuesToRead.Count > 0)
             {
-                DataValueCollection values = null;
+                List<DataValue> values = null;
 
                 m_session.Read(
                     null,
@@ -959,10 +959,10 @@ namespace Opc.Ua.Client.Controls
             HistoryReadValueId nodeToRead = new HistoryReadValueId();
             nodeToRead.NodeId = m_nodeId;
 
-            HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+            List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
             nodesToRead.Add(nodeToRead);
 
-            HistoryReadResultCollection results = null;
+            List<HistoryReadResult> results = null;
             DiagnosticInfoCollection diagnosticInfos = null;
 
             m_session.HistoryRead(
@@ -1029,10 +1029,10 @@ namespace Opc.Ua.Client.Controls
             HistoryReadValueId nodeToRead = new HistoryReadValueId();
             nodeToRead.NodeId = m_nodeId;
 
-            HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+            List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
             nodesToRead.Add(nodeToRead);
 
-            HistoryReadResultCollection results = null;
+            List<HistoryReadResult> results = null;
             DiagnosticInfoCollection diagnosticInfos = null;
 
             m_session.HistoryRead(
@@ -1273,10 +1273,10 @@ namespace Opc.Ua.Client.Controls
                 return;
             }
 
-            HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+            List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
             nodesToRead.Add(m_nodeToContinue);
 
-            HistoryReadResultCollection results = null;
+            List<HistoryReadResult> results = null;
             DiagnosticInfoCollection diagnosticInfos = null;
 
             m_session.HistoryRead(
@@ -1330,12 +1330,12 @@ namespace Opc.Ua.Client.Controls
             details.IsReadModified = isReadModified;
             details.ReturnBounds = (isReadModified)?false:ReturnBoundsCK.Checked;
 
-            HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+            List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
             HistoryReadValueId nodeToRead = new HistoryReadValueId();
             nodeToRead.NodeId = GetSelectedNode();
             nodesToRead.Add(nodeToRead);
 
-            HistoryReadResultCollection results = null;
+            List<HistoryReadResult> results = null;
             DiagnosticInfoCollection diagnosticInfos = null;
 
             m_session.HistoryRead(
@@ -1380,12 +1380,12 @@ namespace Opc.Ua.Client.Controls
                 details.ReqTimes.Add(startTime.AddMilliseconds((double)(ii*TimeStepNP.Value)));
             }
 
-            HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+            List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
             HistoryReadValueId nodeToRead = new HistoryReadValueId();
             nodeToRead.NodeId = GetSelectedNode();
             nodesToRead.Add(nodeToRead);
 
-            HistoryReadResultCollection results = null;
+            List<HistoryReadResult> results = null;
             DiagnosticInfoCollection diagnosticInfos = null;
 
             m_session.HistoryRead(
@@ -1433,12 +1433,12 @@ namespace Opc.Ua.Client.Controls
             details.AggregateType.Add(aggregate.NodeId);
             details.AggregateConfiguration.UseServerCapabilitiesDefaults = true;
 
-            HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+            List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
             HistoryReadValueId nodeToRead = new HistoryReadValueId();
             nodeToRead.NodeId = m_nodeId;
             nodesToRead.Add(nodeToRead);
 
-            HistoryReadResultCollection results = null;
+            List<HistoryReadResult> results = null;
             DiagnosticInfoCollection diagnosticInfos = null;
 
             m_session.HistoryRead(
@@ -1473,10 +1473,10 @@ namespace Opc.Ua.Client.Controls
             // clear existing continuation point.
             if (m_nodeToContinue != null)
             {
-                HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+                List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
                 nodesToRead.Add(m_nodeToContinue);
                                 
-                HistoryReadResultCollection results = null;
+                List<HistoryReadResult> results = null;
                 DiagnosticInfoCollection diagnosticInfos = null;
 
                 m_session.HistoryRead(
@@ -1525,7 +1525,7 @@ namespace Opc.Ua.Client.Controls
         /// </summary>
         private void InsertReplace(PerformUpdateType updateType)
         {
-            DataValueCollection values = new DataValueCollection();
+            List<DataValue> values = new List<DataValue>();
 
             foreach (DataRowView row in m_dataset.Tables[0].DefaultView)
             {
@@ -1542,7 +1542,7 @@ namespace Opc.Ua.Client.Controls
                 isStructured = true;
             }
 
-            HistoryUpdateResultCollection results = InsertReplace(GetSelectedNode(), updateType, isStructured, values);
+            List<HistoryUpdateResult> results = InsertReplace(GetSelectedNode(), updateType, isStructured, values);
 
             ResultsDV.Columns[ResultsDV.Columns.Count - 1].Visible = true;
 
@@ -1557,7 +1557,7 @@ namespace Opc.Ua.Client.Controls
         /// <summary>
         /// Updates the history.
         /// </summary>
-        private HistoryUpdateResultCollection InsertReplace(NodeId nodeId, PerformUpdateType updateType, bool isStructure, IList<DataValue> values)
+        private List<HistoryUpdateResult> InsertReplace(NodeId nodeId, PerformUpdateType updateType, bool isStructure, IList<DataValue> values)
         {
             HistoryUpdateDetails details = null;
 
@@ -1578,10 +1578,10 @@ namespace Opc.Ua.Client.Controls
                 details = details2;
             }
 
-            ExtensionObjectCollection nodesToUpdate = new ExtensionObjectCollection();
+            List<ExtensionObject> nodesToUpdate = new List<ExtensionObject>();
             nodesToUpdate.Add(new ExtensionObject(details));
 
-            HistoryUpdateResultCollection results = null;
+            List<HistoryUpdateResult> results = null;
             DiagnosticInfoCollection diagnosticInfos = null;
 
             m_session.HistoryUpdate(
@@ -1612,10 +1612,10 @@ namespace Opc.Ua.Client.Controls
             details.StartTime = StartTimeDP.Value;
             details.EndTime = EndTimeDP.Value;
 
-            ExtensionObjectCollection nodesToUpdate = new ExtensionObjectCollection();
+            List<ExtensionObject> nodesToUpdate = new List<ExtensionObject>();
             nodesToUpdate.Add(new ExtensionObject(details));
 
-            HistoryUpdateResultCollection results = null;
+            List<HistoryUpdateResult> results = null;
             DiagnosticInfoCollection diagnosticInfos = null;
 
             m_session.HistoryUpdate(
@@ -1650,10 +1650,10 @@ namespace Opc.Ua.Client.Controls
                 details.ReqTimes.Add(value);
             }
 
-            ExtensionObjectCollection nodesToUpdate = new ExtensionObjectCollection();
+            List<ExtensionObject> nodesToUpdate = new List<ExtensionObject>();
             nodesToUpdate.Add(new ExtensionObject(details));
 
-            HistoryUpdateResultCollection results = null;
+            List<HistoryUpdateResult> results = null;
             DiagnosticInfoCollection diagnosticInfos = null;
 
             m_session.HistoryUpdate(
@@ -2349,7 +2349,7 @@ namespace Opc.Ua.Client.Controls
 
                     }
 
-                    HistoryUpdateResultCollection results = InsertReplace(propertyId, PerformUpdateType.Insert, true, valuesToUpdate); 
+                    List<HistoryUpdateResult> results = InsertReplace(propertyId, PerformUpdateType.Insert, true, valuesToUpdate); 
 
                     ResultsDV.Columns[ResultsDV.Columns.Count - 1].Visible = true;
 

--- a/Samples/ClientControls.Net4/Common/ReferenceListCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/ReferenceListCtrl.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -152,9 +152,9 @@ namespace Opc.Ua.Client.Controls
         /// <summary>
         /// Gets the list of references to follow.
         /// </summary>
-        private BrowseDescriptionCollection CreateNodesToBrowse()
+        private List<BrowseDescription> CreateNodesToBrowse()
         {
-            BrowseDescriptionCollection nodesToBrowse = new BrowseDescriptionCollection();
+            List<BrowseDescription> nodesToBrowse = new List<BrowseDescription>();
 
             if (ReferenceTypeIds != null && ReferenceTypeIds.Length > 0)
             {

--- a/Samples/ClientControls.Net4/Common/SelectNodeDlg.cs
+++ b/Samples/ClientControls.Net4/Common/SelectNodeDlg.cs
@@ -71,7 +71,7 @@ namespace Opc.Ua.Client.Controls
             }
 
             // set default root.
-            if (NodeId.IsNull(rootId))
+            if ((rootId).IsNull)
             {
                 rootId = Opc.Ua.ObjectIds.ObjectsFolder;
             }
@@ -119,7 +119,7 @@ namespace Opc.Ua.Client.Controls
             }
             
             // set default root.
-            if (NodeId.IsNull(rootId))
+            if ((rootId).IsNull)
             {
                 rootId = Opc.Ua.ObjectIds.ObjectsFolder;
             }

--- a/Samples/ClientControls.Net4/Configuration/CertificateDlg.cs
+++ b/Samples/ClientControls.Net4/Configuration/CertificateDlg.cs
@@ -98,13 +98,19 @@ namespace Opc.Ua.Client.Controls
 
         private async Task<X509Certificate2> FindCertificateAsync(CertificateIdentifier certificateIdentifier, bool needPrivateKey, CancellationToken ct)
         {
-            if (certificateIdentifier?.Certificate != null && (!needPrivateKey || certificateIdentifier.Certificate.HasPrivateKey))
+            if (certificateIdentifier == null)
             {
-                return certificateIdentifier.Certificate;
+                return null;
             }
 
-            if (certificateIdentifier == null ||
-                String.IsNullOrEmpty(certificateIdentifier.StoreType) ||
+            var resolvedCertificate = await CertificateIdentifierResolver.ResolveAsync(certificateIdentifier, null, needPrivateKey, null, m_telemetry, ct);
+
+            if (resolvedCertificate != null)
+            {
+                return resolvedCertificate.AsX509Certificate2();
+            }
+
+            if (String.IsNullOrEmpty(certificateIdentifier.StoreType) ||
                 String.IsNullOrEmpty(certificateIdentifier.StorePath) ||
                 (String.IsNullOrEmpty(certificateIdentifier.Thumbprint) && String.IsNullOrEmpty(certificateIdentifier.SubjectName)))
             {

--- a/Samples/ClientControls.Net4/Configuration/CertificateListCtrl.cs
+++ b/Samples/ClientControls.Net4/Configuration/CertificateListCtrl.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -72,7 +72,7 @@ namespace Opc.Ua.Client.Controls
         };
 
         private CertificateStoreIdentifier m_storeId;
-        private CertificateIdentifierCollection m_certificates;
+        private List<CertificateIdentifier> m_certificates;
         private IList<string> m_thumbprints;
         private List<ListViewItem> m_items;
         #endregion
@@ -170,7 +170,7 @@ namespace Opc.Ua.Client.Controls
         /// <summary>
         /// Displays the applications in the control.
         /// </summary>
-        internal void Initialize(CertificateIdentifierCollection certificates)
+        internal void Initialize(List<CertificateIdentifier> certificates)
         {
             ItemsLV.Items.Clear();
 

--- a/Samples/ClientControls.Net4/Configuration/CertificateListCtrl.cs
+++ b/Samples/ClientControls.Net4/Configuration/CertificateListCtrl.cs
@@ -543,7 +543,7 @@ namespace Opc.Ua.Client.Controls
             }
         }
 
-        private void PasteMI_Click(object sender, EventArgs e)
+        private async void PasteMI_Click(object sender, EventArgs e)
         {
             try
             {
@@ -563,14 +563,16 @@ namespace Opc.Ua.Client.Controls
                     id = (CertificateIdentifier)serializer.ReadObject(reader, false);
                 }
 
-                if (id.Certificate != null)
+                var certificate = await CertificateIdentifierResolver.ResolveAsync(id, null, false, null, Telemetry, default);
+
+                if (certificate != null)
                 {
                     using (ICertificateStore store = m_storeId.OpenStore(Telemetry))
                     {
-                        store.AddAsync(Certificate.From(id.Certificate));
+                        await store.AddAsync(certificate);
                     }
 
-                    AddItem(id.Certificate);
+                    AddItem(certificate.AsX509Certificate2());
                 }
             }
             catch (Exception exception)

--- a/Samples/ClientControls.Net4/Configuration/CertificateStoreTreeCtrl.cs
+++ b/Samples/ClientControls.Net4/Configuration/CertificateStoreTreeCtrl.cs
@@ -455,7 +455,7 @@ namespace Opc.Ua.Client.Controls
             }
         }
 
-        private void PasteMI_Click(object sender, EventArgs e)
+        private async void PasteMI_Click(object sender, EventArgs e)
         {
             try
             {
@@ -480,13 +480,15 @@ namespace Opc.Ua.Client.Controls
                         id = (CertificateIdentifier)serializer.ReadObject(reader, false);
                     }
 
-                    if (id.Certificate != null)
+                    var certificate = await CertificateIdentifierResolver.ResolveAsync(id, null, false, null, Telemetry, default);
+
+                    if (certificate != null)
                     {
                         CertificateStoreIdentifier storeId = info.GetCertificateStore();
 
                         using (ICertificateStore store = storeId.OpenStore(Telemetry))
                         {
-                            store.AddAsync(Certificate.From(id.Certificate));
+                            await store.AddAsync(certificate);
                         }
                     }
 

--- a/Samples/ClientControls.Net4/Configuration/Common (OLD)/DataListCtrl.cs
+++ b/Samples/ClientControls.Net4/Configuration/Common (OLD)/DataListCtrl.cs
@@ -345,7 +345,7 @@ namespace Opc.Ua.Client.Controls
             // check for Variant.
             if (value is Variant)
             {
-                return IsExpandableType(((Variant)value).Value);
+                return IsExpandableType(((Variant)value).AsBoxedObject());
             }
 
             // check for bytes.
@@ -584,7 +584,7 @@ namespace Opc.Ua.Client.Controls
                     formattedValue.Append("] ");
                 }
 
-                formattedValue.AppendFormat("{0}", dataValue.Value);
+                formattedValue.AppendFormat("{0}", dataValue.WrappedValue.AsBoxedObject());
                 return formattedValue.ToString();
             }
 
@@ -731,7 +731,7 @@ namespace Opc.Ua.Client.Controls
 
             if (propertyValue is Variant)
             {
-                propertyValue = ((Variant)propertyValue).Value;
+                propertyValue = ((Variant)propertyValue).AsBoxedObject();
             }
 
             // update the list view.
@@ -898,7 +898,7 @@ namespace Opc.Ua.Client.Controls
         private Task<(int, bool)> ShowValueAsync(int index, bool overwrite, EventFieldList value, int fieldIndex, CancellationToken ct = default)
         {
             // ignore children that are not elements.
-            object field = value.EventFields[fieldIndex].Value;
+            object field = value.EventFields[fieldIndex].AsBoxedObject();
 
             if (field == null)
             {
@@ -959,7 +959,7 @@ namespace Opc.Ua.Client.Controls
                 case 0:
                 {
                     name = "Value";
-                    componentValue = value.Value;
+                    componentValue = value.WrappedValue.AsBoxedObject();
 
                     if (componentValue is ExtensionObject extension)
                     {
@@ -1271,7 +1271,7 @@ namespace Opc.Ua.Client.Controls
             if (writevalue != null)
             {
                 // check if the value is an array
-                Array arrayvalue = writevalue.Value.Value as Array;
+                Array arrayvalue = writevalue.Value.WrappedValue.AsBoxedObject() as Array;
 
                 if (arrayvalue != null)
                 {
@@ -1442,7 +1442,7 @@ namespace Opc.Ua.Client.Controls
 
             if (variant != null)
             {
-                return await ShowValueAsync(index, overwrite, variant.Value.Value, ct);
+                return await ShowValueAsync(index, overwrite, variant.Value.AsBoxedObject(), ct);
             }
 
             // show unknown types as strings.

--- a/Samples/ClientControls.Net4/Configuration/Common (OLD)/DataListCtrl.cs
+++ b/Samples/ClientControls.Net4/Configuration/Common (OLD)/DataListCtrl.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -334,6 +334,73 @@ namespace Opc.Ua.Client.Controls
         /// <summary>
         /// Returns true if the type can be expanded.
         /// </summary>
+        private static object GetExtensionObjectBody(ExtensionObject extension)
+        {
+            if (extension.TryGetAsBinary(out ByteString bytes, ServiceMessageContext.CreateEmpty(null)))
+            {
+                return bytes.ToArray();
+            }
+
+            if (extension.TryGetAsXml(out XmlElement xml, ServiceMessageContext.CreateEmpty(null)))
+            {
+                return xml;
+            }
+
+            if (extension.TryGetValue(out IEncodeable encodeable, ServiceMessageContext.CreateEmpty(null)))
+            {
+                return encodeable;
+            }
+
+            return null;
+        }
+
+        private static object GetIdentifier(NodeId value)
+        {
+            switch (value.IdType)
+            {
+                case IdType.Numeric:
+                    return value.TryGetValue(out uint numeric) ? (object)numeric : value.IdentifierAsString;
+                case IdType.String:
+                    return value.TryGetValue(out string text) ? text : value.IdentifierAsString;
+                case IdType.Guid:
+                    return value.TryGetValue(out Guid uuid) ? (object)uuid : value.IdentifierAsString;
+                case IdType.Opaque:
+                    return value.TryGetValue(out ByteString bytes) ? (object)bytes.ToArray() : value.IdentifierAsString;
+                default:
+                    return value.IdentifierAsString;
+            }
+        }
+
+        private static object GetIdentifier(ExpandedNodeId value)
+        {
+            switch (value.IdType)
+            {
+                case IdType.Numeric:
+                    return value.TryGetValue(out uint numeric) ? (object)numeric : value.IdentifierAsString;
+                case IdType.String:
+                    return value.TryGetValue(out string text) ? text : value.IdentifierAsString;
+                case IdType.Guid:
+                    return value.TryGetValue(out Guid uuid) ? (object)uuid : value.IdentifierAsString;
+                case IdType.Opaque:
+                    return value.TryGetValue(out ByteString bytes) ? (object)bytes.ToArray() : value.IdentifierAsString;
+                default:
+                    return value.IdentifierAsString;
+            }
+        }
+
+        private static string GetDataMemberName(PropertyInfo property)
+        {
+            foreach (Attribute attribute in property.GetCustomAttributes(true))
+            {
+                if (attribute is DataMemberAttribute dataMember && !String.IsNullOrEmpty(dataMember.Name))
+                {
+                    return dataMember.Name;
+                }
+            }
+
+            return property.Name;
+        }
+
         private bool IsExpandableType(object value)
         {
             // check for null.
@@ -406,7 +473,7 @@ namespace Opc.Ua.Client.Controls
             // check for extension object.
             if (value is ExtensionObject extension)
             {
-                return IsExpandableType(extension.Body);
+                return IsExpandableType(GetExtensionObjectBody(extension));
             }
 
             // check for data value.
@@ -534,7 +601,7 @@ namespace Opc.Ua.Client.Controls
             // format extension object.
             if (value is ExtensionObject extension)
             {
-                return await GetValueTextAsync(extension.Body, ct);
+                return await GetValueTextAsync(GetExtensionObjectBody(extension), ct);
             }
 
             // check for event value.
@@ -708,7 +775,7 @@ namespace Opc.Ua.Client.Controls
         private Task<(int, bool)> ShowValueAsync(int index, bool overwrite, IEncodeable value, PropertyInfo property, CancellationToken ct = default)
         {
             // get the name of the property.
-            string name = Utils.GetDataMemberName(property);
+            string name = GetDataMemberName(property);
 
             if (name == null)
             {
@@ -963,7 +1030,7 @@ namespace Opc.Ua.Client.Controls
 
                     if (componentValue is ExtensionObject extension)
                     {
-                        componentValue = extension.Body;
+                        componentValue = GetExtensionObjectBody(extension);
                     }
 
                     break;
@@ -1037,7 +1104,7 @@ namespace Opc.Ua.Client.Controls
                 case 1:
                 {
                     name = "Identifier";
-                    componentValue = value.Identifier;
+                    componentValue = GetIdentifier(value);
                     break;
                 }
 
@@ -1087,7 +1154,7 @@ namespace Opc.Ua.Client.Controls
                 case 1:
                 {
                     name = "Identifier";
-                    componentValue = value.Identifier;
+                    componentValue = GetIdentifier(value);
                     break;
                 }
 
@@ -1309,7 +1376,7 @@ namespace Opc.Ua.Client.Controls
             // show extension bodies.
             if (value is ExtensionObject extension)
             {
-                return await ShowValueAsync(index, overwrite, extension.Body, ct);
+                return await ShowValueAsync(index, overwrite, GetExtensionObjectBody(extension), ct);
             }
 
             // show encodeables.
@@ -1602,7 +1669,7 @@ namespace Opc.Ua.Client.Controls
 
                     switch (component)
                     {
-                        case 0: { state.Value = datavalue.WithWrappedValue(new Variant(value)); state.Component = value; break; }
+                        case 0: { state.Value = datavalue.WithWrappedValue(ClientUtils.ToVariant(value)); state.Component = value; break; }
                     }
                 }
 

--- a/Samples/ClientControls.Net4/Configuration/Common (OLD)/GuiUtils.cs
+++ b/Samples/ClientControls.Net4/Configuration/Common (OLD)/GuiUtils.cs
@@ -428,7 +428,7 @@ namespace Opc.Ua.Client.Controls
         {
             TypeInfo typeInfo = TypeInfo.Construct(value);
 
-            if (typeInfo != null)
+            if (!typeInfo.IsUnknown)
             {
                 return EditValue(session, value, new NodeId((uint)typeInfo.BuiltInType), typeInfo.ValueRank, telemetry);
             }

--- a/Samples/ClientControls.Net4/Configuration/Common (OLD)/NodeIdCtrl.cs
+++ b/Samples/ClientControls.Net4/Configuration/Common (OLD)/NodeIdCtrl.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -115,7 +115,7 @@ namespace Opc.Ua.Client.Controls
             {
                 m_rootId = value;
 
-                if (NodeId.IsNull(m_rootId))
+                if ((m_rootId).IsNull)
                 {
                     m_rootId = (NodeId)Objects.RootFolder;
                 }

--- a/Samples/ClientControls.Net4/Configuration/Common (OLD)/ReferenceTypeCtrl.cs
+++ b/Samples/ClientControls.Net4/Configuration/Common (OLD)/ReferenceTypeCtrl.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -74,7 +74,7 @@ namespace Opc.Ua.Client.Controls
             m_baseTypeId = baseTypeId;
             m_logger = session?.MessageContext?.Telemetry.CreateLogger<ReferenceTypeCtrl>();
 
-            if (NodeId.IsNull(m_baseTypeId))
+            if ((m_baseTypeId).IsNull)
             {
                 m_baseTypeId = ReferenceTypeIds.References;
             }

--- a/Samples/ClientControls.Net4/Configuration/ViewCertificateDlg.cs
+++ b/Samples/ClientControls.Net4/Configuration/ViewCertificateDlg.cs
@@ -185,12 +185,19 @@ namespace Opc.Ua.Client.Controls
         #region Private Methods
         private async Task<X509Certificate2> FindCertificateAsync(CertificateIdentifier certificate, CancellationToken ct = default)
         {
-            if (certificate?.Certificate != null)
+            if (certificate == null)
             {
-                return certificate.Certificate;
+                return null;
             }
 
-            if (certificate == null || String.IsNullOrEmpty(certificate.StoreType) || String.IsNullOrEmpty(certificate.StorePath) || String.IsNullOrEmpty(certificate.Thumbprint))
+            var resolvedCertificate = await CertificateIdentifierResolver.ResolveAsync(certificate, null, false, null, m_telemetry, ct);
+
+            if (resolvedCertificate != null)
+            {
+                return resolvedCertificate.AsX509Certificate2();
+            }
+
+            if (String.IsNullOrEmpty(certificate.StoreType) || String.IsNullOrEmpty(certificate.StorePath) || String.IsNullOrEmpty(certificate.Thumbprint))
             {
                 return null;
             }

--- a/Samples/ClientControls.Net4/Endpoints/ConfiguredServerDlg.cs
+++ b/Samples/ClientControls.Net4/Endpoints/ConfiguredServerDlg.cs
@@ -1,4 +1,4 @@
-/* ========================================================================
+﻿/* ========================================================================
  * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -1695,7 +1695,7 @@ namespace Opc.Ua.Client.Controls
 
                     if (m_currentDescription.Server != null)
                     {
-                        if (m_currentDescription.Server.ApplicationName != null)
+                        if (!m_currentDescription.Server.ApplicationName.IsNull)
                         {
                             ApplicationNameTB.Text = m_currentDescription.Server.ApplicationName.ToString();
                         }

--- a/Samples/ClientControls.Net4/Endpoints/ConfiguredServerDlg.cs
+++ b/Samples/ClientControls.Net4/Endpoints/ConfiguredServerDlg.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -315,7 +315,7 @@ namespace Opc.Ua.Client.Controls
 
         private ConfiguredEndpoint m_endpoint;
         private EndpointDescription m_currentDescription;
-        private EndpointDescriptionCollection m_availableEndpoints;
+        private List<EndpointDescription> m_availableEndpoints;
         private List<EndpointDescriptionString> m_availableEndpointsDescriptions;
         private int m_discoveryTimeout;
         private int m_discoverCount;
@@ -359,7 +359,7 @@ namespace Opc.Ua.Client.Controls
             m_configuration = configuration;
 
             // construct a list of available endpoint descriptions for the application.
-            m_availableEndpoints = new EndpointDescriptionCollection();
+            m_availableEndpoints = new List<EndpointDescription>();
             m_availableEndpointsDescriptions = new List<EndpointDescriptionString>();
             m_endpointConfiguration = EndpointConfiguration.Create(configuration);
 
@@ -395,7 +395,7 @@ namespace Opc.Ua.Client.Controls
             m_configuration = configuration;
 
             // construct a list of available endpoint descriptions for the application.
-            m_availableEndpoints = new EndpointDescriptionCollection();
+            m_availableEndpoints = new List<EndpointDescription>();
             m_availableEndpointsDescriptions = new List<EndpointDescriptionString>();
 
             m_availableEndpoints.Add(endpoint.Description);
@@ -474,7 +474,7 @@ namespace Opc.Ua.Client.Controls
         /// <summary>
         /// Creates the string representation of each EndpointDescription - to be used in the Endpoint Description List
         /// </summary>
-        private void BuildEndpointDescriptionStrings(EndpointDescriptionCollection endpoints)
+        private void BuildEndpointDescriptionStrings(List<EndpointDescription> endpoints)
         {
             lock (m_availableEndpointsDescriptions)
             {
@@ -545,7 +545,7 @@ namespace Opc.Ua.Client.Controls
         /// <summary>
         /// Finds the best match for the current protocol and security selections.
         /// </summary>
-        private EndpointDescription FindBestEndpointDescription(EndpointDescriptionCollection endpoints)
+        private EndpointDescription FindBestEndpointDescription(List<EndpointDescription> endpoints)
         {
             // filter by the current protocol.
             Protocol currentProtocol = (Protocol)ProtocolCB.SelectedItem;
@@ -562,7 +562,7 @@ namespace Opc.Ua.Client.Controls
             string currentPolicy = (string)SecurityPolicyCB.SelectedItem;
 
             // find all matching descriptions.
-            EndpointDescriptionCollection matches = new EndpointDescriptionCollection();
+            List<EndpointDescription> matches = new List<EndpointDescription>();
 
             if (endpoints != null)
             {
@@ -711,7 +711,7 @@ namespace Opc.Ua.Client.Controls
         /// <summary>
         /// Initializes the protocol dropdown.
         /// </summary>
-        private void InitializeProtocols(EndpointDescriptionCollection endpoints)
+        private void InitializeProtocols(List<EndpointDescription> endpoints)
         {
             // preserve the existing value.
             Protocol currentProtocol = (Protocol)ProtocolCB.SelectedItem;
@@ -786,7 +786,7 @@ namespace Opc.Ua.Client.Controls
         /// <summary>
         /// Initializes the security modes dropdown.
         /// </summary>
-        private void InitializeSecurityModes(EndpointDescriptionCollection endpoints)
+        private void InitializeSecurityModes(List<EndpointDescription> endpoints)
         {
             // filter by the current protocol.
             Protocol currentProtocol = (Protocol)ProtocolCB.SelectedItem;
@@ -854,7 +854,7 @@ namespace Opc.Ua.Client.Controls
         /// <summary>
         /// Initializes the security policies dropdown.
         /// </summary>
-        private void InitializeSecurityPolicies(EndpointDescriptionCollection endpoints)
+        private void InitializeSecurityPolicies(List<EndpointDescription> endpoints)
         {
             // filter by the current protocol.
             Protocol currentProtocol = (Protocol)ProtocolCB.SelectedItem;
@@ -940,7 +940,7 @@ namespace Opc.Ua.Client.Controls
         /// <summary>
         /// Initializes the message encodings dropdown.
         /// </summary>
-        private void InitializeEncodings(EndpointDescriptionCollection endpoints, EndpointDescription endpoint)
+        private void InitializeEncodings(List<EndpointDescription> endpoints, EndpointDescription endpoint)
         {
             // preserve the existing value.
             Encoding currentEncoding = Encoding.Default;
@@ -1147,7 +1147,7 @@ namespace Opc.Ua.Client.Controls
 
             try
             {
-                EndpointDescriptionCollection endpoints = new EndpointDescriptionCollection((await client.GetEndpointsAsync(default, ct)).ToArray());
+                List<EndpointDescription> endpoints = new List<EndpointDescription>((await client.GetEndpointsAsync(default, ct)).ToArray());
                 OnUpdateEndpoints(endpoints);
                 return (true, String.Empty);
             }
@@ -1194,7 +1194,7 @@ namespace Opc.Ua.Client.Controls
             try
             {
                 // get the updated descriptions.
-                EndpointDescriptionCollection endpoints = state as EndpointDescriptionCollection;
+                List<EndpointDescription> endpoints = state as List<EndpointDescription>;
 
                 if (endpoints == null)
                 {

--- a/Samples/ClientControls.Net4/Endpoints/DiscoveredServerListCtrl.cs
+++ b/Samples/ClientControls.Net4/Endpoints/DiscoveredServerListCtrl.cs
@@ -167,7 +167,7 @@ namespace Opc.Ua.Client.Controls
             
             ItemsLV.Items.Clear();
 
-            ApplicationDescriptionCollection servers = state as ApplicationDescriptionCollection;
+            List<ApplicationDescription> servers = state as List<ApplicationDescription>;
 
             if (servers != null)
             {
@@ -254,7 +254,7 @@ namespace Opc.Ua.Client.Controls
                     BindingFactory.Create(m_configuration, m_configuration.CreateMessageContext()),
                     EndpointConfiguration.Create(m_configuration));
 
-                ApplicationDescriptionCollection servers = client.FindServers(null);
+                List<ApplicationDescription> servers = client.FindServers(null);
                 m_discoveryUrl = discoveryUrl.ToString();
                 OnUpdateServers(servers);
                 return true;

--- a/Samples/ClientControls.Net4/ExceptionDlg.cs
+++ b/Samples/ClientControls.Net4/ExceptionDlg.cs
@@ -125,7 +125,7 @@ namespace Opc.Ua.Client.Controls
                 {
                     AddBlock(buffer, "SERVICE RESULT (" + new StatusCode(sr.Code).ToString() + ")", 2);
 
-                    string text = (sr.LocalizedText != null) ? sr.LocalizedText.Text : null;
+                    string text = (!sr.LocalizedText.IsNull) ? sr.LocalizedText.Text : null;
 
                     if (text != e.Message)
                     {

--- a/Samples/Controls.Net4/Common/ArgumentListCtrl.cs
+++ b/Samples/Controls.Net4/Common/ArgumentListCtrl.cs
@@ -125,7 +125,7 @@ namespace Opc.Ua.Sample.Controls
             {
                 for (int ii = 0; ii < argumentsList.Length; ii++)
                 {
-                    AddItem(argumentsList[ii].Body as Argument);
+                    AddItem(argumentsList[ii].TryGetValue<Argument>(out var argument, m_session.MessageContext) ? argument : null);
                 }
             }
 
@@ -147,7 +147,7 @@ namespace Opc.Ua.Sample.Controls
 
                 if (argument != null)
                 {
-                    values.Add(new Variant(argument.Value));
+                    values.Add(Variant.From((dynamic)argument.Value));
                 }
             }
 
@@ -234,7 +234,7 @@ namespace Opc.Ua.Sample.Controls
                         {
                             if (argument.ValueRank == ValueRanks.Scalar)
                             {
-                                argument.Value = new ExtensionObject(ExpandedNodeId.Null, Activator.CreateInstance(type));
+                                argument.Value = new ExtensionObject((IEncodeable)Activator.CreateInstance(type), false);
                             }
                             else
                             {

--- a/Samples/Controls.Net4/Common/ArgumentListCtrl.cs
+++ b/Samples/Controls.Net4/Common/ArgumentListCtrl.cs
@@ -119,7 +119,7 @@ namespace Opc.Ua.Sample.Controls
             // read the value from the server.
             DataValue value = await m_session.ReadValueAsync(argumentsNode.NodeId, ct);
 
-            ExtensionObject[] argumentsList = value.Value as ExtensionObject[];
+            ExtensionObject[] argumentsList = value.WrappedValue.AsBoxedObject() as ExtensionObject[];
 
             if (argumentsList != null)
             {
@@ -167,7 +167,7 @@ namespace Opc.Ua.Sample.Controls
 
                 if (argument != null)
                 {
-                    argument.Value = values[ii++].Value;
+                    argument.Value = values[ii++].AsBoxedObject();
                     await UpdateItemAsync(item, argument, ct);
                 }
             }

--- a/Samples/Controls.Net4/Common/AttributeListCtrl.cs
+++ b/Samples/Controls.Net4/Common/AttributeListCtrl.cs
@@ -141,7 +141,7 @@ namespace Opc.Ua.Sample.Controls
         private async Task AddAttributesAsync(CancellationToken ct = default)
         {
             // build list of attributes to read.
-            ReadValueIdCollection nodesToRead = new ReadValueIdCollection();
+            List<ReadValueId> nodesToRead = new List<ReadValueId>();
 
             foreach (uint attributeId in Attributes.Identifiers)
             {
@@ -182,7 +182,7 @@ namespace Opc.Ua.Sample.Controls
 
                 field.ValueId = nodesToRead[ii];
                 field.Name = Attributes.GetBrowseName(nodesToRead[ii].AttributeId);
-                field.Value = values[ii].Value;
+                field.Value = values[ii].WrappedValue.AsBoxedObject();
                 field.StatusCode = values[ii].StatusCode;
 
                 if (diagnosticInfos != null && diagnosticInfos.Count > ii)
@@ -200,7 +200,7 @@ namespace Opc.Ua.Sample.Controls
         private async Task AddPropertiesAsync(CancellationToken ct = default)
         {
             // build list of properties to read.
-            ReadValueIdCollection nodesToRead = new ReadValueIdCollection();
+            List<ReadValueId> nodesToRead = new List<ReadValueId>();
 
             Browser browser = new Browser(m_session);
 
@@ -251,7 +251,7 @@ namespace Opc.Ua.Sample.Controls
 
                 field.ValueId = nodesToRead[ii];
                 field.Name = references[ii].ToString();
-                field.Value = values[ii].Value;
+                field.Value = values[ii].WrappedValue.AsBoxedObject();
                 field.StatusCode = values[ii].StatusCode;
 
                 if (diagnosticInfos != null && diagnosticInfos.Count > ii)
@@ -484,7 +484,7 @@ namespace Opc.Ua.Sample.Controls
         /// <see cref="BaseListCtrl.GetDataToDrag" />
         protected override object GetDataToDrag()
         {
-            ReadValueIdCollection valueIds = new ReadValueIdCollection();
+            List<ReadValueId> valueIds = new List<ReadValueId>();
 
             foreach (ListViewItem listItem in ItemsLV.SelectedItems)
             {

--- a/Samples/Controls.Net4/Common/CallMethodDlg.cs
+++ b/Samples/Controls.Net4/Common/CallMethodDlg.cs
@@ -119,7 +119,7 @@ namespace Opc.Ua.Sample.Controls
                 request.MethodId = m_methodId;
                 request.InputArguments = inputArguments;
 
-                CallMethodRequestCollection requests = new CallMethodRequestCollection();
+                List<CallMethodRequest> requests = new List<CallMethodRequest>();
                 requests.Add(request);
 
                 CallResponse response = await m_session.CallAsync(

--- a/Samples/Controls.Net4/Common/DataValueListCtrl.cs
+++ b/Samples/Controls.Net4/Common/DataValueListCtrl.cs
@@ -210,7 +210,7 @@ namespace Opc.Ua.Sample.Controls
             listItem.SubItems[4].Text = "";
             listItem.SubItems[5].Text = "";
 
-            if (dataValue.Value != null)
+            if (!dataValue.Value.IsNull)
             {
                 listItem.SubItems[2].Text = String.Format("{0}", dataValue.Value.WrappedValue);
 

--- a/Samples/Controls.Net4/Common/FindNodeDlg.cs
+++ b/Samples/Controls.Net4/Common/FindNodeDlg.cs
@@ -74,7 +74,7 @@ namespace Opc.Ua.Sample.Controls
         {
             try
             {
-                BrowsePathCollection browsePaths = new BrowsePathCollection();
+                List<BrowsePath> browsePaths = new List<BrowsePath>();
 
                 BrowsePath browsePath = new BrowsePath();
 

--- a/Samples/Controls.Net4/Common/NodeListCtrl.cs
+++ b/Samples/Controls.Net4/Common/NodeListCtrl.cs
@@ -253,7 +253,7 @@ namespace Opc.Ua.Sample.Controls
                     await AddNodeIdAsync(reference, ct);
                 }
 
-                ReferenceDescriptionCollection references = e.Data.GetData(typeof(ReferenceDescriptionCollection)) as ReferenceDescriptionCollection;
+                List<ReferenceDescription> references = e.Data.GetData(typeof(List<ReferenceDescription>)) as List<ReferenceDescription>;
 
                 if (references != null)
                 {
@@ -263,7 +263,7 @@ namespace Opc.Ua.Sample.Controls
                     }
                 }
 
-                ReadValueIdCollection valueIds = e.Data.GetData(typeof(ReadValueIdCollection)) as ReadValueIdCollection;
+                List<ReadValueId> valueIds = e.Data.GetData(typeof(List<ReadValueId>)) as List<ReadValueId>;
 
                 if (valueIds != null)
                 {

--- a/Samples/Controls.Net4/Common/PerformanceTestDlg.cs
+++ b/Samples/Controls.Net4/Common/PerformanceTestDlg.cs
@@ -318,7 +318,7 @@ namespace Opc.Ua.Sample.Controls
                     RequestHeader requestHeader = new RequestHeader();
                     requestHeader.ReturnDiagnostics = 5000;
 
-                    ReadValueIdCollection nodesToRead = new ReadValueIdCollection(count);
+                    List<ReadValueId> nodesToRead = new List<ReadValueId>(count);
 
                     for (int jj = 0; jj < count; jj++)
                     {

--- a/Samples/Controls.Net4/Common/PropertyListCtrl.cs
+++ b/Samples/Controls.Net4/Common/PropertyListCtrl.cs
@@ -146,7 +146,7 @@ namespace Opc.Ua.Sample.Controls
             }
 
             // build list of properties to read.
-            ReadValueIdCollection nodesToRead = new ReadValueIdCollection();
+            List<ReadValueId> nodesToRead = new List<ReadValueId>();
 
             Browser browser = new Browser(m_session);
 
@@ -175,7 +175,7 @@ namespace Opc.Ua.Sample.Controls
         /// <see cref="BaseListCtrl.GetDataToDrag" />
         protected override object GetDataToDrag()
         {
-            ReferenceDescriptionCollection references = new ReferenceDescriptionCollection();
+            List<ReferenceDescription> references = new List<ReferenceDescription>();
 
             foreach (ListViewItem listItem in ItemsLV.SelectedItems)
             {

--- a/Samples/Controls.Net4/SelectLocaleDlg.cs
+++ b/Samples/Controls.Net4/SelectLocaleDlg.cs
@@ -72,7 +72,7 @@ namespace Opc.Ua.Sample.Controls
             // get the locales from the server.
             DataValue value = await m_session.ReadValueAsync(VariableIds.Server_ServerCapabilities_LocaleIdArray, ct);
 
-            if (value != null)
+            if (!value.IsNull)
             {
                 string[] availableLocales = value.GetValue<string[]>(null);
 

--- a/Samples/Controls.Net4/Sessions/BrowseListCtrl.cs
+++ b/Samples/Controls.Net4/Sessions/BrowseListCtrl.cs
@@ -225,7 +225,7 @@ namespace Opc.Ua.Sample.Controls
         /// </summary>
         private async Task BrowseAsync(NodeId startId, CancellationToken ct = default)
         {
-            if (m_browser == null || NodeId.IsNull(startId))
+            if (m_browser == null || (startId).IsNull)
             {
                 Clear();
                 return;
@@ -272,7 +272,7 @@ namespace Opc.Ua.Sample.Controls
             // read the current value for any variables.
             if (variables.Count > 0)
             {
-                ReadValueIdCollection nodesToRead = new ReadValueIdCollection();
+                List<ReadValueId> nodesToRead = new List<ReadValueId>();
 
                 foreach (ItemData item in variables)
                 {

--- a/Samples/Controls.Net4/Sessions/BrowseListCtrl.cs
+++ b/Samples/Controls.Net4/Sessions/BrowseListCtrl.cs
@@ -443,7 +443,7 @@ namespace Opc.Ua.Sample.Controls
             listItem.SubItems[1].Text = String.Format("{0}", itemData.Target);
             listItem.SubItems[2].Text = String.Format("{0}", itemData.TypeDefinition);
 
-            if (itemData.Value != null)
+            if (!itemData.Value.IsNull)
             {
                 listItem.SubItems[3].Text = String.Format("{0}", itemData.Value);
             }

--- a/Samples/Controls.Net4/Sessions/BrowseOptionsDlg.cs
+++ b/Samples/Controls.Net4/Sessions/BrowseOptionsDlg.cs
@@ -194,7 +194,7 @@ namespace Opc.Ua.Sample.Controls
             {
                 ViewDescription view = null;
 
-                if (!NodeId.IsNull(viewId) || ViewTimestampCK.Checked || ViewVersionCK.Checked)
+                if (!(viewId).IsNull || ViewTimestampCK.Checked || ViewVersionCK.Checked)
                 {
                     view = new ViewDescription();
 

--- a/Samples/Controls.Net4/Sessions/BrowseTreeCtrl.cs
+++ b/Samples/Controls.Net4/Sessions/BrowseTreeCtrl.cs
@@ -807,7 +807,7 @@ namespace Opc.Ua.Sample.Controls
 
                 if (typeNode.NodeId == referenceTypeId)
                 {
-                    if (typeNode.InverseName == null)
+                    if (typeNode.InverseName.IsNull)
                     {
                         return child;
                     }
@@ -834,7 +834,7 @@ namespace Opc.Ua.Sample.Controls
                 string text = typeNode.DisplayName.Text;
                 string icon = "ReferenceType";
 
-                if (!reference.IsForward && typeNode.InverseName != null)
+                if (!reference.IsForward && !typeNode.InverseName.IsNull)
                 {
                     text = typeNode.InverseName.Text;
                 }
@@ -857,7 +857,7 @@ namespace Opc.Ua.Sample.Controls
         {
             if (reference != null)
             {
-                if (reference.DisplayName != null && !String.IsNullOrEmpty(reference.DisplayName.Text))
+                if (!reference.DisplayName.IsNull && !String.IsNullOrEmpty(reference.DisplayName.Text))
                 {
                     return reference.DisplayName.Text;
                 }

--- a/Samples/Controls.Net4/Sessions/BrowseTreeCtrl.cs
+++ b/Samples/Controls.Net4/Sessions/BrowseTreeCtrl.cs
@@ -194,7 +194,7 @@ namespace Opc.Ua.Sample.Controls
                 return;
             }
 
-            if (NodeId.IsNull(rootId))
+            if ((rootId).IsNull)
             {
                 m_rootId = new NodeId(Objects.RootFolder);
             }
@@ -669,7 +669,7 @@ namespace Opc.Ua.Sample.Controls
         {
             foreach (ReferenceDescription reference in references.ToList())
             {
-                if (reference.ReferenceTypeId.IsNullNodeId)
+                if (reference.ReferenceTypeId.IsNull)
                 {
                     if (m_logger.IsEnabled(LogLevel.Debug))
                     {
@@ -790,7 +790,7 @@ namespace Opc.Ua.Sample.Controls
                 return null;
             }
 
-            if (reference.ReferenceTypeId.IsNullNodeId)
+            if (reference.ReferenceTypeId.IsNull)
             {
                 if (m_logger.IsEnabled(LogLevel.Debug))
                 {
@@ -1088,7 +1088,7 @@ namespace Opc.Ua.Sample.Controls
                 Session session = m_browser.Session as Session;
 
                 // build list of nodes to read.
-                ReadValueIdCollection valueIds = new ReadValueIdCollection();
+                List<ReadValueId> valueIds = new List<ReadValueId>();
 
                 ReadValueId valueId = new ReadValueId();
 
@@ -1128,7 +1128,7 @@ namespace Opc.Ua.Sample.Controls
                 Session session = m_browser.Session as Session;
 
                 // build list of nodes to read.
-                WriteValueCollection values = new WriteValueCollection();
+                List<WriteValue> values = new List<WriteValue>();
 
                 WriteValue value = new WriteValue();
 

--- a/Samples/Controls.Net4/Sessions/ReadHistoryDlg.cs
+++ b/Samples/Controls.Net4/Sessions/ReadHistoryDlg.cs
@@ -194,7 +194,7 @@ namespace Opc.Ua.Sample.Controls
                 nodeToRead.ContinuationPoint = m_result.ContinuationPoint;
             }
 
-            HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+            List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
             nodesToRead.Add(nodeToRead);
 
             HistoryReadResponse response = await m_session.HistoryReadAsync(
@@ -228,7 +228,7 @@ namespace Opc.Ua.Sample.Controls
             HistoryReadValueId nodeToRead = new HistoryReadValueId();
             nodeToRead.NodeId = m_nodeId;
 
-            HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+            List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
             nodesToRead.Add(nodeToRead);
 
             HistoryReadResponse response = await m_session.HistoryReadAsync(
@@ -313,7 +313,7 @@ namespace Opc.Ua.Sample.Controls
                 nodeToRead.ContinuationPoint = m_result.ContinuationPoint;
             }
 
-            HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+            List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
             nodesToRead.Add(nodeToRead);
 
             HistoryReadResponse response = await m_session.HistoryReadAsync(
@@ -375,7 +375,7 @@ namespace Opc.Ua.Sample.Controls
                 nodeToRead.ContinuationPoint = m_result.ContinuationPoint;
             }
 
-            HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+            List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
             nodesToRead.Add(nodeToRead);
 
             HistoryReadResponse response = await m_session.HistoryReadAsync(

--- a/Samples/Controls.Net4/Sessions/SelectNodeDlg.cs
+++ b/Samples/Controls.Net4/Sessions/SelectNodeDlg.cs
@@ -144,7 +144,7 @@ namespace Opc.Ua.Sample.Controls
                     return;
                 }
 
-                if (NodeId.IsNull(reference.NodeId))
+                if ((reference.NodeId).IsNull)
                 {
                     return;
                 }

--- a/Samples/Controls.Net4/Sessions/SelectNodeDlg.cs
+++ b/Samples/Controls.Net4/Sessions/SelectNodeDlg.cs
@@ -180,13 +180,13 @@ namespace Opc.Ua.Sample.Controls
                 {
                     case IdType.Opaque:
                     {
-                        NodeIdentifierTB.Text = Convert.ToBase64String((byte[])reference.NodeId.Identifier);
+                        NodeIdentifierTB.Text = reference.NodeId.TryGetValue(out ByteString id) ? Convert.ToBase64String(id.Span.ToArray()) : String.Empty;
                         break;
                     }
 
                     default:
                     {
-                        NodeIdentifierTB.Text = Utils.Format("{0}", reference.NodeId.Identifier);
+                        NodeIdentifierTB.Text = Utils.Format("{0}", reference.NodeId.IdentifierAsString);
                         break;
                     }
                 }

--- a/Samples/Controls.Net4/Sessions/SessionTreeCtrl.cs
+++ b/Samples/Controls.Net4/Sessions/SessionTreeCtrl.cs
@@ -1081,7 +1081,7 @@ namespace Opc.Ua.Sample.Controls
                 }
 
                 // build list of nodes to read.
-                ReadValueIdCollection valueIds = new ReadValueIdCollection();
+                List<ReadValueId> valueIds = new List<ReadValueId>();
 
                 MonitoredItem monitoredItem = Get<MonitoredItem>(NodesTV.SelectedNode);
 
@@ -1140,7 +1140,7 @@ namespace Opc.Ua.Sample.Controls
                 }
 
                 // build list of nodes to read.
-                WriteValueCollection values = new WriteValueCollection();
+                List<WriteValue> values = new List<WriteValue>();
 
                 MonitoredItem monitoredItem = Get<MonitoredItem>(NodesTV.SelectedNode);
 

--- a/Samples/Controls.Net4/Subscriptions/ContentFilterElementListCtrl.cs
+++ b/Samples/Controls.Net4/Subscriptions/ContentFilterElementListCtrl.cs
@@ -423,7 +423,7 @@ namespace Opc.Ua.Sample.Controls
                 }
 
                 // get the current value.
-                object currentValue = literal.Value.Value;
+                object currentValue = literal.Value.AsBoxedObject();
 
                 if (currentValue == null)
                 {

--- a/Samples/Controls.Net4/Subscriptions/ContentFilterElementListCtrl.cs
+++ b/Samples/Controls.Net4/Subscriptions/ContentFilterElementListCtrl.cs
@@ -284,7 +284,7 @@ namespace Opc.Ua.Sample.Controls
                             object value = GuiUtils.GetDefaultValue(variable.DataType, variable.ValueRank);
 
                             // create attribute filter.
-                            element = m_filter.Push(FilterOperator.Equals, new Variant(attribute), new Variant(value));
+                            element = m_filter.Push(FilterOperator.Equals, new Variant(new ExtensionObject(attribute, false)), Variant.From((dynamic)value));
                             break;
                         }
 
@@ -299,13 +299,13 @@ namespace Opc.Ua.Sample.Controls
                             attribute.AttributeId = Attributes.NodeId;
 
                             // create attribute filter.
-                            element = m_filter.Push(FilterOperator.IsNull, new Variant(attribute));
+                            element = m_filter.Push(FilterOperator.IsNull, new Variant(new ExtensionObject(attribute, false)));
                             break;
                         }
 
                         case NodeClass.ObjectType:
                         {
-                            element = m_filter.Push(FilterOperator.OfType, new Variant(node.NodeId));
+                            element = m_filter.Push(FilterOperator.OfType, Variant.From(node.NodeId));
                             break;
                         }
 
@@ -342,7 +342,7 @@ namespace Opc.Ua.Sample.Controls
                 ContentFilterElement element2 = ItemsLV.SelectedItems[1].Tag as ContentFilterElement;
 
                 ContentFilter filter = GetFilter();
-                filter.Push(FilterOperator.And, new Variant(element1), new Variant(element2));
+                filter.Push(FilterOperator.And, new Variant(new ExtensionObject(element1, false)), new Variant(new ExtensionObject(element2, false)));
 
                 Update(filter);
             }
@@ -365,7 +365,7 @@ namespace Opc.Ua.Sample.Controls
                 ContentFilterElement element2 = ItemsLV.SelectedItems[1].Tag as ContentFilterElement;
 
                 ContentFilter filter = GetFilter();
-                filter.Push(FilterOperator.Or, new Variant(element1), new Variant(element2));
+                filter.Push(FilterOperator.Or, new Variant(new ExtensionObject(element1, false)), new Variant(new ExtensionObject(element2, false)));
 
                 Update(filter);
             }
@@ -387,7 +387,7 @@ namespace Opc.Ua.Sample.Controls
                 ContentFilterElement element1 = ItemsLV.SelectedItems[0].Tag as ContentFilterElement;
 
                 ContentFilter filter = GetFilter();
-                filter.Push(FilterOperator.Not, new Variant(element1));
+                filter.Push(FilterOperator.Not, new Variant(new ExtensionObject(element1, false)));
 
                 Update(filter);
             }
@@ -441,7 +441,7 @@ namespace Opc.Ua.Sample.Controls
                 }
 
                 // update value.
-                literal.Value = new Variant(value);
+                literal.Value = Variant.From((dynamic)value);
                 ContentFilter filter = GetFilter();
                 Update(filter);
             }

--- a/Samples/Controls.Net4/Subscriptions/EventNotificationListCtrl.cs
+++ b/Samples/Controls.Net4/Subscriptions/EventNotificationListCtrl.cs
@@ -410,7 +410,7 @@ namespace Opc.Ua.Sample.Controls
 
             listItem.SubItems[4].Text = String.Format("{0}", severity);
 
-            if (message != null)
+            if (!message.IsNull)
             {
                 listItem.SubItems[5].Text = String.Format("{0}", message.Text);
             }

--- a/Samples/Controls.Net4/Subscriptions/FilterOperandEditDlg.cs
+++ b/Samples/Controls.Net4/Subscriptions/FilterOperandEditDlg.cs
@@ -141,7 +141,7 @@ namespace Opc.Ua.Sample.Controls
                             buffer.Append("\r\n");
                         }
 
-                        buffer.AppendFormat("{0}", new Variant(array.GetValue(ii)));
+                        buffer.AppendFormat("{0}", Variant.From((dynamic)array.GetValue(ii)));
                     }
                 }
                 else

--- a/Samples/Controls.Net4/Subscriptions/FilterOperandEditDlg.cs
+++ b/Samples/Controls.Net4/Subscriptions/FilterOperandEditDlg.cs
@@ -130,7 +130,7 @@ namespace Opc.Ua.Sample.Controls
 
                 StringBuilder buffer = new StringBuilder();
 
-                Array array = literalOperand.Value.Value as Array;
+                Array array = literalOperand.Value.AsBoxedObject() as Array;
 
                 if (array != null)
                 {

--- a/Samples/Controls.Net4/Subscriptions/MonitoredItemConfigCtrl.cs
+++ b/Samples/Controls.Net4/Subscriptions/MonitoredItemConfigCtrl.cs
@@ -246,7 +246,7 @@ namespace Opc.Ua.Sample.Controls
             Node parent = null;
 
             // if the NodeId is of type string and contains '.' do not use relative paths
-            if (node.NodeId.IdType != IdType.String || (!node.NodeId.Identifier.ToString().Contains('.', StringComparison.Ordinal) && !node.NodeId.Identifier.ToString().Contains('/', StringComparison.Ordinal)))
+            if (node.NodeId.IdType != IdType.String || (!node.NodeId.IdentifierAsString.Contains('.', StringComparison.Ordinal) && !node.NodeId.IdentifierAsString.Contains('/', StringComparison.Ordinal)))
             {
                 parent = await FindParentAsync(node, ct);
             }

--- a/Samples/Controls.Net4/Subscriptions/NotificationMessageListCtrl.cs
+++ b/Samples/Controls.Net4/Subscriptions/NotificationMessageListCtrl.cs
@@ -233,7 +233,7 @@ namespace Opc.Ua.Sample.Controls
             {
                 notifications++;
 
-                if (ExtensionObject.IsNull(notification))
+                if ((notification).IsNull)
                 {
                     continue;
                 }

--- a/Samples/Controls.Net4/Subscriptions/NotificationMessageListCtrl.cs
+++ b/Samples/Controls.Net4/Subscriptions/NotificationMessageListCtrl.cs
@@ -238,14 +238,14 @@ namespace Opc.Ua.Sample.Controls
                     continue;
                 }
 
-                DataChangeNotification datachangeNotification = notification.Body as DataChangeNotification;
+                DataChangeNotification datachangeNotification = notification.TryGetValue<DataChangeNotification>(out var dataChangeValue, ServiceMessageContext.CreateEmpty(null)) ? dataChangeValue : null;
 
                 if (datachangeNotification != null)
                 {
                     datachanges += datachangeNotification.MonitoredItems.Count;
                 }
 
-                EventNotificationList EventNotification = notification.Body as EventNotificationList;
+                EventNotificationList EventNotification = notification.TryGetValue<EventNotificationList>(out var eventValue, ServiceMessageContext.CreateEmpty(null)) ? eventValue : null;
 
                 if (EventNotification != null)
                 {

--- a/Samples/Controls.Net4/Subscriptions/WriteDlg.cs
+++ b/Samples/Controls.Net4/Subscriptions/WriteDlg.cs
@@ -97,7 +97,7 @@ namespace Opc.Ua.Sample.Controls
                 if (ServiceResult.IsGood(result) && indexRange != NumericRange.Null)
                 {
                     // apply the index range.
-                    Variant valueToWrite = new Variant(nodeToWrite.Value.WrappedValue.AsBoxedObject());
+                    Variant valueToWrite = nodeToWrite.Value.WrappedValue;
 
                     result = indexRange.ApplyRange(ref valueToWrite);
 

--- a/Samples/Controls.Net4/Subscriptions/WriteDlg.cs
+++ b/Samples/Controls.Net4/Subscriptions/WriteDlg.cs
@@ -97,7 +97,7 @@ namespace Opc.Ua.Sample.Controls
                 if (ServiceResult.IsGood(result) && indexRange != NumericRange.Null)
                 {
                     // apply the index range.
-                    Variant valueToWrite = new Variant(nodeToWrite.Value.Value);
+                    Variant valueToWrite = new Variant(nodeToWrite.Value.WrappedValue.AsBoxedObject());
 
                     result = indexRange.ApplyRange(ref valueToWrite);
 

--- a/Samples/Controls.Net4/Subscriptions/WriteValueListCtrl.cs
+++ b/Samples/Controls.Net4/Subscriptions/WriteValueListCtrl.cs
@@ -146,7 +146,7 @@ namespace Opc.Ua.Sample.Controls
 
                 if (value != null)
                 {
-                    value.Value = new DataValue(new Variant(value.Value.WrappedValue.AsBoxedObject()), StatusCodes.Good, DateTime.MinValue, DateTime.MinValue);
+                    value.Value = new DataValue(value.Value.WrappedValue, StatusCodes.Good, DateTime.MinValue, DateTime.MinValue);
 
                     values.Add(value);
                 }
@@ -175,7 +175,7 @@ namespace Opc.Ua.Sample.Controls
 
             if (ServiceResult.IsBad(result))
             {
-                value = new DataValue(new Variant(GuiUtils.GetDefaultValue(Attributes.GetDataTypeId(attributeId), ValueRanks.Scalar)), StatusCodes.Good, DateTime.MinValue, DateTime.MinValue);
+                value = new DataValue(Variant.From((dynamic)GuiUtils.GetDefaultValue(Attributes.GetDataTypeId(attributeId), ValueRanks.Scalar)), StatusCodes.Good, DateTime.MinValue, DateTime.MinValue);
             }
 
             // update the value attribute.
@@ -191,7 +191,7 @@ namespace Opc.Ua.Sample.Controls
 
                     if (variable != null)
                     {
-                        value = new DataValue(new Variant(GuiUtils.GetDefaultValue(variable.DataType, variable.ValueRank)), StatusCodes.Good, DateTime.MinValue, DateTime.MinValue);
+                        value = new DataValue(Variant.From((dynamic)GuiUtils.GetDefaultValue(variable.DataType, variable.ValueRank)), StatusCodes.Good, DateTime.MinValue, DateTime.MinValue);
                     }
                 }
             }
@@ -228,7 +228,7 @@ namespace Opc.Ua.Sample.Controls
                 return;
             }
 
-            if (value.Value == null)
+            if (value.Value.IsNull)
             {
                 value.Value = new DataValue();
             }
@@ -403,7 +403,7 @@ namespace Opc.Ua.Sample.Controls
 
                 if (value != null)
                 {
-                    values[0].Value = new DataValue(new Variant(value), StatusCodes.Good, values[0].Value.SourceTimestamp, values[0].Value.ServerTimestamp);
+                    values[0].Value = new DataValue(Variant.From((dynamic)value), StatusCodes.Good, values[0].Value.SourceTimestamp, values[0].Value.ServerTimestamp);
 
                     await UpdateItemAsync(ItemsLV.SelectedItems[0], values[0]);
 

--- a/Samples/Controls.Net4/Subscriptions/WriteValueListCtrl.cs
+++ b/Samples/Controls.Net4/Subscriptions/WriteValueListCtrl.cs
@@ -146,7 +146,7 @@ namespace Opc.Ua.Sample.Controls
 
                 if (value != null)
                 {
-                    value.Value = new DataValue(new Variant(value.Value.Value), StatusCodes.Good, DateTime.MinValue, DateTime.MinValue);
+                    value.Value = new DataValue(new Variant(value.Value.WrappedValue.AsBoxedObject()), StatusCodes.Good, DateTime.MinValue, DateTime.MinValue);
 
                     values.Add(value);
                 }
@@ -233,7 +233,7 @@ namespace Opc.Ua.Sample.Controls
                 value.Value = new DataValue();
             }
 
-            if (value.Value.Value == null)
+            if (value.Value.WrappedValue.AsBoxedObject() == null)
             {
                 value.Value = await GetDefaultValueAsync(value.NodeId, value.AttributeId, ct);
             }
@@ -252,7 +252,7 @@ namespace Opc.Ua.Sample.Controls
             listItem.SubItems[1].Text = String.Format("{0}", value.NodeId);
             listItem.SubItems[2].Text = String.Format("{0}", Attributes.GetBrowseName(value.AttributeId));
             listItem.SubItems[3].Text = String.Format("{0}", value.IndexRange);
-            listItem.SubItems[4].Text = String.Format("{0}", value.Value.Value);
+            listItem.SubItems[4].Text = String.Format("{0}", value.Value.WrappedValue.AsBoxedObject());
             listItem.SubItems[5].Text = String.Format("{0}", value.Value.StatusCode);
             listItem.SubItems[6].Text = String.Format("{0}", value.Value.SourceTimestamp);
 
@@ -393,12 +393,12 @@ namespace Opc.Ua.Sample.Controls
 
                     if (writeValue != null)
                     {
-                        value = writeValue.Value.Value;
+                        value = writeValue.Value.WrappedValue.AsBoxedObject();
                     }
                 }
                 else
                 {
-                    value = GuiUtils.EditValue(m_session, values[0].Value.Value, datatypeId, valueRank, Telemetry);
+                    value = GuiUtils.EditValue(m_session, values[0].Value.WrappedValue.AsBoxedObject(), datatypeId, valueRank, Telemetry);
                 }
 
                 if (value != null)

--- a/Samples/GDS/Client/Controls/ApplicationCertificateControl.cs
+++ b/Samples/GDS/Client/Controls/ApplicationCertificateControl.cs
@@ -346,11 +346,11 @@ certificateRequest);
                         else
                         {
                             #pragma warning disable CA2000 // Justification: WinForms/sample ownership or lifetime is managed outside the local scope.
-                            csrCertificate = CertificateFactory.CreateCertificateWithPEMPrivateKey(Certificate.From(m_certificate), pkcsData, m_certificatePassword.AsSpan()).AsX509Certificate2();
+                            csrCertificate = DefaultCertificateFactory.Instance.CreateWithPEMPrivateKey(Certificate.From(m_certificate), pkcsData, m_certificatePassword.AsSpan()).AsX509Certificate2();
                             #pragma warning restore CA2000
                         }
                     }
-                    byte[] certificateRequest = CertificateFactory.CreateSigningRequest(Certificate.From(csrCertificate), domainNames);
+                    byte[] certificateRequest = DefaultCertificateFactory.Instance.CreateSigningRequest(Certificate.From(csrCertificate), domainNames);
                     requestId = await m_gds.StartSigningRequestAsync(NodeId.Parse(m_application.ApplicationId), NodeId.Null, NodeId.Null, certificateRequest.ToByteString());
                 }
 
@@ -411,7 +411,7 @@ certificateRequest);
                                 if (oldCertificate != null && oldCertificate.HasPrivateKey)
                                 {
                                     oldCertificate = await LoadPrivateKeyAsync(cid, oldCertificate, []);
-                                    newCert = CertificateFactory.CreateCertificateWithPrivateKey(Certificate.From(newCert), Certificate.From(m_temporaryCertificateCreated ? m_certificate : oldCertificate)).AsX509Certificate2();
+                                    newCert = DefaultCertificateFactory.Instance.CreateWithPrivateKey(Certificate.From(newCert), Certificate.From(m_temporaryCertificateCreated ? m_certificate : oldCertificate)).AsX509Certificate2();
                                     await store.DeleteAsync(oldCertificate.Thumbprint);
                                 }
                                 else
@@ -489,7 +489,7 @@ certificateRequest);
                                     X509Certificate2 oldCertificate = X509PfxUtils.CreateCertificateFromPKCS12(pkcsData, m_certificatePassword.AsSpan()).AsX509Certificate2();
                                     #pragma warning restore CA2000
                                     #pragma warning disable CA2000 // Justification: WinForms/sample ownership or lifetime is managed outside the local scope.
-                                    newCert = CertificateFactory.CreateCertificateWithPrivateKey(Certificate.From(newCert), Certificate.From(oldCertificate)).AsX509Certificate2();
+                                    newCert = DefaultCertificateFactory.Instance.CreateWithPrivateKey(Certificate.From(newCert), Certificate.From(oldCertificate)).AsX509Certificate2();
                                     #pragma warning restore CA2000
                                     pkcsData = newCert.Export(X509ContentType.Pfx, m_certificatePassword);
                                     File.WriteAllBytes(absoluteCertificatePrivateKeyPath, pkcsData);

--- a/Samples/GDS/Client/Controls/RegisterApplicationControl.cs
+++ b/Samples/GDS/Client/Controls/RegisterApplicationControl.cs
@@ -129,7 +129,7 @@ namespace Opc.Ua.Gds.Client
                 ApplicationUriTextBox.Text = server.ApplicationUri;
                 await ReadRegistrationAsync(true);
 
-                ApplicationNameTextBox.Text = (server.ApplicationName != null) ? server.ApplicationName.Text : "";
+                ApplicationNameTextBox.Text = (!server.ApplicationName.IsNull) ? server.ApplicationName.Text : "";
                 ProductUriTextBox.Text = server.ProductUri;
                 SetDiscoveryUrls(server.DiscoveryUrls.ToArray());
                 SetServerCapabilities(new string[] { Opc.Ua.ServerCapability.DA });

--- a/Samples/GDS/ClientControls/Controls/DiscoveryControl.cs
+++ b/Samples/GDS/ClientControls/Controls/DiscoveryControl.cs
@@ -508,7 +508,7 @@ namespace Opc.Ua.Gds.Client.Controls
 
                 DataRow row = ServersTable.NewRow();
 
-                row[0] = (LocalizedText.IsNullOrEmpty(server.ApplicationName)) ? "" : server.ApplicationName.Text;
+                row[0] = ((server.ApplicationName).IsNullOrEmpty) ? "" : server.ApplicationName.Text;
                 row[1] = server.ApplicationType.ToString();
 
                 StringBuilder buffer = new StringBuilder();
@@ -599,7 +599,7 @@ namespace Opc.Ua.Gds.Client.Controls
             {
                 if (!headerSet)
                 {
-                    ApplicationNameTextBox.Text = (LocalizedText.IsNullOrEmpty(endpoint.Server.ApplicationName)) ? "---" : endpoint.Server.ApplicationName.Text;
+                    ApplicationNameTextBox.Text = ((endpoint.Server.ApplicationName).IsNullOrEmpty) ? "---" : endpoint.Server.ApplicationName.Text;
                     ApplicationTypeTextBox.Text = endpoint.Server.ApplicationType.ToString();
                     ApplicationUriTextBox.Text = endpoint.Server.ApplicationUri;
                     ProductUriTextBox.Text = endpoint.Server.ProductUri;
@@ -891,7 +891,7 @@ namespace Opc.Ua.Gds.Client.Controls
 
                     ApplicationDescription application = (ApplicationDescription)e.Node.Tag;
 
-                    ApplicationNameTextBox.Text = (LocalizedText.IsNullOrEmpty(application.ApplicationName))?"---":application.ApplicationName.Text;
+                    ApplicationNameTextBox.Text = ((application.ApplicationName).IsNullOrEmpty)?"---":application.ApplicationName.Text;
                     ApplicationTypeTextBox.Text = application.ApplicationType.ToString();
                     ApplicationUriTextBox.Text = application.ApplicationUri;
                     ProductUriTextBox.Text = application.ProductUri;

--- a/Samples/GDS/ClientControls/Controls/EditValueCtrl.cs
+++ b/Samples/GDS/ClientControls/Controls/EditValueCtrl.cs
@@ -174,7 +174,7 @@ namespace Opc.Ua.Gds.Client.Controls
 
                     if (info != null)
                     {
-                        return info.Parent != null && info.Parent.TypeInfo != null && info.Parent.TypeInfo.BuiltInType == BuiltInType.Variant;
+                        return info.Parent != null && !info.Parent.TypeInfo.IsUnknown && info.Parent.TypeInfo.BuiltInType == BuiltInType.Variant;
                     }
                 }
 
@@ -197,7 +197,7 @@ namespace Opc.Ua.Gds.Client.Controls
                     {
                         Variant? value = info.Value as Variant?;
 
-                        if (value != null && value.Value.TypeInfo != null)
+                        if (value != null && !value.Value.TypeInfo.IsUnknown)
                         {
                             return value.Value.TypeInfo.BuiltInType;
                         }
@@ -258,7 +258,7 @@ namespace Opc.Ua.Gds.Client.Controls
                 {
                     currentType = variant.TypeInfo;
 
-                    if (currentType == null)
+                    if (currentType.IsUnknown)
                     {
                         currentType = Opc.Ua.TypeInfo.Construct(currentValue);
                     }
@@ -417,7 +417,7 @@ namespace Opc.Ua.Gds.Client.Controls
                 {
                     currentType = variant.TypeInfo;
 
-                    if (currentType == null)
+                    if (currentType.IsUnknown)
                     {
                         currentType = Opc.Ua.TypeInfo.Construct(currentValue);
                     }
@@ -557,7 +557,7 @@ namespace Opc.Ua.Gds.Client.Controls
             }
 
             // assign a type.
-            if (expectedType == null)
+            if (expectedType.IsUnknown)
             {
                 if (value == null)
                 {
@@ -578,9 +578,9 @@ namespace Opc.Ua.Gds.Client.Controls
                 {
                     name = value.GetType().Name;
 
-                    if (value is ExtensionObject extension && extension.Body != null)
+                    if (value is ExtensionObject extension && TryGetExtensionObjectBody(extension, out object body))
                     {
-                        name = extension.Body.GetType().Name;
+                        name = body.GetType().Name;
                     }
                 }
             }
@@ -733,7 +733,7 @@ namespace Opc.Ua.Gds.Client.Controls
                 {
                     parent.TypeInfo = typeInfo = variant.TypeInfo;
 
-                    if (typeInfo == null)
+                    if (typeInfo.IsUnknown)
                     {
                         parent.TypeInfo = typeInfo = Opc.Ua.TypeInfo.Construct(value);
                     }
@@ -836,9 +836,7 @@ namespace Opc.Ua.Gds.Client.Controls
             // check for extension object.
             if (structure is ExtensionObject extension)
             {
-                structure = extension.Body;
-
-                if (structure == null)
+                if (!TryGetExtensionObjectBody(extension, out structure))
                 {
                     return;
                 }
@@ -1134,7 +1132,7 @@ namespace Opc.Ua.Gds.Client.Controls
         /// </summary>
         private Type GetDataType(AccessInfo accessInfo)
         {
-            if (accessInfo == null || accessInfo.TypeInfo == null)
+            if (accessInfo == null || accessInfo.TypeInfo.IsUnknown)
             {
                 return null;
             }
@@ -1366,7 +1364,7 @@ namespace Opc.Ua.Gds.Client.Controls
                 {
                     typeInfo = variant.TypeInfo;
 
-                    if (typeInfo == null)
+                    if (typeInfo.IsUnknown)
                     {
                         typeInfo = Opc.Ua.TypeInfo.Construct(value);
                     }
@@ -1445,7 +1443,7 @@ namespace Opc.Ua.Gds.Client.Controls
         /// </summary>
         private bool IsSimpleValue(AccessInfo info)
         {
-            if (info == null || info.TypeInfo == null)
+            if (info == null || info.TypeInfo.IsUnknown)
             {
                 return true;
             }
@@ -1459,7 +1457,7 @@ namespace Opc.Ua.Gds.Client.Controls
                 typeInfo = variant.TypeInfo;
                 value = variant.AsBoxedObject();
 
-                if (typeInfo == null)
+                if (typeInfo.IsUnknown)
                 {
                     typeInfo = Opc.Ua.TypeInfo.Construct(value);
                 }
@@ -1497,6 +1495,61 @@ namespace Opc.Ua.Gds.Client.Controls
             return true;
         }
 
+        private static bool TryGetExtensionObjectBody(ExtensionObject extension, out object body)
+        {
+            body = null;
+
+            if (extension.IsNull)
+            {
+                return false;
+            }
+
+            if (extension.TryGetValue(out IEncodeable encodeable, ServiceMessageContext.CreateEmpty(null)))
+            {
+                body = encodeable;
+                return true;
+            }
+
+            return false;
+        }
+
+        private static Variant CreateVariant(object value)
+        {
+            if (value == null)
+            {
+                return Variant.Null;
+            }
+
+            return value switch
+            {
+                bool v => Variant.From(v),
+                sbyte v => Variant.From(v),
+                byte v => Variant.From(v),
+                short v => Variant.From(v),
+                ushort v => Variant.From(v),
+                int v => Variant.From(v),
+                uint v => Variant.From(v),
+                long v => Variant.From(v),
+                ulong v => Variant.From(v),
+                float v => Variant.From(v),
+                double v => Variant.From(v),
+                string v => Variant.From(v),
+                DateTime v => Variant.From(new DateTimeUtc(v)),
+                Guid v => Variant.From(new Uuid(v)),
+                byte[] v => Variant.From(ByteString.From(v)),
+                NodeId v => Variant.From(v),
+                ExpandedNodeId v => Variant.From(v),
+                StatusCode v => Variant.From(v),
+                QualifiedName v => Variant.From(v),
+                LocalizedText v => Variant.From(v),
+                ExtensionObject v => Variant.From(v),
+                DataValue v => Variant.From(v),
+                Variant v => Variant.From(ref v),
+                IEncodeable v => Variant.From(new ExtensionObject(v)),
+                _ => Variant.Null
+            };
+        }
+
         private object CreateInstance(Type type)
         {
             if (typeof(string).Equals(type))
@@ -1530,9 +1583,9 @@ namespace Opc.Ua.Gds.Client.Controls
                     parentValue = variant.Value.AsBoxedObject();
                 }
 
-                if (parentValue is ExtensionObject extension)
+                if (parentValue is ExtensionObject extension && TryGetExtensionObjectBody(extension, out object body))
                 {
-                    parentValue = extension.Body;
+                    parentValue = body;
                 }
 
                 if (info.PropertyInfo.CanWrite && info.PropertyInfo.PropertyType.IsInstanceOfType(info.Value))
@@ -1567,7 +1620,7 @@ namespace Opc.Ua.Gds.Client.Controls
                 {
                     if (info.Parent.TypeInfo.BuiltInType == BuiltInType.Variant && info.Parent.TypeInfo.ValueRank >= 0)
                     {
-                        array.SetValue(new Variant(info.Value), indexes);
+                        array.SetValue(CreateVariant(info.Value), indexes);
                     }
                     else
                     {
@@ -1580,7 +1633,7 @@ namespace Opc.Ua.Gds.Client.Controls
 
                     if (info.Parent.TypeInfo.BuiltInType == BuiltInType.Variant && info.Parent.TypeInfo.ValueRank >= 0)
                     {
-                        list[indexes[0]] = new Variant(info.Value);
+                        list[indexes[0]] = CreateVariant(info.Value);
                     }
                     else
                     {

--- a/Samples/GDS/ClientControls/Controls/EditValueCtrl.cs
+++ b/Samples/GDS/ClientControls/Controls/EditValueCtrl.cs
@@ -252,7 +252,7 @@ namespace Opc.Ua.Gds.Client.Controls
             if (info.Value is Variant)
             {
                 Variant variant = (Variant)info.Value;
-                currentValue = variant.Value;
+                currentValue = variant.AsBoxedObject();
 
                 if (currentValue != null)
                 {
@@ -411,7 +411,7 @@ namespace Opc.Ua.Gds.Client.Controls
             if (info.Value is Variant)
             {
                 Variant variant = (Variant)info.Value;
-                currentValue = variant.Value;
+                currentValue = variant.AsBoxedObject();
 
                 if (currentValue != null)
                 {
@@ -727,7 +727,7 @@ namespace Opc.Ua.Gds.Client.Controls
             if (value is Variant)
             {
                 Variant variant = (Variant)value;
-                value = variant.Value;
+                value = variant.AsBoxedObject();
 
                 if (value != null)
                 {
@@ -1360,7 +1360,7 @@ namespace Opc.Ua.Gds.Client.Controls
             if (value is Variant)
             {
                 Variant variant = (Variant)value;
-                value = variant.Value;
+                value = variant.AsBoxedObject();
 
                 if (value != null)
                 {
@@ -1457,7 +1457,7 @@ namespace Opc.Ua.Gds.Client.Controls
             {
                 Variant variant = (Variant)info.Value;
                 typeInfo = variant.TypeInfo;
-                value = variant.Value;
+                value = variant.AsBoxedObject();
 
                 if (typeInfo == null)
                 {
@@ -1518,7 +1518,7 @@ namespace Opc.Ua.Gds.Client.Controls
 
             if (info.Parent.TypeInfo.BuiltInType == BuiltInType.Variant && info.Parent.TypeInfo.ValueRank < 0)
             {
-                parentValue = ((Variant)info.Parent.Value).Value;
+                parentValue = ((Variant)info.Parent.Value).AsBoxedObject();
             }
 
             if (info.PropertyInfo != null && info.Parent.TypeInfo.ValueRank < 0)
@@ -1527,7 +1527,7 @@ namespace Opc.Ua.Gds.Client.Controls
 
                 if (variant != null)
                 {
-                    parentValue = variant.Value.Value;
+                    parentValue = variant.Value.AsBoxedObject();
                 }
 
                 if (parentValue is ExtensionObject extension)

--- a/Samples/GDS/ClientControls/Controls/ImageListControl.cs
+++ b/Samples/GDS/ClientControls/Controls/ImageListControl.cs
@@ -157,7 +157,7 @@ namespace Opc.Ua.Gds.Client.Controls
 
                     if (typeInfo == null)
                     {
-                        typeInfo = TypeInfo.Construct(((Variant)value).Value);
+                        typeInfo = TypeInfo.Construct(((Variant)value).AsBoxedObject());
                     }
                 }
 

--- a/Samples/GDS/ClientControls/Controls/ImageListControl.cs
+++ b/Samples/GDS/ClientControls/Controls/ImageListControl.cs
@@ -155,7 +155,7 @@ namespace Opc.Ua.Gds.Client.Controls
                 {
                     typeInfo = ((Variant)value).TypeInfo;
 
-                    if (typeInfo == null)
+                    if (typeInfo.IsUnknown)
                     {
                         typeInfo = TypeInfo.Construct(((Variant)value).AsBoxedObject());
                     }

--- a/Samples/GDS/ClientControls/Controls/ViewApplicationRecordsDialog.cs
+++ b/Samples/GDS/ClientControls/Controls/ViewApplicationRecordsDialog.cs
@@ -90,7 +90,7 @@ namespace Opc.Ua.Gds.Client.Controls
                     }
 
                     row[0] = record.ApplicationId;
-                    row[1] = (record.ApplicationNames != null && record.ApplicationNames.Count > 0 && !LocalizedText.IsNullOrEmpty(record.ApplicationNames[0]))?record.ApplicationNames[0].Text:String.Empty;
+                    row[1] = (record.ApplicationNames != null && record.ApplicationNames.Count > 0 && !(record.ApplicationNames[0]).IsNullOrEmpty)?record.ApplicationNames[0].Text:String.Empty;
                     row[2] = record.ApplicationType;
                     row[3] = record.ProductUri;
 

--- a/Samples/GDS/ConsoleServer/Program.cs
+++ b/Samples/GDS/ConsoleServer/Program.cs
@@ -278,6 +278,7 @@ namespace Opc.Ua.Gds.Server
                 database,
                 new CertificateGroup(telemetry),
                 userDatabase,
+                telemetry,
                 true);
             await application.StartAsync(server).ConfigureAwait(false);
 

--- a/Samples/GDS/Server/DB/SqlRoleCast.cs
+++ b/Samples/GDS/Server/DB/SqlRoleCast.cs
@@ -28,7 +28,7 @@ namespace Opc.Ua.Gds.Server.DB
             return new SqlRole() {
                 Id = Guid.NewGuid(),
                 Name = role.Name,
-                RoleId = (int?)(role.RoleId.Identifier as uint?),
+                RoleId = role.RoleId.TryGetValue(out uint roleId) ? (int?)roleId : null,
                 NamespaceIndex = role.RoleId.NamespaceIndex
             };
         }

--- a/Samples/GDS/Server/Program.cs
+++ b/Samples/GDS/Server/Program.cs
@@ -109,6 +109,7 @@ namespace Opc.Ua.Gds.Server
                     database,
                     new CertificateGroup(m_telemetry),
                     userDatabase,
+                    m_telemetry,
                     true);
                 application.StartAsync(server).Wait();
 

--- a/Samples/GDS/Server/SqlApplicationsDatabase.cs
+++ b/Samples/GDS/Server/SqlApplicationsDatabase.cs
@@ -65,7 +65,7 @@ namespace Opc.Ua.Gds.Server.Database.Sql
             )
         {
             NodeId appNodeId = base.RegisterApplication(application);
-            if (NodeId.IsNull(appNodeId))
+            if ((appNodeId).IsNull)
             {
                 appNodeId = new NodeId(Guid.NewGuid(), NamespaceIndex);
             }

--- a/Samples/GDS/Server/SqlApplicationsDatabase.cs
+++ b/Samples/GDS/Server/SqlApplicationsDatabase.cs
@@ -659,7 +659,7 @@ namespace Opc.Ua.Gds.Server.Database.Sql
                 }
             }
 
-            return certificate != null;
+            return !certificate.IsNull;
         }
 
         public override bool SetApplicationTrustLists(NodeId applicationId, string certificateTypeId, string trustListId)

--- a/Samples/Opc.Ua.Sample/Base/CustomNodeManager.cs
+++ b/Samples/Opc.Ua.Sample/Base/CustomNodeManager.cs
@@ -297,7 +297,7 @@ namespace Opc.Ua.Sample
             // must release the lock before removing cross references to other node managers.
             if (referencesToRemove.Count > 0)
             {
-                Server.NodeManager.RemoveReferences(referencesToRemove);
+                Server.NodeManager.RemoveReferencesAsync(referencesToRemove).GetAwaiter().GetResult();
             }
 
             return found;
@@ -584,7 +584,7 @@ namespace Opc.Ua.Sample
 
                 if (variable != null && variable.Value.IsNull)
                 {
-                    variable.Value = new Variant(TypeInfo.GetDefaultValue(variable.DataType, variable.ValueRank, Server.TypeTree));
+                    variable.Value = TypeInfo.GetDefaultVariantValue(variable.DataType, variable.ValueRank, Server.TypeTree);
                 }
 
                 // add reference from supertype for type nodes.
@@ -2367,7 +2367,7 @@ namespace Opc.Ua.Sample
             range = null;
 
             // check for valid filter type.
-            filter = requestedFilter.Body as DataChangeFilter;
+            filter = requestedFilter.TryGetValue<DataChangeFilter>(out var requestedDataChangeFilter, ServiceMessageContext.CreateEmpty(null)) ? requestedDataChangeFilter : null;
 
             if (filter == null)
             {

--- a/Samples/Opc.Ua.Sample/Base/CustomNodeManager.cs
+++ b/Samples/Opc.Ua.Sample/Base/CustomNodeManager.cs
@@ -168,7 +168,7 @@ namespace Opc.Ua.Sample
         /// <returns>True if the namespace is one of the nodes.</returns>
         protected virtual bool IsNodeIdInNamespace(NodeId nodeId)
         {
-            if (NodeId.IsNull(nodeId))
+            if ((nodeId).IsNull)
             {
                 return false;
             }
@@ -590,7 +590,7 @@ namespace Opc.Ua.Sample
                 // add reference from supertype for type nodes.
                 BaseTypeState type = source as BaseTypeState;
 
-                if (type != null && !NodeId.IsNull(type.SuperTypeId))
+                if (type != null && !(type.SuperTypeId).IsNull)
                 {
                     if (!IsNodeIdInNamespace(type.SuperTypeId))
                     {
@@ -687,7 +687,7 @@ namespace Opc.Ua.Sample
         /// </summary>
         protected void AddTypesToTypeTree(BaseTypeState type)
         {
-            if (!NodeId.IsNull(type.SuperTypeId))
+            if (!(type.SuperTypeId).IsNull)
             {
                 if (!Server.TypeTree.IsKnown(type.SuperTypeId))
                 {
@@ -930,17 +930,17 @@ namespace Opc.Ua.Sample
 
                 if (!values[0].IsNull && !values[1].IsNull)
                 {
-                    metadata.WriteMask = (AttributeWriteMask)(((uint)values[0].Value) & ((uint)values[1].Value));
+                    metadata.WriteMask = (AttributeWriteMask)(((uint)values[0].AsBoxedObject()) & ((uint)values[1].AsBoxedObject()));
                 }
 
-                metadata.DataType = (NodeId)values[2].Value;
+                metadata.DataType = (NodeId)values[2].AsBoxedObject();
 
                 if (!values[3].IsNull)
                 {
-                    metadata.ValueRank = (int)values[3].Value;
+                    metadata.ValueRank = (int)values[3].AsBoxedObject();
                 }
 
-                metadata.ArrayDimensions = values[4].Value switch
+                metadata.ArrayDimensions = values[4].AsBoxedObject() switch
                 {
                     ArrayOf<uint> dimensions => dimensions,
                     IList<uint> dimensions => dimensions.ToArrayOf(),
@@ -949,17 +949,17 @@ namespace Opc.Ua.Sample
 
                 if (!values[5].IsNull && !values[6].IsNull)
                 {
-                    metadata.AccessLevel = (byte)(((byte)values[5].Value) & ((byte)values[6].Value));
+                    metadata.AccessLevel = (byte)(((byte)values[5].AsBoxedObject()) & ((byte)values[6].AsBoxedObject()));
                 }
 
                 if (!values[7].IsNull)
                 {
-                    metadata.EventNotifier = (byte)values[7].Value;
+                    metadata.EventNotifier = (byte)values[7].AsBoxedObject();
                 }
 
                 if (!values[8].IsNull && !values[9].IsNull)
                 {
-                    metadata.Executable = (((bool)values[8].Value) && ((bool)values[9].Value));
+                    metadata.Executable = (((bool)values[8].AsBoxedObject()) && ((bool)values[9].AsBoxedObject()));
                 }
 
                 // get instance references.
@@ -2413,7 +2413,7 @@ namespace Opc.Ua.Sample
                     return StatusCodes.BadMonitoredItemFilterUnsupported;
                 }
 
-                range = euRange.Value.Value as Range;
+                range = euRange.Value.AsBoxedObject() as Range;
 
                 if (range == null)
                 {
@@ -2470,7 +2470,7 @@ namespace Opc.Ua.Sample
             DataChangeFilter filter = null;
             Range range = null;
 
-            if (!ExtensionObject.IsNull(parameters.Filter))
+            if (!(parameters.Filter).IsNull)
             {
                 error = ValidateDataChangeFilter(
                     context,
@@ -2757,7 +2757,7 @@ namespace Opc.Ua.Sample
             DataChangeFilter filter = null;
             Range range = null;
 
-            if (!ExtensionObject.IsNull(parameters.Filter))
+            if (!(parameters.Filter).IsNull)
             {
                 error = ValidateDataChangeFilter(
                     context,

--- a/Samples/Opc.Ua.Sample/Base/DataChangeMonitoredItem.cs
+++ b/Samples/Opc.Ua.Sample/Base/DataChangeMonitoredItem.cs
@@ -582,7 +582,7 @@ namespace Opc.Ua.Sample
                 // make a shallow copy of the value (DataValue is an immutable struct in 2.0).
                 DataValue queued = value;
 
-                if (value != null)
+                if (!value.IsNull)
                 {
                     // ensure the data value matches the error status code.
                     if (error != null && error.StatusCode.Code != 0)
@@ -785,7 +785,7 @@ namespace Opc.Ua.Sample
             // set semantics changed bit.
             if (m_semanticsChanged)
             {
-                if (value != null)
+                if (!value.IsNull)
                 {
                     value = new DataValue(
                         value.WrappedValue,
@@ -813,7 +813,7 @@ namespace Opc.Ua.Sample
             // set structure changed bit.
             if (m_structureChanged)
             {
-                if (value != null)
+                if (!value.IsNull)
                 {
                     value = new DataValue(
                         value.WrappedValue,

--- a/Samples/Opc.Ua.Sample/Base/MonitoredItemQueue.cs
+++ b/Samples/Opc.Ua.Sample/Base/MonitoredItemQueue.cs
@@ -367,7 +367,7 @@ namespace Opc.Ua.Sample
         /// <param name="error">The error to update.</param>
         private void SetOverflowBit(ref DataValue value, ref ServiceResult error)
         {
-            if (value != null)
+            if (!value.IsNull)
             {
                 value = new DataValue(
                     value.WrappedValue,

--- a/Samples/Opc.Ua.Sample/Base/SampleNodeManager.cs
+++ b/Samples/Opc.Ua.Sample/Base/SampleNodeManager.cs
@@ -286,7 +286,7 @@ namespace Opc.Ua.Sample
             // must release the lock before removing cross references to other node managers.
             if (referencesToRemove.Count > 0)
             {
-                Server.NodeManager.RemoveReferences(referencesToRemove);
+                Server.NodeManager.RemoveReferencesAsync(referencesToRemove).GetAwaiter().GetResult();
             }
 
             return found;
@@ -583,7 +583,7 @@ namespace Opc.Ua.Sample
 
                 if (variable != null && variable.Value.IsNull)
                 {
-                    variable.Value = new Variant(TypeInfo.GetDefaultValue(variable.DataType, variable.ValueRank, Server.TypeTree));
+                    variable.Value = TypeInfo.GetDefaultVariantValue(variable.DataType, variable.ValueRank, Server.TypeTree);
                 }
 
                 // add reference from supertype for type nodes.
@@ -2397,7 +2397,7 @@ namespace Opc.Ua.Sample
             range = null;
 
             // check for valid filter type.
-            filter = requestedFilter.Body as DataChangeFilter;
+            filter = requestedFilter.TryGetValue<DataChangeFilter>(out var requestedDataChangeFilter, ServiceMessageContext.CreateEmpty(null)) ? requestedDataChangeFilter : null;
 
             if (filter == null)
             {

--- a/Samples/Opc.Ua.Sample/Base/SampleNodeManager.cs
+++ b/Samples/Opc.Ua.Sample/Base/SampleNodeManager.cs
@@ -157,7 +157,7 @@ namespace Opc.Ua.Sample
         /// <returns>True if the namespace is one of the nodes.</returns>
         protected virtual bool IsNodeIdInNamespace(NodeId nodeId)
         {
-            if (NodeId.IsNull(nodeId))
+            if ((nodeId).IsNull)
             {
                 return false;
             }
@@ -590,7 +590,7 @@ namespace Opc.Ua.Sample
                 /*
                 BaseTypeState type = source as BaseTypeState;
 
-                if (type != null && !NodeId.IsNull(type.SuperTypeId))
+                if (type != null && !(type.SuperTypeId).IsNull)
                 {
                     if (!IsNodeIdInNamespace(type.SuperTypeId))
                     {
@@ -688,7 +688,7 @@ namespace Opc.Ua.Sample
         /// </summary>
         protected void AddTypesToTypeTree(BaseTypeState type)
         {
-            if (!NodeId.IsNull(type.SuperTypeId))
+            if (!(type.SuperTypeId).IsNull)
             {
                 if (!Server.TypeTree.IsKnown(type.SuperTypeId))
                 {
@@ -930,17 +930,17 @@ namespace Opc.Ua.Sample
 
                 if (!values[0].IsNull && !values[1].IsNull)
                 {
-                    metadata.WriteMask = (AttributeWriteMask)(((uint)values[0].Value) & ((uint)values[1].Value));
+                    metadata.WriteMask = (AttributeWriteMask)(((uint)values[0].AsBoxedObject()) & ((uint)values[1].AsBoxedObject()));
                 }
 
-                metadata.DataType = (NodeId)values[2].Value;
+                metadata.DataType = (NodeId)values[2].AsBoxedObject();
 
                 if (!values[3].IsNull)
                 {
-                    metadata.ValueRank = (int)values[3].Value;
+                    metadata.ValueRank = (int)values[3].AsBoxedObject();
                 }
 
-                metadata.ArrayDimensions = values[4].Value switch
+                metadata.ArrayDimensions = values[4].AsBoxedObject() switch
                 {
                     ArrayOf<uint> dimensions => dimensions,
                     IList<uint> dimensions => dimensions.ToArrayOf(),
@@ -949,17 +949,17 @@ namespace Opc.Ua.Sample
 
                 if (!values[5].IsNull && !values[6].IsNull)
                 {
-                    metadata.AccessLevel = (byte)(((byte)values[5].Value) & ((byte)values[6].Value));
+                    metadata.AccessLevel = (byte)(((byte)values[5].AsBoxedObject()) & ((byte)values[6].AsBoxedObject()));
                 }
 
                 if (!values[7].IsNull)
                 {
-                    metadata.EventNotifier = (byte)values[7].Value;
+                    metadata.EventNotifier = (byte)values[7].AsBoxedObject();
                 }
 
                 if (!values[8].IsNull && !values[9].IsNull)
                 {
-                    metadata.Executable = (((bool)values[8].Value) && ((bool)values[9].Value));
+                    metadata.Executable = (((bool)values[8].AsBoxedObject()) && ((bool)values[9].AsBoxedObject()));
                 }
 
                 // get instance references.
@@ -2446,7 +2446,7 @@ namespace Opc.Ua.Sample
                     return StatusCodes.BadMonitoredItemFilterUnsupported;
                 }
 
-                range = euRange.Value.Value as Range;
+                range = euRange.Value.AsBoxedObject() as Range;
 
                 if (range == null)
                 {
@@ -2517,7 +2517,7 @@ namespace Opc.Ua.Sample
             DataChangeFilter filter = null;
             Range range = null;
 
-            if (!ExtensionObject.IsNull(parameters.Filter))
+            if (!(parameters.Filter).IsNull)
             {
                 error = ValidateDataChangeFilter(
                     context,
@@ -2778,7 +2778,7 @@ namespace Opc.Ua.Sample
             DataChangeFilter filter = null;
             Range range = null;
 
-            if (!ExtensionObject.IsNull(parameters.Filter))
+            if (!(parameters.Filter).IsNull)
             {
                 error = ValidateDataChangeFilter(
                     context,

--- a/Samples/Opc.Ua.Sample/Boiler/BoilerNodeManager.cs
+++ b/Samples/Opc.Ua.Sample/Boiler/BoilerNodeManager.cs
@@ -177,7 +177,7 @@ namespace Boiler
         {
             LocalizedText displayName = instance.DisplayName;
 
-            if (displayName != null)
+            if (!displayName.IsNull)
             {
                 string text = displayName.Text;
 
@@ -221,7 +221,12 @@ namespace Boiler
                 return predefinedNode;
             }
 
-            switch ((uint)typeId.Identifier)
+            if (!typeId.TryGetValue(out uint numericTypeId))
+            {
+                return predefinedNode;
+            }
+
+            switch (numericTypeId)
             {
                 case ObjectTypes.BoilerType:
                 {

--- a/Samples/Opc.Ua.Sample/Boiler/BoilerState.cs
+++ b/Samples/Opc.Ua.Sample/Boiler/BoilerState.cs
@@ -288,7 +288,7 @@ namespace Boiler
             }
             catch (Exception e)
             {
-                Utils.LogError(e, "Unexpected error during boiler simulation.");
+                m_simulationContext?.Telemetry?.CreateLogger<BoilerState>().LogError(e, "Unexpected error during boiler simulation.");
             }
         }
         #endregion

--- a/Samples/Opc.Ua.Sample/MemoryBuffer/MemoryBufferBrowser.cs
+++ b/Samples/Opc.Ua.Sample/MemoryBuffer/MemoryBufferBrowser.cs
@@ -137,7 +137,7 @@ namespace MemoryBuffer
             MemoryTagState tag = null;
 
             // check if a specific browse name is requested.
-            if (!QualifiedName.IsNull(base.BrowseName))
+            if (!(base.BrowseName).IsNull)
             {
                 // check if match found previously.
                 if (m_position == UInt32.MaxValue)

--- a/Samples/Opc.Ua.Sample/MemoryBuffer/MemoryBufferMonitoredItem.cs
+++ b/Samples/Opc.Ua.Sample/MemoryBuffer/MemoryBufferMonitoredItem.cs
@@ -65,7 +65,7 @@ namespace MemoryBuffer
         :
             base(
                 server,
-                nodeManager,
+                (IAsyncNodeManager)nodeManager,
                 mangerHandle,
                 subscriptionId,
                 id,

--- a/Samples/Opc.Ua.Sample/MemoryBuffer/MemoryBufferMonitoredItem.cs
+++ b/Samples/Opc.Ua.Sample/MemoryBuffer/MemoryBufferMonitoredItem.cs
@@ -65,7 +65,7 @@ namespace MemoryBuffer
         :
             base(
                 server,
-                (IAsyncNodeManager)nodeManager,
+                nodeManager.ToAsyncNodeManager(),
                 mangerHandle,
                 subscriptionId,
                 id,

--- a/Samples/Opc.Ua.Sample/MemoryBuffer/MemoryBufferNodeManager.cs
+++ b/Samples/Opc.Ua.Sample/MemoryBuffer/MemoryBufferNodeManager.cs
@@ -313,7 +313,7 @@ namespace MemoryBuffer
             }
 
             // data encoding not supported.
-            if (!QualifiedName.IsNull(itemToCreate.ItemToMonitor.DataEncoding))
+            if (!(itemToCreate.ItemToMonitor.DataEncoding).IsNull)
             {
                 return StatusCodes.BadDataEncodingUnsupported;
             }

--- a/Samples/Opc.Ua.Sample/MemoryBuffer/MemoryBufferNodeManager.cs
+++ b/Samples/Opc.Ua.Sample/MemoryBuffer/MemoryBufferNodeManager.cs
@@ -191,7 +191,7 @@ namespace MemoryBuffer
                     return null;
                 }
 
-                string id = nodeId.Identifier as string;
+                string id = nodeId.TryGetValue(out string identifier) ? identifier : null;
 
                 if (id != null)
                 {

--- a/Samples/Opc.Ua.Sample/MemoryBuffer/MemoryBufferState.cs
+++ b/Samples/Opc.Ua.Sample/MemoryBuffer/MemoryBufferState.cs
@@ -243,7 +243,7 @@ namespace MemoryBuffer
                 return StatusCodes.BadIndexRangeInvalid;
             }
 
-            if (!QualifiedName.IsNull(dataEncoding))
+            if (!(dataEncoding).IsNull)
             {
                 return StatusCodes.BadDataEncodingUnsupported;
             }
@@ -295,7 +295,7 @@ namespace MemoryBuffer
                 return StatusCodes.BadIndexRangeInvalid;
             }
 
-            if (!QualifiedName.IsNull(dataEncoding))
+            if (!(dataEncoding).IsNull)
             {
                 return StatusCodes.BadDataEncodingUnsupported;
             }
@@ -331,7 +331,7 @@ namespace MemoryBuffer
                 {
                     case BuiltInType.UInt32:
                     {
-                        uint? valueToWrite = value.Value as uint?;
+                        uint? valueToWrite = value.AsBoxedObject() as uint?;
 
                         if (valueToWrite == null)
                         {
@@ -344,7 +344,7 @@ namespace MemoryBuffer
 
                     case BuiltInType.Double:
                     {
-                        double? valueToWrite = value.Value as double?;
+                        double? valueToWrite = value.AsBoxedObject() as double?;
 
                         if (valueToWrite == null)
                         {

--- a/Samples/Opc.Ua.Sample/SampleServer.UserAuthentication.cs
+++ b/Samples/Opc.Ua.Sample/SampleServer.UserAuthentication.cs
@@ -70,10 +70,10 @@ namespace Opc.Ua.Sample
         private void SessionManager_ImpersonateUser(ISession session, ImpersonateEventArgs args)
         {
             // check for a WSS token.
-            IssuedIdentityToken wssToken = args.NewIdentity as IssuedIdentityToken;
+            IssuedIdentityToken wssToken = args.UserIdentityTokenHandler?.Token as IssuedIdentityToken;
 
             // check for a user name token.
-            UserNameIdentityToken userNameToken = args.NewIdentity as UserNameIdentityToken;
+            UserNameIdentityToken userNameToken = args.UserIdentityTokenHandler?.Token as UserNameIdentityToken;
 
             if (userNameToken != null)
             {
@@ -87,7 +87,7 @@ namespace Opc.Ua.Sample
             }
 
             // check for x509 user token.
-            X509IdentityToken x509Token = args.NewIdentity as X509IdentityToken;
+            X509IdentityToken x509Token = args.UserIdentityTokenHandler?.Token as X509IdentityToken;
 
             if (x509Token != null)
             {

--- a/Samples/Opc.Ua.Sample/SampleServer.cs
+++ b/Samples/Opc.Ua.Sample/SampleServer.cs
@@ -79,7 +79,12 @@ namespace Opc.Ua.Sample
             base.OnServerStarted(server);
 
             // request notifications when the user identity is changed. all valid users are accepted by default.
+            // TODO: ISessionManager.ImpersonateUser is replaced by IUserTokenAuthenticator +
+            // IServerIdentityRegistry. Migrating the sample's impersonation flow is tracked
+            // separately. See issue #724.
+#pragma warning disable CS0618 // Type or member is obsolete
             server.SessionManager.ImpersonateUser += new ImpersonateEventHandler(SessionManager_ImpersonateUser);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         /// <summary>

--- a/Samples/Opc.Ua.Sample/TestData/HistoryArchive.cs
+++ b/Samples/Opc.Ua.Sample/TestData/HistoryArchive.cs
@@ -181,7 +181,7 @@ namespace TestData
                         {
                             case BuiltInType.Int32:
                             {
-                                int lastValue = (int)record.RawData[record.RawData.Count - 1].Value.Value;
+                                int lastValue = (int)record.RawData[record.RawData.Count - 1].Value.WrappedValue.AsBoxedObject();
                                 value = Variant.From(lastValue + 1);
                                 break;
                             }

--- a/Samples/Opc.Ua.Sample/TestData/HistoryDataReader.cs
+++ b/Samples/Opc.Ua.Sample/TestData/HistoryDataReader.cs
@@ -242,7 +242,7 @@ namespace TestData
                 }
 
                 // apply the data encoding.
-                if (!QualifiedName.IsNull(dataEncoding))
+                if (!(dataEncoding).IsNull)
                 {
                     wrappedValue = Variant.Null;
                     statusCode = StatusCodes.BadDataEncodingUnsupported;

--- a/Samples/Opc.Ua.Sample/TestData/TestDataNodeManager.cs
+++ b/Samples/Opc.Ua.Sample/TestData/TestDataNodeManager.cs
@@ -106,12 +106,67 @@ namespace TestData
         {
             lock (Lock)
             {
-                variable.Value = new Variant(value);
+                variable.Value = ToVariant(value);
                 variable.StatusCode = statusCode;
                 variable.Timestamp = timestamp;
 
                 // notifies any monitored items that the value has changed.
                 variable.ClearChangeMasks(SystemContext, false);
+            }
+        }
+
+        private static Variant ToVariant(object value)
+        {
+            switch (value)
+            {
+                case null: return Variant.Null;
+                case Variant v: return v;
+                case bool v: return Variant.From(v);
+                case sbyte v: return Variant.From(v);
+                case byte v: return Variant.From(v);
+                case short v: return Variant.From(v);
+                case ushort v: return Variant.From(v);
+                case int v: return Variant.From(v);
+                case uint v: return Variant.From(v);
+                case long v: return Variant.From(v);
+                case ulong v: return Variant.From(v);
+                case float v: return Variant.From(v);
+                case double v: return Variant.From(v);
+                case string v: return Variant.From(v);
+                case DateTime v: return Variant.From(new DateTimeUtc(v));
+                case Guid v: return Variant.From(new Uuid(v));
+                case ByteString v: return Variant.From(v);
+                case byte[] v: return Variant.From(v.ToByteString());
+                case XmlElement v: return Variant.From(v);
+                case NodeId v: return Variant.From(v);
+                case ExpandedNodeId v: return Variant.From(v);
+                case StatusCode v: return Variant.From(v);
+                case QualifiedName v: return Variant.From(v);
+                case LocalizedText v: return Variant.From(v);
+                case ExtensionObject v: return Variant.From(v);
+                case bool[] v: return Variant.From(new ArrayOf<bool>(v));
+                case sbyte[] v: return Variant.From(new ArrayOf<sbyte>(v));
+                case short[] v: return Variant.From(new ArrayOf<short>(v));
+                case ushort[] v: return Variant.From(new ArrayOf<ushort>(v));
+                case int[] v: return Variant.From(new ArrayOf<int>(v));
+                case uint[] v: return Variant.From(new ArrayOf<uint>(v));
+                case long[] v: return Variant.From(new ArrayOf<long>(v));
+                case ulong[] v: return Variant.From(new ArrayOf<ulong>(v));
+                case float[] v: return Variant.From(new ArrayOf<float>(v));
+                case double[] v: return Variant.From(new ArrayOf<double>(v));
+                case string[] v: return Variant.From(new ArrayOf<string>(v));
+                case DateTime[] v: return Variant.From(new ArrayOf<DateTimeUtc>(Array.ConvertAll(v, x => new DateTimeUtc(x))));
+                case Guid[] v: return Variant.From(new ArrayOf<Uuid>(Array.ConvertAll(v, x => new Uuid(x))));
+                case ByteString[] v: return Variant.From(new ArrayOf<ByteString>(v));
+                case XmlElement[] v: return Variant.From(new ArrayOf<XmlElement>(v));
+                case NodeId[] v: return Variant.From(new ArrayOf<NodeId>(v));
+                case ExpandedNodeId[] v: return Variant.From(new ArrayOf<ExpandedNodeId>(v));
+                case StatusCode[] v: return Variant.From(new ArrayOf<StatusCode>(v));
+                case QualifiedName[] v: return Variant.From(new ArrayOf<QualifiedName>(v));
+                case LocalizedText[] v: return Variant.From(new ArrayOf<LocalizedText>(v));
+                case ExtensionObject[] v: return Variant.From(new ArrayOf<ExtensionObject>(v));
+                case IEncodeable v: return Variant.From(new ExtensionObject(v, false));
+                default: return Variant.Null;
             }
         }
         #endregion
@@ -215,7 +270,12 @@ namespace TestData
                 return predefinedNode;
             }
 
-            switch ((uint)typeId.Identifier)
+            if (!typeId.TryGetValue(out uint numericTypeId))
+            {
+                return predefinedNode;
+            }
+
+            switch (numericTypeId)
             {
                 case ObjectTypes.TestSystemConditionType:
                 {

--- a/Samples/Opc.Ua.Sample/TestData/TestDataNodeManager.cs
+++ b/Samples/Opc.Ua.Sample/TestData/TestDataNodeManager.cs
@@ -136,7 +136,7 @@ namespace TestData
                 case DateTime v: return Variant.From(new DateTimeUtc(v));
                 case Guid v: return Variant.From(new Uuid(v));
                 case ByteString v: return Variant.From(v);
-                case byte[] v: return Variant.From(v.ToByteString());
+                case byte[] v: return Variant.From(new ArrayOf<byte>(v));
                 case XmlElement v: return Variant.From(v);
                 case NodeId v: return Variant.From(v);
                 case ExpandedNodeId v: return Variant.From(v);
@@ -166,6 +166,7 @@ namespace TestData
                 case LocalizedText[] v: return Variant.From(new ArrayOf<LocalizedText>(v));
                 case ExtensionObject[] v: return Variant.From(new ArrayOf<ExtensionObject>(v));
                 case IEncodeable v: return Variant.From(new ExtensionObject(v, false));
+                case Variant[] v: return Variant.From(new ArrayOf<Variant>(v));
                 default: return Variant.Null;
             }
         }

--- a/Samples/Opc.Ua.Sample/TestData/TestDataObjectState.cs
+++ b/Samples/Opc.Ua.Sample/TestData/TestDataObjectState.cs
@@ -188,7 +188,7 @@ namespace TestData
                 case DateTime v: return Variant.From(new DateTimeUtc(v));
                 case Guid v: return Variant.From(new Uuid(v));
                 case ByteString v: return Variant.From(v);
-                case byte[] v: return Variant.From(v.ToByteString());
+                case byte[] v: return Variant.From(new ArrayOf<byte>(v));
                 case XmlElement v: return Variant.From(v);
                 case NodeId v: return Variant.From(v);
                 case ExpandedNodeId v: return Variant.From(v);
@@ -218,6 +218,7 @@ namespace TestData
                 case LocalizedText[] v: return Variant.From(new ArrayOf<LocalizedText>(v));
                 case ExtensionObject[] v: return Variant.From(new ArrayOf<ExtensionObject>(v));
                 case IEncodeable v: return Variant.From(new ExtensionObject(v, false));
+                case Variant[] v: return Variant.From(new ArrayOf<Variant>(v));
                 default: return Variant.Null;
             }
         }

--- a/Samples/Opc.Ua.Sample/TestData/TestDataObjectState.cs
+++ b/Samples/Opc.Ua.Sample/TestData/TestDataObjectState.cs
@@ -82,11 +82,11 @@ namespace TestData
             {
                 if (context.TypeTable.IsTypeOf(variable.DataType, Opc.Ua.DataTypeIds.UInteger))
                 {
-                    euRange.Value = new Variant(new Range(250, 50));
+                    euRange.Value = new Variant(new ExtensionObject(new Range(250, 50), false));
                 }
                 else
                 {
-                    euRange.Value = new Variant(new Range(100, -100));
+                    euRange.Value = new Variant(new ExtensionObject(new Range(100, -100), false));
                 }
             }
 
@@ -162,9 +162,64 @@ namespace TestData
         /// </summary>
         protected void GenerateValue(TestDataSystem system, BaseVariableState variable)
         {
-            variable.Value = new Variant(system.ReadValue(variable));
+            variable.Value = ToVariant(system.ReadValue(variable));
             variable.Timestamp = DateTime.UtcNow;
             variable.StatusCode = StatusCodes.Good;
+        }
+
+        private static Variant ToVariant(object value)
+        {
+            switch (value)
+            {
+                case null: return Variant.Null;
+                case Variant v: return v;
+                case bool v: return Variant.From(v);
+                case sbyte v: return Variant.From(v);
+                case byte v: return Variant.From(v);
+                case short v: return Variant.From(v);
+                case ushort v: return Variant.From(v);
+                case int v: return Variant.From(v);
+                case uint v: return Variant.From(v);
+                case long v: return Variant.From(v);
+                case ulong v: return Variant.From(v);
+                case float v: return Variant.From(v);
+                case double v: return Variant.From(v);
+                case string v: return Variant.From(v);
+                case DateTime v: return Variant.From(new DateTimeUtc(v));
+                case Guid v: return Variant.From(new Uuid(v));
+                case ByteString v: return Variant.From(v);
+                case byte[] v: return Variant.From(v.ToByteString());
+                case XmlElement v: return Variant.From(v);
+                case NodeId v: return Variant.From(v);
+                case ExpandedNodeId v: return Variant.From(v);
+                case StatusCode v: return Variant.From(v);
+                case QualifiedName v: return Variant.From(v);
+                case LocalizedText v: return Variant.From(v);
+                case ExtensionObject v: return Variant.From(v);
+                case bool[] v: return Variant.From(new ArrayOf<bool>(v));
+                case sbyte[] v: return Variant.From(new ArrayOf<sbyte>(v));
+                case short[] v: return Variant.From(new ArrayOf<short>(v));
+                case ushort[] v: return Variant.From(new ArrayOf<ushort>(v));
+                case int[] v: return Variant.From(new ArrayOf<int>(v));
+                case uint[] v: return Variant.From(new ArrayOf<uint>(v));
+                case long[] v: return Variant.From(new ArrayOf<long>(v));
+                case ulong[] v: return Variant.From(new ArrayOf<ulong>(v));
+                case float[] v: return Variant.From(new ArrayOf<float>(v));
+                case double[] v: return Variant.From(new ArrayOf<double>(v));
+                case string[] v: return Variant.From(new ArrayOf<string>(v));
+                case DateTime[] v: return Variant.From(new ArrayOf<DateTimeUtc>(Array.ConvertAll(v, x => new DateTimeUtc(x))));
+                case Guid[] v: return Variant.From(new ArrayOf<Uuid>(Array.ConvertAll(v, x => new Uuid(x))));
+                case ByteString[] v: return Variant.From(new ArrayOf<ByteString>(v));
+                case XmlElement[] v: return Variant.From(new ArrayOf<XmlElement>(v));
+                case NodeId[] v: return Variant.From(new ArrayOf<NodeId>(v));
+                case ExpandedNodeId[] v: return Variant.From(new ArrayOf<ExpandedNodeId>(v));
+                case StatusCode[] v: return Variant.From(new ArrayOf<StatusCode>(v));
+                case QualifiedName[] v: return Variant.From(new ArrayOf<QualifiedName>(v));
+                case LocalizedText[] v: return Variant.From(new ArrayOf<LocalizedText>(v));
+                case ExtensionObject[] v: return Variant.From(new ArrayOf<ExtensionObject>(v));
+                case IEncodeable v: return Variant.From(new ExtensionObject(v, false));
+                default: return Variant.Null;
+            }
         }
 
         /// <summary>
@@ -245,7 +300,7 @@ namespace TestData
 
             try
             {
-                value = new Variant(system.ReadValue(variable));
+                value = ToVariant(system.ReadValue(variable));
 
                 statusCode = StatusCodes.Good;
                 timestamp = DateTime.UtcNow;

--- a/Samples/Opc.Ua.Sample/TestData/TestDataObjectState.cs
+++ b/Samples/Opc.Ua.Sample/TestData/TestDataObjectState.cs
@@ -111,14 +111,14 @@ namespace TestData
                     return ServiceResult.Good;
                 }
 
-                Range range = euRange.Value.Value as Range;
+                Range range = euRange.Value.AsBoxedObject() as Range;
 
                 if (range == null)
                 {
                     return ServiceResult.Good;
                 }
 
-                Array array = value.Value as Array;
+                Array array = value.AsBoxedObject() as Array;
 
                 if (array != null)
                 {
@@ -128,7 +128,7 @@ namespace TestData
 
                         if (typeof(Variant).IsInstanceOfType(element))
                         {
-                            element = ((Variant)element).Value;
+                            element = ((Variant)element).AsBoxedObject();
                         }
 
                         double elementNumber = Convert.ToDouble(element);
@@ -142,7 +142,7 @@ namespace TestData
                     return ServiceResult.Good;
                 }
 
-                double number = Convert.ToDouble(value.Value);
+                double number = Convert.ToDouble(value.AsBoxedObject());
 
                 if (number > range.High || number < range.Low)
                 {

--- a/Samples/Opc.Ua.Sample/TestData/TestDataSystem.cs
+++ b/Samples/Opc.Ua.Sample/TestData/TestDataSystem.cs
@@ -327,7 +327,7 @@ namespace TestData
                     case TestData.Variables.ScalarValueObjectType_VariantValue:
                     case TestData.Variables.UserScalarValueObjectType_VariantValue:
                     {
-                        return m_generator.GetRandomVariant(false).Value;
+                        return m_generator.GetRandomVariant(false).AsBoxedObject();
                     }
 
                     case TestData.Variables.ScalarValueObjectType_StructureValue:
@@ -342,34 +342,34 @@ namespace TestData
 
                     case TestData.Variables.ScalarValueObjectType_NumberValue:
                     {
-                        return m_generator.GetRandomScalar(BuiltInType.Number, false).Value;
+                        return m_generator.GetRandomScalar(BuiltInType.Number, false).AsBoxedObject();
                     }
 
                     case TestData.Variables.ScalarValueObjectType_IntegerValue:
                     {
-                        return m_generator.GetRandomScalar(BuiltInType.Integer, false).Value;
+                        return m_generator.GetRandomScalar(BuiltInType.Integer, false).AsBoxedObject();
                     }
 
                     case TestData.Variables.ScalarValueObjectType_UIntegerValue:
                     {
-                        return m_generator.GetRandomScalar(BuiltInType.UInteger, false).Value;
+                        return m_generator.GetRandomScalar(BuiltInType.UInteger, false).AsBoxedObject();
                     }
 
                     case TestData.Variables.ArrayValueObjectType_BooleanValue:
                     case TestData.Variables.UserArrayValueObjectType_BooleanValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.Boolean, 100, false, false).Value;
+                        return m_generator.GetRandomArray(BuiltInType.Boolean, 100, false, false).AsBoxedObject();
                     }
 
                     case TestData.Variables.ArrayValueObjectType_SByteValue:
                     case TestData.Variables.UserArrayValueObjectType_SByteValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.SByte, 100, false, false).Value;
+                        return m_generator.GetRandomArray(BuiltInType.SByte, 100, false, false).AsBoxedObject();
                     }
 
                     case TestData.Variables.AnalogArrayValueObjectType_SByteValue:
                     {
-                        sbyte[] values = (sbyte[])m_generator.GetRandomArray(BuiltInType.SByte, 100, false, false).Value;
+                        sbyte[] values = (sbyte[])m_generator.GetRandomArray(BuiltInType.SByte, 100, false, false).AsBoxedObject();
 
                         for (int ii = 0; ii < values.Length; ii++)
                         {
@@ -382,12 +382,12 @@ namespace TestData
                     case TestData.Variables.ArrayValueObjectType_ByteValue:
                     case TestData.Variables.UserArrayValueObjectType_ByteValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.Byte, 100, false, false).Value;
+                        return m_generator.GetRandomArray(BuiltInType.Byte, 100, false, false).AsBoxedObject();
                     }
 
                     case TestData.Variables.AnalogArrayValueObjectType_ByteValue:
                     {
-                        byte[] values = (byte[])m_generator.GetRandomArray(BuiltInType.Byte, 100, false, false).Value;
+                        byte[] values = (byte[])m_generator.GetRandomArray(BuiltInType.Byte, 100, false, false).AsBoxedObject();
 
                         for (int ii = 0; ii < values.Length; ii++)
                         {
@@ -400,12 +400,12 @@ namespace TestData
                     case TestData.Variables.ArrayValueObjectType_Int16Value:
                     case TestData.Variables.UserArrayValueObjectType_Int16Value:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.Int16, 100, false, false).Value;
+                        return m_generator.GetRandomArray(BuiltInType.Int16, 100, false, false).AsBoxedObject();
                     }
 
                     case TestData.Variables.AnalogArrayValueObjectType_Int16Value:
                     {
-                        short[] values = (short[])m_generator.GetRandomArray(BuiltInType.Int16, 100, false, false).Value;
+                        short[] values = (short[])m_generator.GetRandomArray(BuiltInType.Int16, 100, false, false).AsBoxedObject();
 
                         for (int ii = 0; ii < values.Length; ii++)
                         {
@@ -418,12 +418,12 @@ namespace TestData
                     case TestData.Variables.ArrayValueObjectType_UInt16Value:
                     case TestData.Variables.UserArrayValueObjectType_UInt16Value:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.UInt16, 100, false, false).Value;
+                        return m_generator.GetRandomArray(BuiltInType.UInt16, 100, false, false).AsBoxedObject();
                     }
 
                     case TestData.Variables.AnalogArrayValueObjectType_UInt16Value:
                     {
-                        ushort[] values = (ushort[])m_generator.GetRandomArray(BuiltInType.UInt16, 100, false, false).Value;
+                        ushort[] values = (ushort[])m_generator.GetRandomArray(BuiltInType.UInt16, 100, false, false).AsBoxedObject();
 
                         for (int ii = 0; ii < values.Length; ii++)
                         {
@@ -436,13 +436,13 @@ namespace TestData
                     case TestData.Variables.ArrayValueObjectType_Int32Value:
                     case TestData.Variables.UserArrayValueObjectType_Int32Value:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.Int32, 100, false, false).Value;
+                        return m_generator.GetRandomArray(BuiltInType.Int32, 100, false, false).AsBoxedObject();
                     }
 
                     case TestData.Variables.AnalogArrayValueObjectType_Int32Value:
                     case TestData.Variables.AnalogArrayValueObjectType_IntegerValue:
                     {
-                        int[] values = (int[])m_generator.GetRandomArray(BuiltInType.Int32, 100, false, false).Value;
+                        int[] values = (int[])m_generator.GetRandomArray(BuiltInType.Int32, 100, false, false).AsBoxedObject();
 
                         for (int ii = 0; ii < values.Length; ii++)
                         {
@@ -455,13 +455,13 @@ namespace TestData
                     case TestData.Variables.ArrayValueObjectType_UInt32Value:
                     case TestData.Variables.UserArrayValueObjectType_UInt32Value:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.UInt32, 100, false, false).Value;
+                        return m_generator.GetRandomArray(BuiltInType.UInt32, 100, false, false).AsBoxedObject();
                     }
 
                     case TestData.Variables.AnalogArrayValueObjectType_UInt32Value:
                     case TestData.Variables.AnalogArrayValueObjectType_UIntegerValue:
                     {
-                        uint[] values = (uint[])m_generator.GetRandomArray(BuiltInType.UInt32, 100, false, false).Value;
+                        uint[] values = (uint[])m_generator.GetRandomArray(BuiltInType.UInt32, 100, false, false).AsBoxedObject();
 
                         for (int ii = 0; ii < values.Length; ii++)
                         {
@@ -474,12 +474,12 @@ namespace TestData
                     case TestData.Variables.ArrayValueObjectType_Int64Value:
                     case TestData.Variables.UserArrayValueObjectType_Int64Value:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.Int64, 100, false, false).Value;
+                        return m_generator.GetRandomArray(BuiltInType.Int64, 100, false, false).AsBoxedObject();
                     }
 
                     case TestData.Variables.AnalogArrayValueObjectType_Int64Value:
                     {
-                        long[] values = (long[])m_generator.GetRandomArray(BuiltInType.Int64, 100, false, false).Value;
+                        long[] values = (long[])m_generator.GetRandomArray(BuiltInType.Int64, 100, false, false).AsBoxedObject();
 
                         for (int ii = 0; ii < values.Length; ii++)
                         {
@@ -492,12 +492,12 @@ namespace TestData
                     case TestData.Variables.ArrayValueObjectType_UInt64Value:
                     case TestData.Variables.UserArrayValueObjectType_UInt64Value:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.UInt64, 100, false, false).Value;
+                        return m_generator.GetRandomArray(BuiltInType.UInt64, 100, false, false).AsBoxedObject();
                     }
 
                     case TestData.Variables.AnalogArrayValueObjectType_UInt64Value:
                     {
-                        ulong[] values = (ulong[])m_generator.GetRandomArray(BuiltInType.UInt64, 100, false, false).Value;
+                        ulong[] values = (ulong[])m_generator.GetRandomArray(BuiltInType.UInt64, 100, false, false).AsBoxedObject();
 
                         for (int ii = 0; ii < values.Length; ii++)
                         {
@@ -510,12 +510,12 @@ namespace TestData
                     case TestData.Variables.ArrayValueObjectType_FloatValue:
                     case TestData.Variables.UserArrayValueObjectType_FloatValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.Float, 100, false, false).Value;
+                        return m_generator.GetRandomArray(BuiltInType.Float, 100, false, false).AsBoxedObject();
                     }
 
                     case TestData.Variables.AnalogArrayValueObjectType_FloatValue:
                     {
-                        float[] values = (float[])m_generator.GetRandomArray(BuiltInType.Float, 100, false, false).Value;
+                        float[] values = (float[])m_generator.GetRandomArray(BuiltInType.Float, 100, false, false).AsBoxedObject();
 
                         for (int ii = 0; ii < values.Length; ii++)
                         {
@@ -528,13 +528,13 @@ namespace TestData
                     case TestData.Variables.ArrayValueObjectType_DoubleValue:
                     case TestData.Variables.UserArrayValueObjectType_DoubleValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.Double, 100, false, false).Value;
+                        return m_generator.GetRandomArray(BuiltInType.Double, 100, false, false).AsBoxedObject();
                     }
 
                     case TestData.Variables.AnalogArrayValueObjectType_DoubleValue:
                     case TestData.Variables.AnalogArrayValueObjectType_NumberValue:
                     {
-                        double[] values = (double[])m_generator.GetRandomArray(BuiltInType.Double, 100, false, false).Value;
+                        double[] values = (double[])m_generator.GetRandomArray(BuiltInType.Double, 100, false, false).AsBoxedObject();
 
                         for (int ii = 0; ii < values.Length; ii++)
                         {
@@ -547,72 +547,72 @@ namespace TestData
                     case TestData.Variables.ArrayValueObjectType_StringValue:
                     case TestData.Variables.UserArrayValueObjectType_StringValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.String, 100, false, false).Value;
+                        return m_generator.GetRandomArray(BuiltInType.String, 100, false, false).AsBoxedObject();
                     }
 
                     case TestData.Variables.ArrayValueObjectType_DateTimeValue:
                     case TestData.Variables.UserArrayValueObjectType_DateTimeValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.DateTime, 100, false, false).Value;
+                        return m_generator.GetRandomArray(BuiltInType.DateTime, 100, false, false).AsBoxedObject();
                     }
 
                     case TestData.Variables.ArrayValueObjectType_GuidValue:
                     case TestData.Variables.UserArrayValueObjectType_GuidValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.Guid, 100, false, false).Value;
+                        return m_generator.GetRandomArray(BuiltInType.Guid, 100, false, false).AsBoxedObject();
                     }
 
                     case TestData.Variables.ArrayValueObjectType_ByteStringValue:
                     case TestData.Variables.UserArrayValueObjectType_ByteStringValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.ByteString, 100, false, false).Value;
+                        return m_generator.GetRandomArray(BuiltInType.ByteString, 100, false, false).AsBoxedObject();
                     }
 
                     case TestData.Variables.ArrayValueObjectType_XmlElementValue:
                     case TestData.Variables.UserArrayValueObjectType_XmlElementValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.XmlElement, 100, false, false).Value;
+                        return m_generator.GetRandomArray(BuiltInType.XmlElement, 100, false, false).AsBoxedObject();
                     }
 
                     case TestData.Variables.ArrayValueObjectType_NodeIdValue:
                     case TestData.Variables.UserArrayValueObjectType_NodeIdValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.NodeId, 100, false, false).Value;
+                        return m_generator.GetRandomArray(BuiltInType.NodeId, 100, false, false).AsBoxedObject();
                     }
 
                     case TestData.Variables.ArrayValueObjectType_ExpandedNodeIdValue:
                     case TestData.Variables.UserArrayValueObjectType_ExpandedNodeIdValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.ExpandedNodeId, 100, false, false).Value;
+                        return m_generator.GetRandomArray(BuiltInType.ExpandedNodeId, 100, false, false).AsBoxedObject();
                     }
 
                     case TestData.Variables.ArrayValueObjectType_QualifiedNameValue:
                     case TestData.Variables.UserArrayValueObjectType_QualifiedNameValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.QualifiedName, 100, false, false).Value;
+                        return m_generator.GetRandomArray(BuiltInType.QualifiedName, 100, false, false).AsBoxedObject();
                     }
 
                     case TestData.Variables.ArrayValueObjectType_LocalizedTextValue:
                     case TestData.Variables.UserArrayValueObjectType_LocalizedTextValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.LocalizedText, 100, false, false).Value;
+                        return m_generator.GetRandomArray(BuiltInType.LocalizedText, 100, false, false).AsBoxedObject();
                     }
 
                     case TestData.Variables.ArrayValueObjectType_StatusCodeValue:
                     case TestData.Variables.UserArrayValueObjectType_StatusCodeValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.StatusCode, 100, false, false).Value;
+                        return m_generator.GetRandomArray(BuiltInType.StatusCode, 100, false, false).AsBoxedObject();
                     }
 
                     case TestData.Variables.ArrayValueObjectType_VariantValue:
                     case TestData.Variables.UserArrayValueObjectType_VariantValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.Variant, 100, false, false).Value;
+                        return m_generator.GetRandomArray(BuiltInType.Variant, 100, false, false).AsBoxedObject();
                     }
 
                     case TestData.Variables.ArrayValueObjectType_StructureValue:
                     {
-                        ExtensionObject[] values = (ExtensionObject[])m_generator.GetRandomArray(BuiltInType.ExtensionObject, 10, false, false).Value;
+                        ExtensionObject[] values = (ExtensionObject[])m_generator.GetRandomArray(BuiltInType.ExtensionObject, 10, false, false).AsBoxedObject();
 
                         for (int ii = 0; values != null && ii < values.Length; ii++)
                         {
@@ -624,22 +624,22 @@ namespace TestData
 
                     case TestData.Variables.ArrayValueObjectType_EnumerationValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.Int32, 100, false, false).Value;
+                        return m_generator.GetRandomArray(BuiltInType.Int32, 100, false, false).AsBoxedObject();
                     }
 
                     case TestData.Variables.ArrayValueObjectType_NumberValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.Number, 100, false, false).Value;
+                        return m_generator.GetRandomArray(BuiltInType.Number, 100, false, false).AsBoxedObject();
                     }
 
                     case TestData.Variables.ArrayValueObjectType_IntegerValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.Integer, 100, false, false).Value;
+                        return m_generator.GetRandomArray(BuiltInType.Integer, 100, false, false).AsBoxedObject();
                     }
 
                     case TestData.Variables.ArrayValueObjectType_UIntegerValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.UInteger, 100, false, false).Value;
+                        return m_generator.GetRandomArray(BuiltInType.UInteger, 100, false, false).AsBoxedObject();
                     }
                 }
 

--- a/Samples/Opc.Ua.Sample/TestData/TestDataSystem.cs
+++ b/Samples/Opc.Ua.Sample/TestData/TestDataSystem.cs
@@ -770,7 +770,7 @@ namespace TestData
         {
             if (m_logger.IsEnabled(LogLevel.Trace))
             {
-                m_logger.LogTrace("DoSample HiRes={HiResNow:ss.ffff} Now={Now:ss.ffff}", HiResClock.UtcNow, DateTime.UtcNow);
+                m_logger.LogTrace("DoSample HiRes={HiResNow:ss.ffff} Now={Now:ss.ffff}", DateTime.UtcNow, DateTime.UtcNow);
             }
 
             Queue<Sample> samples = new Queue<Sample>();

--- a/Samples/ReferenceServer/Aggregates/AggregateManager.cs
+++ b/Samples/ReferenceServer/Aggregates/AggregateManager.cs
@@ -95,7 +95,7 @@ namespace Opc.Ua.Aggregates
         /// <returns>True if the aggregate is supported.</returns>
         public bool IsSupported(NodeId aggregateId)
         {
-            if (NodeId.IsNull(aggregateId))
+            if ((aggregateId).IsNull)
             {
                 return false;
             }
@@ -178,7 +178,7 @@ namespace Opc.Ua.Aggregates
             double processingInterval,
             AggregateConfiguration configuration)
         {
-            if (NodeId.IsNull(aggregateId))
+            if ((aggregateId).IsNull)
             {
                 return null;
             }

--- a/Samples/ReferenceServer/Aggregates/Experiment.cs
+++ b/Samples/ReferenceServer/Aggregates/Experiment.cs
@@ -249,13 +249,13 @@ namespace Quickstarts.ReferenceServer
                 if (m_timeFlowsBackward)
                 {
                     StatusCode statusCode = (lastBoundBad) ? StatusCodes.UncertainDataSubNormal : StatusCodes.Good;
-                    statusCode = statusCode.SetAggregateBits(AggregateBits.Interpolated);
+                    statusCode = statusCode.WithAggregateBits(AggregateBits.Interpolated);
                     return new DataValue(lastBound.Value.WrappedValue, statusCode, timestamp, timestamp);
                 }
                 else
                 {
                     StatusCode statusCode = (firstBoundBad) ? StatusCodes.UncertainDataSubNormal : StatusCodes.Good;
-                    statusCode = statusCode.SetAggregateBits(AggregateBits.Interpolated);
+                    statusCode = statusCode.WithAggregateBits(AggregateBits.Interpolated);
                     return new DataValue(firstBound.Value.WrappedValue, statusCode, timestamp, timestamp);
                 }
             }
@@ -291,7 +291,7 @@ namespace Quickstarts.ReferenceServer
 
                 // set the aggregate bits as required.
                 StatusCode statusCode = (firstBoundBad || lastBoundBad) ? StatusCodes.UncertainDataSubNormal : StatusCodes.Good;
-                dataValue.StatusCode = statusCode.SetAggregateBits(AggregateBits.Interpolated);
+                dataValue.StatusCode = statusCode.WithAggregateBits(AggregateBits.Interpolated);
                 return dataValue;
             }
         }

--- a/Samples/ReferenceServer/ReferenceServerUtils.cs
+++ b/Samples/ReferenceServer/ReferenceServerUtils.cs
@@ -137,7 +137,7 @@ namespace Quickstarts.ReferenceServer
                         row[6] = e.Parameters.QueueSize;
                         row[7] = e.Parameters.DiscardOldest;
 
-                        if (e.Parameters.Filter != null)
+                        if (!e.Parameters.Filter.IsNull)
                         {
                             row[8] = e.Parameters.Filter.ToString();
                         }
@@ -175,7 +175,7 @@ namespace Quickstarts.ReferenceServer
                 e.EventType = EventType.WriteValue;
                 e.NodeId = nodeId;
                 e.ServerHandle = 0;
-                e.Timestamp = HiResClock.UtcNow;
+                e.Timestamp = DateTime.UtcNow;
                 e.Value = value;
                 e.Parameters = null;
                 e.MonitoringMode = MonitoringMode.Disabled;
@@ -205,7 +205,7 @@ namespace Quickstarts.ReferenceServer
                 e.EventType = EventType.QueueValue;
                 e.NodeId = nodeId;
                 e.ServerHandle = serverHandle;
-                e.Timestamp = HiResClock.UtcNow;
+                e.Timestamp = DateTime.UtcNow;
                 e.Value = value;
                 e.Parameters = null;
                 e.MonitoringMode = MonitoringMode.Disabled;
@@ -229,7 +229,7 @@ namespace Quickstarts.ReferenceServer
                 e.EventType = EventType.FilterValue;
                 e.NodeId = nodeId;
                 e.ServerHandle = serverHandle;
-                e.Timestamp = HiResClock.UtcNow;
+                e.Timestamp = DateTime.UtcNow;
                 e.Value = value;
                 e.Parameters = null;
                 e.MonitoringMode = MonitoringMode.Disabled;
@@ -253,7 +253,7 @@ namespace Quickstarts.ReferenceServer
                 e.EventType = EventType.DiscardValue;
                 e.NodeId = nodeId;
                 e.ServerHandle = serverHandle;
-                e.Timestamp = HiResClock.UtcNow;
+                e.Timestamp = DateTime.UtcNow;
                 e.Value = value;
                 e.Parameters = null;
                 e.MonitoringMode = MonitoringMode.Disabled;
@@ -277,7 +277,7 @@ namespace Quickstarts.ReferenceServer
                 e.EventType = EventType.PublishValue;
                 e.NodeId = nodeId;
                 e.ServerHandle = serverHandle;
-                e.Timestamp = HiResClock.UtcNow;
+                e.Timestamp = DateTime.UtcNow;
                 e.Value = value;
                 e.Parameters = null;
                 e.MonitoringMode = MonitoringMode.Disabled;
@@ -308,7 +308,7 @@ namespace Quickstarts.ReferenceServer
                 e.EventType = EventType.CreateItem;
                 e.NodeId = nodeId;
                 e.ServerHandle = serverHandle;
-                e.Timestamp = HiResClock.UtcNow;
+                e.Timestamp = DateTime.UtcNow;
                 e.Value = null;
                 e.Parameters = new MonitoringParameters();
                 e.Parameters.SamplingInterval = samplingInterval;
@@ -343,7 +343,7 @@ namespace Quickstarts.ReferenceServer
                 e.EventType = EventType.ModifyItem;
                 e.NodeId = nodeId;
                 e.ServerHandle = serverHandle;
-                e.Timestamp = HiResClock.UtcNow;
+                e.Timestamp = DateTime.UtcNow;
                 e.Value = null;
                 e.Parameters = new MonitoringParameters();
                 e.Parameters.SamplingInterval = samplingInterval;

--- a/Workshop/Aggregation/Client/SetUserAndLocaleDlg.cs
+++ b/Workshop/Aggregation/Client/SetUserAndLocaleDlg.cs
@@ -115,7 +115,7 @@ namespace AggregationClient
             // get the locales from the server.
             DataValue value = await m_session.ReadValueAsync(VariableIds.Server_ServerCapabilities_LocaleIdArray, ct);
 
-            if (value != null)
+            if (!value.IsNull)
             {
                 string[] availableLocales = value.GetValue<string[]>(null);
 

--- a/Workshop/Aggregation/Client/ShowReferencesDlg.cs
+++ b/Workshop/Aggregation/Client/ShowReferencesDlg.cs
@@ -108,7 +108,7 @@ namespace AggregationClient
             nodeToBrowse.NodeClassMask = 0;
             nodeToBrowse.ResultMask = (uint)BrowseResultMask.All;
 
-            BrowseDescriptionCollection nodesToBrowse = new BrowseDescriptionCollection();
+            List<BrowseDescription> nodesToBrowse = new List<BrowseDescription>();
             nodesToBrowse.Add(nodeToBrowse);
 
             // start the browse operation.
@@ -193,7 +193,7 @@ namespace AggregationClient
                 {
                     referenceType = referenceTypeNode.DisplayName.Text;
 
-                    if (!reference.IsForward && !LocalizedText.IsNullOrEmpty(referenceTypeNode.InverseName))
+                    if (!reference.IsForward && !(referenceTypeNode.InverseName).IsNullOrEmpty)
                     {
                         referenceType = referenceTypeNode.InverseName.Text;
                     }

--- a/Workshop/Aggregation/Client/SubscribeDlg.cs
+++ b/Workshop/Aggregation/Client/SubscribeDlg.cs
@@ -118,7 +118,7 @@ namespace AggregationClient
             row[2] = value.WrappedValue;
             row[3] = new StatusCode(value.StatusCode.Code);
 
-            if (value.WrappedValue.TypeInfo != null)
+            if (!value.WrappedValue.TypeInfo.IsUnknown)
             {
                 row[4] = value.WrappedValue.TypeInfo.BuiltInType.ToString();
             }

--- a/Workshop/Aggregation/Server/AggregatedTypeCache.cs
+++ b/Workshop/Aggregation/Server/AggregatedTypeCache.cs
@@ -124,7 +124,7 @@ namespace AggregationServer
             nodeToBrowse.NodeClassMask = 0;
             nodeToBrowse.ResultMask = (uint)BrowseResultMask.All;
 
-            BrowseDescriptionCollection nodesToBrowse = new BrowseDescriptionCollection();
+            List<BrowseDescription> nodesToBrowse = new List<BrowseDescription>();
             nodesToBrowse.Add(nodeToBrowse);
 
             // start the browse operation.

--- a/Workshop/Aggregation/Server/AggregationNodeManager.cs
+++ b/Workshop/Aggregation/Server/AggregationNodeManager.cs
@@ -169,7 +169,7 @@ namespace AggregationServer
 
                 string rootName = "Root";
 
-                if (m_endpoint.Description != null && m_endpoint.Description.Server != null && m_endpoint.Description.Server.ApplicationName != null)
+                if (m_endpoint.Description != null && m_endpoint.Description.Server != null && !m_endpoint.Description.Server.ApplicationName.IsNull)
                 {
                     rootName = m_endpoint.Description.Server.ApplicationName.Text;
                 }
@@ -1551,7 +1551,7 @@ namespace AggregationServer
                         BaseVariableTypeState value = new BaseDataVariableTypeState();
 #pragma warning restore CA2000
                         value.IsAbstract = ((IVariableType)node).IsAbstract;
-                        value.Value = new Variant(m_mapper.ToLocalValue(((IVariableType)node).Value));
+                        value.Value = m_mapper.ToLocalVariant(((IVariableType)node).Value);
                         value.DataType = m_mapper.ToLocalId(((IVariableType)node).DataType);
                         value.ValueRank = ((IVariableType)node).ValueRank;
                         value.ArrayDimensions = ((IVariableType)node).ArrayDimensions;
@@ -1596,7 +1596,7 @@ namespace AggregationServer
 #pragma warning disable CA2000 // Justification: NodeState ownership is transferred to the node cache/handle.
                         BaseDataVariableState value = new BaseDataVariableState(null);
 #pragma warning restore CA2000
-                        value.Value = new Variant(m_mapper.ToLocalValue(((IVariable)node).Value));
+                        value.Value = m_mapper.ToLocalVariant(((IVariable)node).Value);
                         value.DataType = m_mapper.ToLocalId(((IVariable)node).DataType);
                         value.ValueRank = ((IVariable)node).ValueRank;
                         value.ArrayDimensions = ((IVariable)node).ArrayDimensions;

--- a/Workshop/Aggregation/Server/AggregationNodeManager.cs
+++ b/Workshop/Aggregation/Server/AggregationNodeManager.cs
@@ -300,7 +300,7 @@ namespace AggregationServer
             List<NodeHandle> nodesToValidate,
             IDictionary<NodeId, NodeState> cache)
         {
-            ReadValueIdCollection requests = new ReadValueIdCollection();
+            List<ReadValueId> requests = new List<ReadValueId>();
             List<int> indexes = new List<int>();
 
             for (int ii = 0; ii < nodesToValidate.Count; ii++)
@@ -405,7 +405,7 @@ namespace AggregationServer
             List<NodeHandle> nodesToValidate,
             IDictionary<NodeId, NodeState> cache)
         {
-            WriteValueCollection requests = new WriteValueCollection();
+            List<WriteValue> requests = new List<WriteValue>();
             List<int> indexes = new List<int>();
 
             // validates the nodes and constructs requests for external nodes.
@@ -505,7 +505,7 @@ namespace AggregationServer
             ServerSystemContext systemContext = SystemContext.Copy(context);
             IDictionary<NodeId, NodeState> operationCache = new NodeIdDictionary<NodeState>();
 
-            CallMethodRequestCollection requests = new CallMethodRequestCollection();
+            List<CallMethodRequest> requests = new List<CallMethodRequest>();
             List<int> indexes = new List<int>();
 
             // validates the nodes and constructs requests for external nodes.

--- a/Workshop/Aggregation/Server/AggregationServer.cs
+++ b/Workshop/Aggregation/Server/AggregationServer.cs
@@ -29,6 +29,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using Microsoft.Extensions.Logging;
 using Opc.Ua;
 using Opc.Ua.Client;
@@ -90,7 +91,7 @@ namespace AggregationServer
                 // start the server even if no endpoint is configured, because
                 // app config can change during operation  and the manager object
                 // is needed
-                reverseConnectManager.StartService(configuration);
+                reverseConnectManager.StartServiceAsync(configuration, CancellationToken.None).GetAwaiter().GetResult();
             }
 
             foreach (ConfiguredEndpoint endpoint in endpoints.Endpoints)

--- a/Workshop/Aggregation/Server/Browser.cs
+++ b/Workshop/Aggregation/Server/Browser.cs
@@ -127,7 +127,7 @@ namespace AggregationServer
                 nodeToBrowse.NodeClassMask = 0;
                 nodeToBrowse.ResultMask = (uint)BrowseResultMask.All;
 
-                BrowseDescriptionCollection nodesToBrowse = new BrowseDescriptionCollection();
+                List<BrowseDescription> nodesToBrowse = new List<BrowseDescription>();
                 nodesToBrowse.Add(nodeToBrowse);
 
                 // start the browse operation.
@@ -187,7 +187,7 @@ namespace AggregationServer
                     nodeToBrowse.NodeClassMask = 0;
                     nodeToBrowse.ResultMask = (uint)BrowseResultMask.All;
 
-                    BrowseDescriptionCollection nodesToBrowse = new BrowseDescriptionCollection();
+                    List<BrowseDescription> nodesToBrowse = new List<BrowseDescription>();
                     nodesToBrowse.Add(nodeToBrowse);
 
                     // start the browse operation.
@@ -345,7 +345,7 @@ namespace AggregationServer
         private async Task<NodeStateReference> NextChildAsync(CancellationToken ct = default)
         {
             // check if a specific browse name is requested.
-            if (!QualifiedName.IsNull(base.BrowseName))
+            if (!(base.BrowseName).IsNull)
             {
                 // check if match found previously.
                 if (m_position == Int32.MaxValue)

--- a/Workshop/Aggregation/Server/NamespaceMapper.cs
+++ b/Workshop/Aggregation/Server/NamespaceMapper.cs
@@ -189,36 +189,6 @@ namespace AggregationServer
         {
             return ToVariant(value, m_remoteNamespaceIndexes);
         }
-
-        /// <summary>
-        /// Converts a remote ExtensionObject to a local ExtensionObject.
-        /// </summary>
-        public object ToLocalValue(object value)
-        {
-            if (value is Variant)
-            {
-                return ToVariant((Variant)value, m_localNamespaceIndexes);
-            }
-            else
-            {
-                return ToVariant(new Variant(value), m_localNamespaceIndexes).AsBoxedObject();
-            }
-        }
-
-        /// <summary>
-        /// Converts a local ExtensionObject to a remote ExtensionObject.
-        /// </summary>
-        public object ToRemoteValue(object value)
-        {
-            if (value is Variant)
-            {
-                return ToVariant((Variant)value, m_remoteNamespaceIndexes);
-            }
-            else
-            {
-                return ToVariant(new Variant(value), m_remoteNamespaceIndexes).AsBoxedObject();
-            }
-        }
         #endregion
 
         #region Private Methods
@@ -243,7 +213,27 @@ namespace AggregationServer
                 return NodeId.Null;
             }
 
-            return new NodeId(nodeId.Identifier, (ushort)namespaceIndexes[nodeId.NamespaceIndex]);
+            if (nodeId.TryGetValue(out uint numericId))
+            {
+                return new NodeId(numericId, (ushort)namespaceIndexes[nodeId.NamespaceIndex]);
+            }
+
+            if (nodeId.TryGetValue(out string stringId))
+            {
+                return new NodeId(stringId, (ushort)namespaceIndexes[nodeId.NamespaceIndex]);
+            }
+
+            if (nodeId.TryGetValue(out Guid guidId))
+            {
+                return new NodeId(guidId, (ushort)namespaceIndexes[nodeId.NamespaceIndex]);
+            }
+
+            if (nodeId.TryGetValue(out ByteString byteStringId))
+            {
+                return new NodeId(byteStringId, (ushort)namespaceIndexes[nodeId.NamespaceIndex]);
+            }
+
+            return NodeId.Null;
         }
 
         /// <summary>
@@ -266,7 +256,27 @@ namespace AggregationServer
                 return NodeId.Null;
             }
 
-            return new ExpandedNodeId(nodeId.Identifier, (ushort)namespaceIndexes[nodeId.NamespaceIndex], nodeId.NamespaceUri, nodeId.ServerIndex);
+            if (nodeId.TryGetValue(out uint numericId))
+            {
+                return new ExpandedNodeId(numericId, (ushort)namespaceIndexes[nodeId.NamespaceIndex], nodeId.NamespaceUri, nodeId.ServerIndex);
+            }
+
+            if (nodeId.TryGetValue(out string stringId))
+            {
+                return new ExpandedNodeId(stringId, (ushort)namespaceIndexes[nodeId.NamespaceIndex], nodeId.NamespaceUri, nodeId.ServerIndex);
+            }
+
+            if (nodeId.TryGetValue(out Guid guidId))
+            {
+                return new ExpandedNodeId(guidId, (ushort)namespaceIndexes[nodeId.NamespaceIndex], nodeId.NamespaceUri, nodeId.ServerIndex);
+            }
+
+            if (nodeId.TryGetValue(out ByteString byteStringId))
+            {
+                return new ExpandedNodeId(byteStringId, (ushort)namespaceIndexes[nodeId.NamespaceIndex], nodeId.NamespaceUri, nodeId.ServerIndex);
+            }
+
+            return NodeId.Null;
         }
 
         /// <summary>
@@ -302,7 +312,7 @@ namespace AggregationServer
                 return extension;
             }
 
-            Argument argument = extension.Body as Argument;
+            Argument argument = extension.TryGetValue<Argument>(out var value, ServiceMessageContext.CreateEmpty(null)) ? value : null;
 
             if (argument != null)
             {
@@ -332,12 +342,12 @@ namespace AggregationServer
 
             TypeInfo type = value.TypeInfo;
 
-            if (type == null)
+            if (type.IsUnknown)
             {
                 type = TypeInfo.Construct(value.AsBoxedObject());
             }
 
-            if (type == null)
+            if (type.IsUnknown)
             {
                 return Variant.Null;
             }
@@ -348,22 +358,22 @@ namespace AggregationServer
                 {
                     case BuiltInType.NodeId:
                     {
-                        return new Variant(ToId((NodeId)value.AsBoxedObject(), namespaceIndexes));
+                        return Variant.From(ToId((NodeId)value.AsBoxedObject(), namespaceIndexes));
                     }
 
                     case BuiltInType.ExpandedNodeId:
                     {
-                        return new Variant(ToId((ExpandedNodeId)value.AsBoxedObject(), namespaceIndexes));
+                        return Variant.From(ToId((ExpandedNodeId)value.AsBoxedObject(), namespaceIndexes));
                     }
 
                     case BuiltInType.QualifiedName:
                     {
-                        return new Variant(ToName((QualifiedName)value.AsBoxedObject(), namespaceIndexes));
+                        return Variant.From(ToName((QualifiedName)value.AsBoxedObject(), namespaceIndexes));
                     }
 
                     case BuiltInType.ExtensionObject:
                     {
-                        return new Variant(ToExtensionObject((ExtensionObject)value.AsBoxedObject(), namespaceIndexes));
+                        return Variant.From(ToExtensionObject((ExtensionObject)value.AsBoxedObject(), namespaceIndexes));
                     }
                 }
             }
@@ -388,7 +398,15 @@ namespace AggregationServer
                             array = CastArray((Array)value.AsBoxedObject(), CastArrayToRemote);
                         }
 
-                        return new Variant(array, type);
+                        return type.BuiltInType switch
+                        {
+                            BuiltInType.NodeId => Variant.From((NodeId[])array),
+                            BuiltInType.ExpandedNodeId => Variant.From((ExpandedNodeId[])array),
+                            BuiltInType.QualifiedName => Variant.From((QualifiedName[])array),
+                            BuiltInType.ExtensionObject => Variant.From((ExtensionObject[])array),
+                            BuiltInType.Variant => Variant.From((Variant[])array),
+                            _ => value
+                        };
                     }
                 }
             }
@@ -401,16 +419,7 @@ namespace AggregationServer
         /// </summary>
         private object CastArrayToLocal(object source, BuiltInType srcType, BuiltInType dstType)
         {
-            if (source is Variant)
-            {
-                Variant result = ToVariant((Variant)source, m_localNamespaceIndexes);
-                return result;
-            }
-            else
-            {
-                Variant result = ToVariant(new Variant(source), m_localNamespaceIndexes);
-                return result.AsBoxedObject();
-            }
+            return MapElement(source, m_localNamespaceIndexes);
         }
 
         /// <summary>
@@ -418,15 +427,22 @@ namespace AggregationServer
         /// </summary>
         private object CastArrayToRemote(object source, BuiltInType srcType, BuiltInType dstType)
         {
-            if (source is Variant)
+            return MapElement(source, m_remoteNamespaceIndexes);
+        }
+
+        /// <summary>
+        /// Maps the namespace indexes of a single array element.
+        /// </summary>
+        private object MapElement(object source, int[] namespaceIndexes)
+        {
+            switch (source)
             {
-                Variant result = ToVariant((Variant)source, m_remoteNamespaceIndexes);
-                return result;
-            }
-            else
-            {
-                Variant result = ToVariant(new Variant(source), m_remoteNamespaceIndexes);
-                return result.AsBoxedObject();
+                case Variant variant: return ToVariant(variant, namespaceIndexes);
+                case NodeId nodeId: return ToId(nodeId, namespaceIndexes);
+                case ExpandedNodeId expandedNodeId: return ToId(expandedNodeId, namespaceIndexes);
+                case QualifiedName qualifiedName: return ToName(qualifiedName, namespaceIndexes);
+                case ExtensionObject extension: return ToExtensionObject(extension, namespaceIndexes);
+                default: return source;
             }
         }
         #endregion

--- a/Workshop/Aggregation/Server/NamespaceMapper.cs
+++ b/Workshop/Aggregation/Server/NamespaceMapper.cs
@@ -201,7 +201,7 @@ namespace AggregationServer
             }
             else
             {
-                return ToVariant(new Variant(value), m_localNamespaceIndexes).Value;
+                return ToVariant(new Variant(value), m_localNamespaceIndexes).AsBoxedObject();
             }
         }
 
@@ -216,7 +216,7 @@ namespace AggregationServer
             }
             else
             {
-                return ToVariant(new Variant(value), m_remoteNamespaceIndexes).Value;
+                return ToVariant(new Variant(value), m_remoteNamespaceIndexes).AsBoxedObject();
             }
         }
         #endregion
@@ -227,7 +227,7 @@ namespace AggregationServer
         /// </summary>
         private NodeId ToId(NodeId nodeId, int[] namespaceIndexes)
         {
-            if (NodeId.IsNull(nodeId))
+            if ((nodeId).IsNull)
             {
                 return NodeId.Null;
             }
@@ -251,7 +251,7 @@ namespace AggregationServer
         /// </summary>
         private ExpandedNodeId ToId(ExpandedNodeId nodeId, int[] namespaceIndexes)
         {
-            if (NodeId.IsNull(nodeId))
+            if ((nodeId).IsNull)
             {
                 return NodeId.Null;
             }
@@ -274,7 +274,7 @@ namespace AggregationServer
         /// </summary>
         private QualifiedName ToName(QualifiedName name, int[] namespaceIndexes)
         {
-            if (QualifiedName.IsNull(name))
+            if ((name).IsNull)
             {
                 return QualifiedName.Null;
             }
@@ -297,7 +297,7 @@ namespace AggregationServer
         /// </summary>
         private ExtensionObject ToExtensionObject(ExtensionObject extension, int[] namespaceIndexes)
         {
-            if (ExtensionObject.IsNull(extension))
+            if ((extension).IsNull)
             {
                 return extension;
             }
@@ -334,7 +334,7 @@ namespace AggregationServer
 
             if (type == null)
             {
-                type = TypeInfo.Construct(value.Value);
+                type = TypeInfo.Construct(value.AsBoxedObject());
             }
 
             if (type == null)
@@ -348,22 +348,22 @@ namespace AggregationServer
                 {
                     case BuiltInType.NodeId:
                     {
-                        return new Variant(ToId((NodeId)value.Value, namespaceIndexes));
+                        return new Variant(ToId((NodeId)value.AsBoxedObject(), namespaceIndexes));
                     }
 
                     case BuiltInType.ExpandedNodeId:
                     {
-                        return new Variant(ToId((ExpandedNodeId)value.Value, namespaceIndexes));
+                        return new Variant(ToId((ExpandedNodeId)value.AsBoxedObject(), namespaceIndexes));
                     }
 
                     case BuiltInType.QualifiedName:
                     {
-                        return new Variant(ToName((QualifiedName)value.Value, namespaceIndexes));
+                        return new Variant(ToName((QualifiedName)value.AsBoxedObject(), namespaceIndexes));
                     }
 
                     case BuiltInType.ExtensionObject:
                     {
-                        return new Variant(ToExtensionObject((ExtensionObject)value.Value, namespaceIndexes));
+                        return new Variant(ToExtensionObject((ExtensionObject)value.AsBoxedObject(), namespaceIndexes));
                     }
                 }
             }
@@ -381,11 +381,11 @@ namespace AggregationServer
 
                         if (Object.ReferenceEquals(m_localNamespaceIndexes, namespaceIndexes))
                         {
-                            array = CastArray((Array)value.Value, CastArrayToLocal);
+                            array = CastArray((Array)value.AsBoxedObject(), CastArrayToLocal);
                         }
                         else
                         {
-                            array = CastArray((Array)value.Value, CastArrayToRemote);
+                            array = CastArray((Array)value.AsBoxedObject(), CastArrayToRemote);
                         }
 
                         return new Variant(array, type);
@@ -409,7 +409,7 @@ namespace AggregationServer
             else
             {
                 Variant result = ToVariant(new Variant(source), m_localNamespaceIndexes);
-                return result.Value;
+                return result.AsBoxedObject();
             }
         }
 
@@ -426,7 +426,7 @@ namespace AggregationServer
             else
             {
                 Variant result = ToVariant(new Variant(source), m_remoteNamespaceIndexes);
-                return result.Value;
+                return result.AsBoxedObject();
             }
         }
         #endregion

--- a/Workshop/AlarmCondition/Client/AuditEventForm.cs
+++ b/Workshop/AlarmCondition/Client/AuditEventForm.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2019 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -152,7 +152,7 @@ namespace Quickstarts.AlarmConditionClient
                 NodeId eventTypeId = FormUtils.FindEventType(monitoredItem, notification);
 
                 // ignore unknown events.
-                if (NodeId.IsNull(eventTypeId))
+                if ((eventTypeId).IsNull)
                 {
                     return;
                 }

--- a/Workshop/AlarmCondition/Client/FilterDefinition.cs
+++ b/Workshop/AlarmCondition/Client/FilterDefinition.cs
@@ -198,7 +198,7 @@ namespace Quickstarts.AlarmConditionClient
                 operand2.Value = new Variant((ushort)Severity);
 
                 // specify that the Severity property must be GreaterThanOrEqual the value specified.
-                element1 = whereClause.Push(FilterOperator.GreaterThanOrEqual, new Variant(operand1), new Variant(operand2));
+                element1 = whereClause.Push(FilterOperator.GreaterThanOrEqual, new Variant(new ExtensionObject(operand1)), new Variant(new ExtensionObject(operand2)));
             }
 
             // add the suppressed or shelved.
@@ -215,12 +215,12 @@ namespace Quickstarts.AlarmConditionClient
                 operand2.Value = new Variant(false);
 
                 // specify that the Severity property must Equal the value specified.
-                element2 = whereClause.Push(FilterOperator.Equals, new Variant(operand1), new Variant(operand2));
+                element2 = whereClause.Push(FilterOperator.Equals, new Variant(new ExtensionObject(operand1)), new Variant(new ExtensionObject(operand2)));
 
                 // chain multiple elements together with an AND clause.
                 if (element1 != null)
                 {
-                    element1 = whereClause.Push(FilterOperator.And, new Variant(element1), new Variant(element2));
+                    element1 = whereClause.Push(FilterOperator.And, new Variant(new ExtensionObject(element1)), new Variant(new ExtensionObject(element2)));
                 }
                 else
                 {
@@ -239,12 +239,12 @@ namespace Quickstarts.AlarmConditionClient
                     // for this example uses the 'OfType' operator to limit events to thoses with specified event type.
                     LiteralOperand operand1 = new LiteralOperand();
                     operand1.Value = new Variant(EventTypes[ii]);
-                    ContentFilterElement element3 = whereClause.Push(FilterOperator.OfType, new Variant(operand1));
+                    ContentFilterElement element3 = whereClause.Push(FilterOperator.OfType, new Variant(new ExtensionObject(operand1)));
 
                     // need to chain multiple types together with an OR clause.
                     if (element2 != null)
                     {
-                        element2 = whereClause.Push(FilterOperator.Or, new Variant(element2), new Variant(element3));
+                        element2 = whereClause.Push(FilterOperator.Or, new Variant(new ExtensionObject(element2)), new Variant(new ExtensionObject(element3)));
                     }
                     else
                     {
@@ -255,7 +255,7 @@ namespace Quickstarts.AlarmConditionClient
                 // need to link the set of event types with the previous filters.
                 if (element1 != null)
                 {
-                    whereClause.Push(FilterOperator.And, new Variant(element1), new Variant(element2));
+                    whereClause.Push(FilterOperator.And, new Variant(new ExtensionObject(element1)), new Variant(new ExtensionObject(element2)));
                 }
             }
 

--- a/Workshop/AlarmCondition/Client/FormUtils.cs
+++ b/Workshop/AlarmCondition/Client/FormUtils.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2019 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -263,7 +263,7 @@ namespace Quickstarts.AlarmConditionClient
             }
 
             // all of the known event types have a UInt32 as identifier.
-            uint? id = knownTypeId.Identifier as uint?;
+            uint? id = knownTypeId.TryGetValue(out uint numericId) ? numericId : null;
 
             if (id == null)
             {

--- a/Workshop/AlarmCondition/Client/FormUtils.cs
+++ b/Workshop/AlarmCondition/Client/FormUtils.cs
@@ -175,7 +175,7 @@ namespace Quickstarts.AlarmConditionClient
 
                     if (clause.BrowsePath.Count == 1 && clause.BrowsePath[0] == BrowseNames.EventType)
                     {
-                        return notification.EventFields[ii].Value is NodeId nodeId ? nodeId : NodeId.Null;
+                        return notification.EventFields[ii].AsBoxedObject() is NodeId nodeId ? nodeId : NodeId.Null;
                     }
                 }
             }

--- a/Workshop/AlarmCondition/Client/MainForm.cs
+++ b/Workshop/AlarmCondition/Client/MainForm.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2019 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -426,7 +426,7 @@ namespace Quickstarts.AlarmConditionClient
         private async Task ShelveAsync(bool shelving, bool oneShot, double shelvingTime, CancellationToken ct = default)
         {
             // build list of methods to call.
-            CallMethodRequestCollection methodsToCall = new CallMethodRequestCollection();
+            List<CallMethodRequest> methodsToCall = new List<CallMethodRequest>();
 
             for (int ii = 0; ii < ConditionsLV.SelectedItems.Count; ii++)
             {
@@ -498,7 +498,7 @@ namespace Quickstarts.AlarmConditionClient
         private async Task RespondAsync(int selectedResponse, CancellationToken ct = default)
         {
             // build list of dialogs to respond to (caller should always make sure that only one is selected).
-            CallMethodRequestCollection methodsToCall = new CallMethodRequestCollection();
+            List<CallMethodRequest> methodsToCall = new List<CallMethodRequest>();
 
             for (int ii = 0; ii < ConditionsLV.SelectedItems.Count; ii++)
             {
@@ -555,7 +555,7 @@ namespace Quickstarts.AlarmConditionClient
         private async Task CallMethodAsync(NodeId methodId, string comment, CancellationToken ct = default)
         {
             // build list of methods to call.
-            CallMethodRequestCollection methodsToCall = new CallMethodRequestCollection();
+            List<CallMethodRequest> methodsToCall = new List<CallMethodRequest>();
 
             for (int ii = 0; ii < ConditionsLV.SelectedItems.Count; ii++)
             {
@@ -629,7 +629,7 @@ namespace Quickstarts.AlarmConditionClient
                 NodeId eventTypeId = FormUtils.FindEventType(monitoredItem, notification);
 
                 // ignore unknown events.
-                if (NodeId.IsNull(eventTypeId))
+                if ((eventTypeId).IsNull)
                 {
                     return;
                 }
@@ -721,7 +721,7 @@ namespace Quickstarts.AlarmConditionClient
                 }
 
                 // Branch
-                if (condition.BranchId != null && !NodeId.IsNull(condition.BranchId.Value))
+                if (condition.BranchId != null && !(condition.BranchId.Value).IsNull)
                 {
                     item.SubItems[2].Text = Utils.Format("{0}", condition.BranchId.Value);
                 }
@@ -799,7 +799,7 @@ namespace Quickstarts.AlarmConditionClient
                 }
                 else
                 {
-                    if (NodeId.IsNull(condition.BranchId.Value))
+                    if ((condition.BranchId.Value).IsNull)
                     {
                         item.ForeColor = Color.Empty;
                     }
@@ -836,7 +836,7 @@ namespace Quickstarts.AlarmConditionClient
                 request.MethodId = MethodIds.ConditionType_ConditionRefresh;
                 AddInputArgument(request, new Variant(m_subscription.Id));
 
-                CallMethodRequestCollection methodsToCall = new CallMethodRequestCollection();
+                List<CallMethodRequest> methodsToCall = new List<CallMethodRequest>();
                 methodsToCall.Add(request);
 
                 CallResponse response = await m_session.CallAsync(

--- a/Workshop/AlarmCondition/Client/ViewEventDetailsDlg.cs
+++ b/Workshop/AlarmCondition/Client/ViewEventDetailsDlg.cs
@@ -68,7 +68,7 @@ namespace Quickstarts.AlarmConditionClient
 
             if (filter != null)
             {
-                if (eventFields.EventFields[0].Value != null)
+                if (eventFields.EventFields[0].AsBoxedObject() != null)
                 {
                     fieldNames.Add("ConditionId");
                     fieldValues.Add(eventFields.EventFields[0]);
@@ -76,7 +76,7 @@ namespace Quickstarts.AlarmConditionClient
 
                 for (int ii = 1; ii < filter.SelectClauses.Count; ii++)
                 {
-                    object fieldValue = eventFields.EventFields[ii].Value;
+                    object fieldValue = eventFields.EventFields[ii].AsBoxedObject();
 
                     if (fieldValue == null)
                     {
@@ -105,8 +105,8 @@ namespace Quickstarts.AlarmConditionClient
             {
                 ListViewItem item = new ListViewItem(fieldNames[ii]);
 
-                item.SubItems.Add(Utils.Format("{0}", fieldValues[ii].Value));
-                item.SubItems.Add(Utils.Format("{0}", fieldValues[ii].Value.GetType().Name));
+                item.SubItems.Add(Utils.Format("{0}", fieldValues[ii].AsBoxedObject()));
+                item.SubItems.Add(Utils.Format("{0}", fieldValues[ii].AsBoxedObject().GetType().Name));
 
                 FieldsLV.Items.Add(item);
             }

--- a/Workshop/AlarmCondition/Server/Model/ModelUtils.cs
+++ b/Workshop/AlarmCondition/Server/Model/ModelUtils.cs
@@ -106,7 +106,7 @@ namespace Quickstarts.AlarmConditionServer
             }
 
             // parent must have a string identifier.
-            string parentId = instance.Parent.NodeId.Identifier as string;
+            string parentId = instance.Parent.NodeId.TryGetValue(out string id) ? id : null;
 
             if (parentId == null)
             {

--- a/Workshop/AlarmCondition/Server/Model/SourceState.cs
+++ b/Workshop/AlarmCondition/Server/Model/SourceState.cs
@@ -711,7 +711,7 @@ namespace Quickstarts.AlarmConditionServer
                 return 0;
             }
 
-            uint? recordNumber = alarm.BranchId.Value.Identifier as uint?;
+            uint? recordNumber = alarm.BranchId.Value.TryGetValue(out uint id) ? id : null;
 
             if (recordNumber != null)
             {

--- a/Workshop/AlarmCondition/Server/Model/SourceState.cs
+++ b/Workshop/AlarmCondition/Server/Model/SourceState.cs
@@ -338,7 +338,7 @@ namespace Quickstarts.AlarmConditionServer
             node.ConfirmedState = new TwoStateVariableState(node);
             node.Confirm = new AddCommentMethodState(node);
 
-            if (NodeId.IsNull(branchId))
+            if ((branchId).IsNull)
             {
                 node.SuppressedState = new TwoStateVariableState(node);
                 node.ShelvingState = new ShelvedStateMachineState(node);
@@ -378,7 +378,7 @@ namespace Quickstarts.AlarmConditionServer
                 true);
 
             // don't add branches to the address space.
-            if (NodeId.IsNull(branchId))
+            if ((branchId).IsNull)
             {
                 this.AddChild(node);
             }

--- a/Workshop/AlarmCondition/Server/UnderlyingSystem/UnderlyingSystemSource.cs
+++ b/Workshop/AlarmCondition/Server/UnderlyingSystem/UnderlyingSystemSource.cs
@@ -205,7 +205,7 @@ namespace Quickstarts.AlarmConditionServer
                     alarm.UserName = userName;
 
                     // only change the comment if a non-null comment was provided.
-                    if (comment != null && (!String.IsNullOrEmpty(comment.Text) || !String.IsNullOrEmpty(comment.Locale)))
+                    if (!comment.IsNull && (!String.IsNullOrEmpty(comment.Text) || !String.IsNullOrEmpty(comment.Locale)))
                     {
                         alarm.Comment = Utils.Format("{0}", comment);
                     }

--- a/Workshop/Boiler/Server/Quickstarts.Boiler.Classes.cs
+++ b/Workshop/Boiler/Server/Quickstarts.Boiler.Classes.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2021 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -196,7 +196,7 @@ namespace Quickstarts.Boiler
             bool createOrReplace,
             BaseInstanceState replacement)
         {
-            if (QualifiedName.IsNull(browseName))
+            if ((browseName).IsNull)
             {
                 return null;
             }
@@ -398,7 +398,7 @@ namespace Quickstarts.Boiler
             bool createOrReplace,
             BaseInstanceState replacement)
         {
-            if (QualifiedName.IsNull(browseName))
+            if ((browseName).IsNull)
             {
                 return null;
             }
@@ -556,7 +556,7 @@ namespace Quickstarts.Boiler
             bool createOrReplace,
             BaseInstanceState replacement)
         {
-            if (QualifiedName.IsNull(browseName))
+            if ((browseName).IsNull)
             {
                 return null;
             }
@@ -788,7 +788,7 @@ namespace Quickstarts.Boiler
             bool createOrReplace,
             BaseInstanceState replacement)
         {
-            if (QualifiedName.IsNull(browseName))
+            if ((browseName).IsNull)
             {
                 return null;
             }
@@ -1417,7 +1417,7 @@ namespace Quickstarts.Boiler
             bool createOrReplace,
             BaseInstanceState replacement)
         {
-            if (QualifiedName.IsNull(browseName))
+            if ((browseName).IsNull)
             {
                 return null;
             }
@@ -1598,7 +1598,7 @@ namespace Quickstarts.Boiler
             bool createOrReplace,
             BaseInstanceState replacement)
         {
-            if (QualifiedName.IsNull(browseName))
+            if ((browseName).IsNull)
             {
                 return null;
             }
@@ -1757,7 +1757,7 @@ namespace Quickstarts.Boiler
             bool createOrReplace,
             BaseInstanceState replacement)
         {
-            if (QualifiedName.IsNull(browseName))
+            if ((browseName).IsNull)
             {
                 return null;
             }
@@ -2062,7 +2062,7 @@ namespace Quickstarts.Boiler
             bool createOrReplace,
             BaseInstanceState replacement)
         {
-            if (QualifiedName.IsNull(browseName))
+            if ((browseName).IsNull)
             {
                 return null;
             }

--- a/Workshop/Common/FilterDefinition.cs
+++ b/Workshop/Common/FilterDefinition.cs
@@ -185,7 +185,7 @@ namespace Quickstarts
                 operand2.Value = new Variant((ushort)Severity);
 
                 // specify that the Severity property must be GreaterThanOrEqual the value specified.
-                element1 = whereClause.Push(FilterOperator.GreaterThanOrEqual, new Variant(operand1), new Variant(operand2));
+                element1 = whereClause.Push(FilterOperator.GreaterThanOrEqual, new Variant(new ExtensionObject(operand1)), new Variant(new ExtensionObject(operand2)));
             }
 
             // add the event types.
@@ -199,12 +199,12 @@ namespace Quickstarts
                     // for this example uses the 'OfType' operator to limit events to thoses with specified event type.
                     LiteralOperand operand1 = new LiteralOperand();
                     operand1.Value = new Variant(EventTypes[ii]);
-                    ContentFilterElement element3 = whereClause.Push(FilterOperator.OfType, new Variant(operand1));
+                    ContentFilterElement element3 = whereClause.Push(FilterOperator.OfType, new Variant(new ExtensionObject(operand1)));
 
                     // need to chain multiple types together with an OR clause.
                     if (element2 != null)
                     {
-                        element2 = whereClause.Push(FilterOperator.Or, new Variant(element2), new Variant(element3));
+                        element2 = whereClause.Push(FilterOperator.Or, new Variant(new ExtensionObject(element2)), new Variant(new ExtensionObject(element3)));
                     }
                     else
                     {
@@ -215,7 +215,7 @@ namespace Quickstarts
                 // need to link the set of event types with the previous filters.
                 if (element1 != null)
                 {
-                    whereClause.Push(FilterOperator.And, new Variant(element1), new Variant(element2));
+                    whereClause.Push(FilterOperator.And, new Variant(new ExtensionObject(element1)), new Variant(new ExtensionObject(element2)));
                 }
             }
 

--- a/Workshop/Common/FormUtils.cs
+++ b/Workshop/Common/FormUtils.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2019 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -187,7 +187,7 @@ namespace Quickstarts
                 case Attributes.AccessLevel:
                 case Attributes.UserAccessLevel:
                 {
-                    byte? field = value.Value as byte?;
+                    byte? field = value.AsBoxedObject() as byte?;
 
                     if (field != null)
                     {
@@ -199,7 +199,7 @@ namespace Quickstarts
 
                 case Attributes.EventNotifier:
                 {
-                    byte? field = value.Value as byte?;
+                    byte? field = value.AsBoxedObject() as byte?;
 
                     if (field != null)
                     {
@@ -211,12 +211,12 @@ namespace Quickstarts
 
                 case Attributes.DataType:
                 {
-                    return await session.NodeCache.GetDisplayTextAsync(value.Value is NodeId nodeId ? nodeId : NodeId.Null, ct);
+                    return await session.NodeCache.GetDisplayTextAsync(value.AsBoxedObject() is NodeId nodeId ? nodeId : NodeId.Null, ct);
                 }
 
                 case Attributes.ValueRank:
                 {
-                    int? field = value.Value as int?;
+                    int? field = value.AsBoxedObject() as int?;
 
                     if (field != null)
                     {
@@ -228,7 +228,7 @@ namespace Quickstarts
 
                 case Attributes.NodeClass:
                 {
-                    int? field = value.Value as int?;
+                    int? field = value.AsBoxedObject() as int?;
 
                     if (field != null)
                     {
@@ -240,9 +240,9 @@ namespace Quickstarts
 
                 case Attributes.NodeId:
                 {
-                    NodeId field = value.Value is NodeId nodeId ? nodeId : NodeId.Null;
+                    NodeId field = value.AsBoxedObject() is NodeId nodeId ? nodeId : NodeId.Null;
 
-                    if (!NodeId.IsNull(field))
+                    if (!(field).IsNull)
                     {
                         return field.ToString();
                     }
@@ -252,9 +252,9 @@ namespace Quickstarts
             }
 
             // check for byte strings.
-            if (value.Value is byte[])
+            if (value.AsBoxedObject() is byte[])
             {
-                return Utils.ToHexString(value.Value as byte[]);
+                return Utils.ToHexString(value.AsBoxedObject() as byte[]);
             }
 
             // use default format.
@@ -558,7 +558,7 @@ namespace Quickstarts
 
                     if (clause.BrowsePath.Count == 1 && clause.BrowsePath[0] == BrowseNames.EventType)
                     {
-                        return notification.EventFields[ii].Value is NodeId nodeId ? nodeId : NodeId.Null;
+                        return notification.EventFields[ii].AsBoxedObject() is NodeId nodeId ? nodeId : NodeId.Null;
                     }
                 }
             }
@@ -824,7 +824,7 @@ namespace Quickstarts
             params string[] relativePaths)
         {
             // build the list of browse paths to follow by parsing the relative paths.
-            BrowsePathCollection browsePaths = new BrowsePathCollection();
+            List<BrowsePath> browsePaths = new List<BrowsePath>();
 
             if (relativePaths != null)
             {

--- a/Workshop/Common/ModelUtils.cs
+++ b/Workshop/Common/ModelUtils.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2019 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -128,7 +128,7 @@ namespace Quickstarts
                 child.BrowseName = reference.BrowseName;
                 child.NodeClass = reference.NodeClass;
 
-                if (!LocalizedText.IsNullOrEmpty(reference.DisplayName))
+                if (!(reference.DisplayName).IsNullOrEmpty)
                 {
                     child.DisplayName = reference.DisplayName.Text;
                 }
@@ -183,7 +183,7 @@ namespace Quickstarts
                     children[ii].ModellingRule = modellingRules[ii];
 
                     // if the modelling rule is null then the instance is not part of the type declaration.
-                    if (NodeId.IsNull(modellingRules[ii]))
+                    if ((modellingRules[ii]).IsNull)
                     {
                         map.Remove(children[ii].BrowsePathDisplayText);
                     }
@@ -196,7 +196,7 @@ namespace Quickstarts
             // recusively collect instance declarations for the tree below.
             for (int ii = 0; ii < children.Count; ii++)
             {
-                if (!NodeId.IsNull(children[ii].ModellingRule))
+                if (!(children[ii].ModellingRule).IsNull)
                 {
                     instances.Add(children[ii]);
                     await CollectInstanceDeclarationsAsync(session, typeId, children[ii], instances, map, ct);
@@ -212,7 +212,7 @@ namespace Quickstarts
             try
             {
                 // construct browse request.
-                BrowseDescriptionCollection nodesToBrowse = new BrowseDescriptionCollection();
+                List<BrowseDescription> nodesToBrowse = new List<BrowseDescription>();
 
                 for (int ii = 0; ii < nodeIds.Count; ii++)
                 {
@@ -262,7 +262,7 @@ namespace Quickstarts
                     // get the node id.
                     if (results[ii].References.Count > 0)
                     {
-                        if (NodeId.IsNull(results[ii].References[0].NodeId) || results[ii].References[0].NodeId.IsAbsolute)
+                        if ((results[ii].References[0].NodeId).IsNull || results[ii].References[0].NodeId.IsAbsolute)
                         {
                             continue;
                         }
@@ -308,7 +308,7 @@ namespace Quickstarts
         {
             try
             {
-                ReadValueIdCollection nodesToRead = new ReadValueIdCollection();
+                List<ReadValueId> nodesToRead = new List<ReadValueId>();
 
                 for (int ii = 0; ii < instances.Count; ii++)
                 {
@@ -351,7 +351,7 @@ namespace Quickstarts
                     instance.DataType = results[ii + 1].GetValue<NodeId>(NodeId.Null);
                     instance.ValueRank = results[ii + 2].GetValue<int>(ValueRanks.Any);
 
-                    if (!NodeId.IsNull(instance.DataType))
+                    if (!(instance.DataType).IsNull)
                     {
                         instance.BuiltInType = TypeInfo.GetBuiltInType(instance.DataType, session.TypeTree);
                         instance.DataTypeDisplayText = await session.NodeCache.GetDisplayTextAsync(instance.DataType, ct);
@@ -572,7 +572,7 @@ namespace Quickstarts
                     continue;
                 }
 
-                if (NodeId.IsNull(instanceDeclaration.ModellingRule))
+                if ((instanceDeclaration.ModellingRule).IsNull)
                 {
                     continue;
                 }
@@ -743,7 +743,7 @@ namespace Quickstarts
                         return defaultValue;
                     }
 
-                    object value = fields[ii + 1].Value;
+                    object value = fields[ii + 1].AsBoxedObject();
 
                     if (typeof(T).IsInstanceOfType(value))
                     {

--- a/Workshop/Common/ModelUtils.cs
+++ b/Workshop/Common/ModelUtils.cs
@@ -700,7 +700,7 @@ namespace Quickstarts
         public ContentFilter GetWhereClause()
         {
             ContentFilter whereClause = new ContentFilter();
-            ContentFilterElement element1 = whereClause.Push(FilterOperator.OfType, new Variant(new LiteralOperand { Value = new Variant(EventTypeId) }));
+            ContentFilterElement element1 = whereClause.Push(FilterOperator.OfType, new Variant(new ExtensionObject(new LiteralOperand { Value = new Variant(EventTypeId) })));
 
             EventFilter filter = new EventFilter();
 
@@ -716,8 +716,8 @@ namespace Quickstarts
                     LiteralOperand operand2 = new LiteralOperand();
                     operand2.Value = field.FilterValue;
 
-                    ContentFilterElement element2 = whereClause.Push(field.FilterOperator, new Variant(operand1), new Variant(operand2));
-                    element1 = whereClause.Push(FilterOperator.And, new Variant(element1), new Variant(element2));
+                    ContentFilterElement element2 = whereClause.Push(field.FilterOperator, new Variant(new ExtensionObject(operand1)), new Variant(new ExtensionObject(operand2)));
+                    element1 = whereClause.Push(FilterOperator.And, new Variant(new ExtensionObject(element1)), new Variant(new ExtensionObject(element2)));
                 }
             }
 

--- a/Workshop/Common/ParsedNodeId.cs
+++ b/Workshop/Common/ParsedNodeId.cs
@@ -94,7 +94,7 @@ namespace Quickstarts
                 return null;
             }
 
-            string identifier = nodeId.Identifier as string;
+            string identifier = nodeId.TryGetValue(out string id) ? id : null;
 
             if (String.IsNullOrEmpty(identifier))
             {

--- a/Workshop/Common/ParsedNodeId.cs
+++ b/Workshop/Common/ParsedNodeId.cs
@@ -89,7 +89,7 @@ namespace Quickstarts
         public static ParsedNodeId Parse(NodeId nodeId)
         {
             // can only parse non-null string node identifiers.
-            if (NodeId.IsNull(nodeId))
+            if ((nodeId).IsNull)
             {
                 return null;
             }

--- a/Workshop/Common/QuickstartNodeManager.cs
+++ b/Workshop/Common/QuickstartNodeManager.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2019 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -294,7 +294,7 @@ namespace Quickstarts
         protected virtual bool IsNodeIdInNamespace(NodeId nodeId)
         {
             // nulls are never a valid node.
-            if (NodeId.IsNull(nodeId))
+            if ((nodeId).IsNull)
             {
                 return false;
             }
@@ -779,7 +779,7 @@ namespace Quickstarts
         /// </summary>
         protected void AddTypesToTypeTree(BaseTypeState type)
         {
-            if (!NodeId.IsNull(type.SuperTypeId))
+            if (!(type.SuperTypeId).IsNull)
             {
                 if (!Server.TypeTree.IsKnown(type.SuperTypeId))
                 {
@@ -1041,33 +1041,33 @@ namespace Quickstarts
                 metadata.BrowseName = target.BrowseName;
                 metadata.DisplayName = target.DisplayName;
 
-                if (values[0].Value != null && values[1].Value != null)
+                if (values[0].AsBoxedObject() != null && values[1].AsBoxedObject() != null)
                 {
-                    metadata.WriteMask = (AttributeWriteMask)(((uint)values[0].Value) & ((uint)values[1].Value));
+                    metadata.WriteMask = (AttributeWriteMask)(((uint)values[0].AsBoxedObject()) & ((uint)values[1].AsBoxedObject()));
                 }
 
-                metadata.DataType = (NodeId)values[2].Value;
+                metadata.DataType = (NodeId)values[2].AsBoxedObject();
 
-                if (values[3].Value != null)
+                if (values[3].AsBoxedObject() != null)
                 {
-                    metadata.ValueRank = (int)values[3].Value;
+                    metadata.ValueRank = (int)values[3].AsBoxedObject();
                 }
 
-                metadata.ArrayDimensions = values[4].Value is IList<uint> dims ? dims.ToArrayOf() : ArrayOf<uint>.Empty;
+                metadata.ArrayDimensions = values[4].AsBoxedObject() is IList<uint> dims ? dims.ToArrayOf() : ArrayOf<uint>.Empty;
 
-                if (values[5].Value != null && values[6].Value != null)
+                if (values[5].AsBoxedObject() != null && values[6].AsBoxedObject() != null)
                 {
-                    metadata.AccessLevel = (byte)(((byte)values[5].Value) & ((byte)values[6].Value));
+                    metadata.AccessLevel = (byte)(((byte)values[5].AsBoxedObject()) & ((byte)values[6].AsBoxedObject()));
                 }
 
-                if (values[7].Value != null)
+                if (values[7].AsBoxedObject() != null)
                 {
-                    metadata.EventNotifier = (byte)values[7].Value;
+                    metadata.EventNotifier = (byte)values[7].AsBoxedObject();
                 }
 
-                if (values[8].Value != null && values[9].Value != null)
+                if (values[8].AsBoxedObject() != null && values[9].AsBoxedObject() != null)
                 {
-                    metadata.Executable = (((bool)values[8].Value) && ((bool)values[9].Value));
+                    metadata.Executable = (((bool)values[8].AsBoxedObject()) && ((bool)values[9].AsBoxedObject()));
                 }
 
                 // get instance references.
@@ -3419,7 +3419,7 @@ namespace Quickstarts
             result = null;
 
             // nothing to do if the filter is not specified.
-            if (ExtensionObject.IsNull(filter))
+            if ((filter).IsNull)
             {
                 return StatusCodes.Good;
             }
@@ -3508,7 +3508,7 @@ namespace Quickstarts
                     return StatusCodes.BadFilterNotAllowed;
                 }
 
-                range = property.Value.Value as Opc.Ua.Range;
+                range = property.Value.AsBoxedObject() as Opc.Ua.Range;
 
                 if (range == null)
                 {

--- a/Workshop/Common/QuickstartNodeManager.cs
+++ b/Workshop/Common/QuickstartNodeManager.cs
@@ -32,6 +32,7 @@ using System.Text;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using Opc.Ua;
 using Opc.Ua.Server;
 using Microsoft.Extensions.Logging;
@@ -438,7 +439,7 @@ namespace Quickstarts
             // must release the lock before removing cross references to other node managers.
             if (referencesToRemove.Count > 0)
             {
-                Server.NodeManager.RemoveReferences(referencesToRemove);
+                Server.NodeManager.RemoveReferencesAsync(referencesToRemove, CancellationToken.None).AsTask().GetAwaiter().GetResult();
             }
 
             return found;
@@ -680,7 +681,7 @@ namespace Quickstarts
 
                 if (variable != null && variable.Value.IsNull)
                 {
-                    variable.Value = new Variant(Opc.Ua.TypeInfo.GetDefaultValue(variable.DataType, variable.ValueRank, Server.TypeTree));
+                    variable.Value = Variant.From((dynamic)Opc.Ua.TypeInfo.GetDefaultValue(variable.DataType, variable.ValueRank, Server.TypeTree));
                 }
 
                 IList<IReference> references = new List<IReference>();
@@ -3325,6 +3326,10 @@ namespace Quickstarts
             }
 
             // create the item.
+            // TODO: The non-obsolete MonitoredItem constructor requires an IAsyncNodeManager.
+            // QuickstartNodeManager is a synchronous INodeManager, so migrating to the async
+            // node-manager model is tracked separately. See issue #723.
+#pragma warning disable CS0618 // Type or member is obsolete
             MonitoredItem datachangeItem = new MonitoredItem(
                 Server,
                 this,
@@ -3343,6 +3348,7 @@ namespace Quickstarts
                 queueSize,
                 itemToCreate.RequestedParameters.DiscardOldest,
                 0);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             // report the initial value.
             ReadInitialValue(context, handle, datachangeItem);

--- a/Workshop/Common/SelectLocaleDlg.cs
+++ b/Workshop/Common/SelectLocaleDlg.cs
@@ -72,7 +72,7 @@ namespace Quickstarts
             // get the locales from the server.
             DataValue value = await m_session.ReadValueAsync(VariableIds.Server_ServerCapabilities_LocaleIdArray, ct);
 
-            if (value != null)
+            if (!value.IsNull)
             {
                 string[] availableLocales = value.GetValue<string[]>(null);
 

--- a/Workshop/DataAccess/Client/MainForm.cs
+++ b/Workshop/DataAccess/Client/MainForm.cs
@@ -259,7 +259,7 @@ namespace Quickstarts.DataAccessClient
                 nodeToBrowse2.NodeClassMask = (uint)(NodeClass.Object | NodeClass.Variable);
                 nodeToBrowse2.ResultMask = (uint)BrowseResultMask.All;
 
-                BrowseDescriptionCollection nodesToBrowse = new BrowseDescriptionCollection();
+                List<BrowseDescription> nodesToBrowse = new List<BrowseDescription>();
                 nodesToBrowse.Add(nodeToBrowse1);
                 nodesToBrowse.Add(nodeToBrowse2);
 
@@ -297,7 +297,7 @@ namespace Quickstarts.DataAccessClient
             {
                 AttributesLV.Items.Clear();
 
-                ReadValueIdCollection nodesToRead = new ReadValueIdCollection();
+                List<ReadValueId> nodesToRead = new List<ReadValueId>();
 
                 // attempt to read all possible attributes.
                 for (uint ii = Attributes.NodeClass; ii <= Attributes.UserExecutable; ii++)
@@ -320,7 +320,7 @@ namespace Quickstarts.DataAccessClient
                 nodeToBrowse1.NodeClassMask = 0;
                 nodeToBrowse1.ResultMask = (uint)BrowseResultMask.All;
 
-                BrowseDescriptionCollection nodesToBrowse = new BrowseDescriptionCollection();
+                List<BrowseDescription> nodesToBrowse = new List<BrowseDescription>();
                 nodesToBrowse.Add(nodeToBrowse1);
 
                 // fetch property references from the server.
@@ -388,7 +388,7 @@ namespace Quickstarts.DataAccessClient
                         // display the value.
                         else
                         {
-                            TypeInfo typeInfo = TypeInfo.Construct(results[ii].Value);
+                            TypeInfo typeInfo = TypeInfo.Construct(results[ii].WrappedValue.AsBoxedObject());
 
                             datatype = typeInfo.BuiltInType.ToString();
 
@@ -397,7 +397,7 @@ namespace Quickstarts.DataAccessClient
                                 datatype += "[]";
                             }
 
-                            value = Utils.Format("{0}", results[ii].Value);
+                            value = Utils.Format("{0}", results[ii].WrappedValue.AsBoxedObject());
                         }
                     }
 
@@ -423,7 +423,7 @@ namespace Quickstarts.DataAccessClient
                         // display the value.
                         else
                         {
-                            TypeInfo typeInfo = TypeInfo.Construct(results[ii].Value);
+                            TypeInfo typeInfo = TypeInfo.Construct(results[ii].WrappedValue.AsBoxedObject());
 
                             datatype = typeInfo.BuiltInType.ToString();
 
@@ -432,7 +432,7 @@ namespace Quickstarts.DataAccessClient
                                 datatype += "[]";
                             }
 
-                            value = Utils.Format("{0}", results[ii].Value);
+                            value = Utils.Format("{0}", results[ii].WrappedValue.AsBoxedObject());
                         }
                     }
 

--- a/Workshop/DataAccess/Client/MainForm.cs
+++ b/Workshop/DataAccess/Client/MainForm.cs
@@ -1183,7 +1183,7 @@ namespace Quickstarts.DataAccessClient
                 }
 
                 ConnectServerCTRL.PreferredLocales = new string[] { locale };
-                m_session.ChangePreferredLocales(new List<string>(ConnectServerCTRL.PreferredLocales));
+                await m_session.ChangePreferredLocalesAsync(new List<string>(ConnectServerCTRL.PreferredLocales));
             }
             catch (Exception exception)
             {

--- a/Workshop/DataAccess/Client/ReadHistoryDlg.cs
+++ b/Workshop/DataAccess/Client/ReadHistoryDlg.cs
@@ -188,7 +188,7 @@ namespace Quickstarts.DataAccessClient
                 nodeToRead.ContinuationPoint = m_result.ContinuationPoint;
             }
 
-            HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+            List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
             nodesToRead.Add(nodeToRead);
 
             HistoryReadResponse response = await m_session.HistoryReadAsync(
@@ -222,7 +222,7 @@ namespace Quickstarts.DataAccessClient
             HistoryReadValueId nodeToRead = new HistoryReadValueId();
             nodeToRead.NodeId = m_nodeId;
 
-            HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+            List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
             nodesToRead.Add(nodeToRead);
 
             HistoryReadResponse response = await m_session.HistoryReadAsync(
@@ -307,7 +307,7 @@ namespace Quickstarts.DataAccessClient
                 nodeToRead.ContinuationPoint = m_result.ContinuationPoint;
             }
 
-            HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+            List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
             nodesToRead.Add(nodeToRead);
 
             HistoryReadResponse response = await m_session.HistoryReadAsync(
@@ -369,7 +369,7 @@ namespace Quickstarts.DataAccessClient
                 nodeToRead.ContinuationPoint = m_result.ContinuationPoint;
             }
 
-            HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+            List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
             nodesToRead.Add(nodeToRead);
 
             HistoryReadResponse response = await m_session.HistoryReadAsync(

--- a/Workshop/DataAccess/Client/WriteValueDlg.cs
+++ b/Workshop/DataAccess/Client/WriteValueDlg.cs
@@ -118,86 +118,70 @@ namespace Quickstarts.DataAccessClient
         /// Changes the value in the text box to the data type required for the write operation.
         /// </summary>
         /// <returns>A value with the correct type.</returns>
-        private object ChangeType()
+        private Variant ChangeType()
         {
-            object value = (m_value != null) ? m_value.WrappedValue.AsBoxedObject() : null;
-
             switch (m_value.WrappedValue.TypeInfo.BuiltInType)
             {
                 case BuiltInType.Boolean:
                 {
-                    value = Convert.ToBoolean(ValueTB.Text);
-                    break;
+                    return Variant.From(Convert.ToBoolean(ValueTB.Text));
                 }
 
                 case BuiltInType.SByte:
                 {
-                    value = Convert.ToSByte(ValueTB.Text);
-                    break;
+                    return Variant.From(Convert.ToSByte(ValueTB.Text));
                 }
 
                 case BuiltInType.Byte:
                 {
-                    value = Convert.ToByte(ValueTB.Text);
-                    break;
+                    return Variant.From(Convert.ToByte(ValueTB.Text));
                 }
 
                 case BuiltInType.Int16:
                 {
-                    value = Convert.ToInt16(ValueTB.Text);
-                    break;
+                    return Variant.From(Convert.ToInt16(ValueTB.Text));
                 }
 
                 case BuiltInType.UInt16:
                 {
-                    value = Convert.ToUInt16(ValueTB.Text);
-                    break;
+                    return Variant.From(Convert.ToUInt16(ValueTB.Text));
                 }
 
                 case BuiltInType.Int32:
                 {
-                    value = Convert.ToInt32(ValueTB.Text);
-                    break;
+                    return Variant.From(Convert.ToInt32(ValueTB.Text));
                 }
 
                 case BuiltInType.UInt32:
                 {
-                    value = Convert.ToUInt32(ValueTB.Text);
-                    break;
+                    return Variant.From(Convert.ToUInt32(ValueTB.Text));
                 }
 
                 case BuiltInType.Int64:
                 {
-                    value = Convert.ToInt64(ValueTB.Text);
-                    break;
+                    return Variant.From(Convert.ToInt64(ValueTB.Text));
                 }
 
                 case BuiltInType.UInt64:
                 {
-                    value = Convert.ToUInt64(ValueTB.Text);
-                    break;
+                    return Variant.From(Convert.ToUInt64(ValueTB.Text));
                 }
 
                 case BuiltInType.Float:
                 {
-                    value = Convert.ToSingle(ValueTB.Text);
-                    break;
+                    return Variant.From(Convert.ToSingle(ValueTB.Text));
                 }
 
                 case BuiltInType.Double:
                 {
-                    value = Convert.ToDouble(ValueTB.Text);
-                    break;
+                    return Variant.From(Convert.ToDouble(ValueTB.Text));
                 }
 
                 default:
                 {
-                    value = ValueTB.Text;
-                    break;
+                    return Variant.From(ValueTB.Text);
                 }
             }
-
-            return value;
         }
         #endregion
 
@@ -214,7 +198,7 @@ namespace Quickstarts.DataAccessClient
                 valueToWrite.NodeId = m_nodeId;
                 valueToWrite.AttributeId = m_attributeId;
                 valueToWrite.Value = new DataValue(
-                    new Variant(ChangeType()),
+                    ChangeType(),
                     StatusCodes.Good,
                     DateTime.MinValue,
                     DateTime.MinValue);

--- a/Workshop/DataAccess/Client/WriteValueDlg.cs
+++ b/Workshop/DataAccess/Client/WriteValueDlg.cs
@@ -83,7 +83,7 @@ namespace Quickstarts.DataAccessClient
             nodeToRead.NodeId = nodeId;
             nodeToRead.AttributeId = attributeId;
 
-            ReadValueIdCollection nodesToRead = new ReadValueIdCollection();
+            List<ReadValueId> nodesToRead = new List<ReadValueId>();
             nodesToRead.Add(nodeToRead);
 
             // read current value.
@@ -120,7 +120,7 @@ namespace Quickstarts.DataAccessClient
         /// <returns>A value with the correct type.</returns>
         private object ChangeType()
         {
-            object value = (m_value != null) ? m_value.Value : null;
+            object value = (m_value != null) ? m_value.WrappedValue.AsBoxedObject() : null;
 
             switch (m_value.WrappedValue.TypeInfo.BuiltInType)
             {
@@ -219,7 +219,7 @@ namespace Quickstarts.DataAccessClient
                     DateTime.MinValue,
                     DateTime.MinValue);
 
-                WriteValueCollection valuesToWrite = new WriteValueCollection();
+                List<WriteValue> valuesToWrite = new List<WriteValue>();
                 valuesToWrite.Add(valueToWrite);
 
                 // write current value.

--- a/Workshop/DataAccess/Server/Model/BlockState.cs
+++ b/Workshop/DataAccess/Server/Model/BlockState.cs
@@ -158,7 +158,7 @@ namespace Quickstarts.DataAccessServer
                 return StatusCodes.BadNodeIdUnknown;
             }
 
-            StatusCode error = block.WriteTagValue(node.SymbolicName, value.Value);
+            StatusCode error = block.WriteTagValue(node.SymbolicName, value.AsBoxedObject());
 
             if (error != 0)
             {

--- a/Workshop/DataAccess/Server/Model/BlockState.cs
+++ b/Workshop/DataAccess/Server/Model/BlockState.cs
@@ -308,7 +308,7 @@ namespace Quickstarts.DataAccessServer
         private void UpdateVariable(ISystemContext context, UnderlyingSystemTag tag, BaseVariableState variable)
         {
             variable.Description = new LocalizedText(tag.Description);
-            variable.Value = new Variant(tag.Value);
+            variable.Value = Variant.From((dynamic)tag.Value);
             variable.Timestamp = tag.Timestamp;
 
             switch (tag.DataType)

--- a/Workshop/DataAccess/Server/Model/ModelUtils.cs
+++ b/Workshop/DataAccess/Server/Model/ModelUtils.cs
@@ -106,7 +106,7 @@ namespace Quickstarts.DataAccessServer
             }
 
             // parent must have a string identifier.
-            string parentId = instance.Parent.NodeId.Identifier as string;
+            string parentId = instance.Parent.NodeId.TryGetValue(out string id) ? id : null;
 
             if (parentId == null)
             {

--- a/Workshop/DataAccess/Server/Model/SegmentBrowser.cs
+++ b/Workshop/DataAccess/Server/Model/SegmentBrowser.cs
@@ -169,7 +169,7 @@ namespace Quickstarts.DataAccessServer
             NodeId targetId = NodeId.Null;
 
             // check if a specific browse name is requested.
-            if (!QualifiedName.IsNull(base.BrowseName))
+            if (!(base.BrowseName).IsNull)
             {
                 // check if match found previously.
                 if (m_position == Int32.MaxValue)

--- a/Workshop/DataTypes/Common/Types/Quickstarts.DataTypes.Types.Classes.cs
+++ b/Workshop/DataTypes/Common/Types/Quickstarts.DataTypes.Types.Classes.cs
@@ -239,7 +239,7 @@ namespace Quickstarts.DataTypes.Types
 
             public Variant WithValue(VehicleType[] value)
             {
-                return new Variant(value);
+                return Variant.FromStructure<VehicleType>(value, false);
             }
         }
 

--- a/Workshop/DataTypes/Common/Types/Quickstarts.DataTypes.Types.Classes.cs
+++ b/Workshop/DataTypes/Common/Types/Quickstarts.DataTypes.Types.Classes.cs
@@ -169,7 +169,7 @@ namespace Quickstarts.DataTypes.Types
             bool createOrReplace,
             BaseInstanceState replacement)
         {
-            if (QualifiedName.IsNull(browseName))
+            if ((browseName).IsNull)
             {
                 return null;
             }
@@ -234,7 +234,7 @@ namespace Quickstarts.DataTypes.Types
         {
             public VehicleType[] GetValue(Variant value)
             {
-                return value.Value as VehicleType[];
+                return value.AsBoxedObject() as VehicleType[];
             }
 
             public Variant WithValue(VehicleType[] value)

--- a/Workshop/HistoricalAccess/Client/HistoryDataListView.cs
+++ b/Workshop/HistoricalAccess/Client/HistoryDataListView.cs
@@ -288,10 +288,10 @@ namespace Quickstarts.HistoricalAccess.Client
             HistoryReadValueId nodeToRead = new HistoryReadValueId();
             nodeToRead.NodeId = m_nodeId;
 
-            HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+            List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
             nodesToRead.Add(nodeToRead);
 
-            HistoryReadResultCollection results = null;
+            List<HistoryReadResult> results = null;
             DiagnosticInfoCollection diagnosticInfos = null;
 
             m_session.HistoryRead(
@@ -358,10 +358,10 @@ namespace Quickstarts.HistoricalAccess.Client
             HistoryReadValueId nodeToRead = new HistoryReadValueId();
             nodeToRead.NodeId = m_nodeId;
 
-            HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+            List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
             nodesToRead.Add(nodeToRead);
 
-            HistoryReadResultCollection results = null;
+            List<HistoryReadResult> results = null;
             DiagnosticInfoCollection diagnosticInfos = null;
 
             m_session.HistoryRead(
@@ -591,12 +591,12 @@ namespace Quickstarts.HistoricalAccess.Client
             details.IsReadModified = isReadModified;
             details.ReturnBounds = (isReadModified)?false:ReturnBoundsCK.Checked;
 
-            HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+            List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
             HistoryReadValueId nodeToRead = new HistoryReadValueId();
             nodeToRead.NodeId = m_nodeId;
             nodesToRead.Add(nodeToRead);
 
-            HistoryReadResultCollection results = null;
+            List<HistoryReadResult> results = null;
             DiagnosticInfoCollection diagnosticInfos = null;
 
             m_session.HistoryRead(
@@ -638,12 +638,12 @@ namespace Quickstarts.HistoricalAccess.Client
                 details.ReqTimes.Add(startTime.AddMilliseconds((double)(ii*TimeStepNP.Value)));
             }
 
-            HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+            List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
             HistoryReadValueId nodeToRead = new HistoryReadValueId();
             nodeToRead.NodeId = m_nodeId;
             nodesToRead.Add(nodeToRead);
 
-            HistoryReadResultCollection results = null;
+            List<HistoryReadResult> results = null;
             DiagnosticInfoCollection diagnosticInfos = null;
 
             m_session.HistoryRead(
@@ -684,12 +684,12 @@ namespace Quickstarts.HistoricalAccess.Client
             details.AggregateType.Add(aggregate.NodeId);
             details.AggregateConfiguration.UseServerCapabilitiesDefaults = true;
 
-            HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+            List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
             HistoryReadValueId nodeToRead = new HistoryReadValueId();
             nodeToRead.NodeId = m_nodeId;
             nodesToRead.Add(nodeToRead);
 
-            HistoryReadResultCollection results = null;
+            List<HistoryReadResult> results = null;
             DiagnosticInfoCollection diagnosticInfos = null;
 
             m_session.HistoryRead(
@@ -724,10 +724,10 @@ namespace Quickstarts.HistoricalAccess.Client
             // clear existing continuation point.
             if (m_nodeToContinue != null)
             {
-                HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+                List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
                 nodesToRead.Add(m_nodeToContinue);
                                 
-                HistoryReadResultCollection results = null;
+                List<HistoryReadResult> results = null;
                 DiagnosticInfoCollection diagnosticInfos = null;
 
                 m_session.HistoryRead(

--- a/Workshop/HistoricalAccess/Client/ReadHistoryDlg.cs
+++ b/Workshop/HistoricalAccess/Client/ReadHistoryDlg.cs
@@ -193,7 +193,7 @@ namespace Quickstarts.HistoricalAccess.Client
                 nodeToRead.ContinuationPoint = m_result.ContinuationPoint;
             }
 
-            HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+            List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
             nodesToRead.Add(nodeToRead);
 
             HistoryReadResponse response = await m_session.HistoryReadAsync(
@@ -227,7 +227,7 @@ namespace Quickstarts.HistoricalAccess.Client
             HistoryReadValueId nodeToRead = new HistoryReadValueId();
             nodeToRead.NodeId = m_nodeId;
 
-            HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+            List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
             nodesToRead.Add(nodeToRead);
 
             HistoryReadResponse response = await m_session.HistoryReadAsync(
@@ -312,7 +312,7 @@ namespace Quickstarts.HistoricalAccess.Client
                 nodeToRead.ContinuationPoint = m_result.ContinuationPoint;
             }
 
-            HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+            List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
             nodesToRead.Add(nodeToRead);
 
             HistoryReadResponse response = await m_session.HistoryReadAsync(
@@ -374,7 +374,7 @@ namespace Quickstarts.HistoricalAccess.Client
                 nodeToRead.ContinuationPoint = m_result.ContinuationPoint;
             }
 
-            HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+            List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
             nodesToRead.Add(nodeToRead);
 
             HistoryReadResponse response = await m_session.HistoryReadAsync(

--- a/Workshop/HistoricalAccess/Client/WriteValueDlg.cs
+++ b/Workshop/HistoricalAccess/Client/WriteValueDlg.cs
@@ -121,86 +121,70 @@ namespace Quickstarts.HistoricalAccess.Client
         /// Changes the value in the text box to the data type required for the write operation.
         /// </summary>
         /// <returns>A value with the correct type.</returns>
-        private object ChangeType()
+        private Variant ChangeType()
         {
-            object value = m_value.WrappedValue.AsBoxedObject();
-
             switch (m_value.WrappedValue.TypeInfo.BuiltInType)
             {
                 case BuiltInType.Boolean:
                 {
-                    value = Convert.ToBoolean(ValueTB.Text);
-                    break;
+                    return Variant.From(Convert.ToBoolean(ValueTB.Text));
                 }
 
                 case BuiltInType.SByte:
                 {
-                    value = Convert.ToSByte(ValueTB.Text);
-                    break;
+                    return Variant.From(Convert.ToSByte(ValueTB.Text));
                 }
 
                 case BuiltInType.Byte:
                 {
-                    value = Convert.ToByte(ValueTB.Text);
-                    break;
+                    return Variant.From(Convert.ToByte(ValueTB.Text));
                 }
 
                 case BuiltInType.Int16:
                 {
-                    value = Convert.ToInt16(ValueTB.Text);
-                    break;
+                    return Variant.From(Convert.ToInt16(ValueTB.Text));
                 }
 
                 case BuiltInType.UInt16:
                 {
-                    value = Convert.ToUInt16(ValueTB.Text);
-                    break;
+                    return Variant.From(Convert.ToUInt16(ValueTB.Text));
                 }
 
                 case BuiltInType.Int32:
                 {
-                    value = Convert.ToInt32(ValueTB.Text);
-                    break;
+                    return Variant.From(Convert.ToInt32(ValueTB.Text));
                 }
 
                 case BuiltInType.UInt32:
                 {
-                    value = Convert.ToUInt32(ValueTB.Text);
-                    break;
+                    return Variant.From(Convert.ToUInt32(ValueTB.Text));
                 }
 
                 case BuiltInType.Int64:
                 {
-                    value = Convert.ToInt64(ValueTB.Text);
-                    break;
+                    return Variant.From(Convert.ToInt64(ValueTB.Text));
                 }
 
                 case BuiltInType.UInt64:
                 {
-                    value = Convert.ToUInt64(ValueTB.Text);
-                    break;
+                    return Variant.From(Convert.ToUInt64(ValueTB.Text));
                 }
 
                 case BuiltInType.Float:
                 {
-                    value = Convert.ToSingle(ValueTB.Text);
-                    break;
+                    return Variant.From(Convert.ToSingle(ValueTB.Text));
                 }
 
                 case BuiltInType.Double:
                 {
-                    value = Convert.ToDouble(ValueTB.Text);
-                    break;
+                    return Variant.From(Convert.ToDouble(ValueTB.Text));
                 }
 
                 default:
                 {
-                    value = ValueTB.Text;
-                    break;
+                    return Variant.From(ValueTB.Text);
                 }
             }
-
-            return value;
         }
         #endregion
 
@@ -217,7 +201,7 @@ namespace Quickstarts.HistoricalAccess.Client
                 valueToWrite.NodeId = m_nodeId;
                 valueToWrite.AttributeId = m_attributeId;
                 valueToWrite.Value = new DataValue(
-                    new Variant(ChangeType()),
+                    ChangeType(),
                     StatusCodes.Good,
                     DateTime.MinValue,
                     DateTime.MinValue);

--- a/Workshop/HistoricalAccess/Client/WriteValueDlg.cs
+++ b/Workshop/HistoricalAccess/Client/WriteValueDlg.cs
@@ -85,7 +85,7 @@ namespace Quickstarts.HistoricalAccess.Client
             nodeToRead.NodeId = nodeId;
             nodeToRead.AttributeId = attributeId;
 
-            ReadValueIdCollection nodesToRead = new ReadValueIdCollection();
+            List<ReadValueId> nodesToRead = new List<ReadValueId>();
             nodesToRead.Add(nodeToRead);
 
             // read current value.
@@ -104,7 +104,7 @@ namespace Quickstarts.HistoricalAccess.Client
             ClientBase.ValidateDiagnosticInfos(diagnosticInfos, nodesToRead);
 
             m_value = results[0];
-            ValueTB.Text = Utils.Format("{0}", m_value.Value);
+            ValueTB.Text = Utils.Format("{0}", m_value.WrappedValue.AsBoxedObject());
 
             // display the dialog.
             if (ShowDialog() != DialogResult.OK)
@@ -123,7 +123,7 @@ namespace Quickstarts.HistoricalAccess.Client
         /// <returns>A value with the correct type.</returns>
         private object ChangeType()
         {
-            object value = m_value.Value;
+            object value = m_value.WrappedValue.AsBoxedObject();
 
             switch (m_value.WrappedValue.TypeInfo.BuiltInType)
             {
@@ -222,7 +222,7 @@ namespace Quickstarts.HistoricalAccess.Client
                     DateTime.MinValue,
                     DateTime.MinValue);
 
-                WriteValueCollection valuesToWrite = new WriteValueCollection();
+                List<WriteValue> valuesToWrite = new List<WriteValue>();
                 valuesToWrite.Add(valueToWrite);
 
                 // write current value.

--- a/Workshop/HistoricalAccess/Server/HistoricalAccessNodeManager.cs
+++ b/Workshop/HistoricalAccess/Server/HistoricalAccessNodeManager.cs
@@ -1030,7 +1030,7 @@ namespace Quickstarts.HistoricalAccessServer
                     // process each item.
                     for (int jj = 0; jj < nodeToUpdate.UpdateValues.Count; jj++)
                     {
-                        Annotation annotation = ExtensionObject.ToEncodeable((ExtensionObject)nodeToUpdate.UpdateValues[jj].Value) as Annotation;
+                        Annotation annotation = ExtensionObject.ToEncodeable((ExtensionObject)nodeToUpdate.UpdateValues[jj].WrappedValue.AsBoxedObject()) as Annotation;
 
                         if (annotation == null)
                         {
@@ -1193,7 +1193,7 @@ namespace Quickstarts.HistoricalAccessServer
             HistoryReadValueId nodeToRead)
         {
             bool sizeLimited = (details.StartTime == DateTime.MinValue || details.EndTime == DateTime.MinValue);
-            bool applyIndexRangeOrEncoding = (!nodeToRead.ParsedIndexRange.IsNull || !QualifiedName.IsNull(nodeToRead.DataEncoding));
+            bool applyIndexRangeOrEncoding = (!nodeToRead.ParsedIndexRange.IsNull || !(nodeToRead.DataEncoding).IsNull);
             bool returnBounds = !details.IsReadModified && details.ReturnBounds;
             bool timeFlowsBackward = (details.StartTime == DateTime.MinValue) || (details.EndTime != DateTime.MinValue && details.EndTime < details.StartTime);
 
@@ -1385,7 +1385,7 @@ namespace Quickstarts.HistoricalAccessServer
             HistoryReadValueId nodeToRead,
             NodeId aggregateId)
         {
-            bool applyIndexRangeOrEncoding = (nodeToRead.ParsedIndexRange != NumericRange.Null || !QualifiedName.IsNull(nodeToRead.DataEncoding));
+            bool applyIndexRangeOrEncoding = (nodeToRead.ParsedIndexRange != NumericRange.Null || !(nodeToRead.DataEncoding).IsNull);
             bool timeFlowsBackward = (details.EndTime < details.StartTime);
 
             ArchiveItemState item = handle.Node as ArchiveItemState;
@@ -1472,7 +1472,7 @@ namespace Quickstarts.HistoricalAccessServer
             NodeHandle handle,
             HistoryReadValueId nodeToRead)
         {
-            bool applyIndexRangeOrEncoding = (!nodeToRead.ParsedIndexRange.IsNull || !QualifiedName.IsNull(nodeToRead.DataEncoding));
+            bool applyIndexRangeOrEncoding = (!nodeToRead.ParsedIndexRange.IsNull || !(nodeToRead.DataEncoding).IsNull);
 
             ArchiveItemState item = handle.Node as ArchiveItemState;
 
@@ -1538,7 +1538,7 @@ namespace Quickstarts.HistoricalAccessServer
 
                     if (StatusCode.IsNotBad(value.StatusCode) && dataBeforeIgnored)
                     {
-                        value = new DataValue(value.WrappedValue, value.StatusCode.SetCodeBits(StatusCodes.UncertainDataSubNormal), value.SourceTimestamp, value.ServerTimestamp, value.SourcePicoseconds, value.ServerPicoseconds);
+                        value = new DataValue(value.WrappedValue, value.StatusCode.WithCodeBits(StatusCodes.UncertainDataSubNormal), value.SourceTimestamp, value.ServerTimestamp, value.SourcePicoseconds, value.ServerPicoseconds);
                     }
 
                     values.AddLast(value);
@@ -1552,7 +1552,7 @@ namespace Quickstarts.HistoricalAccessServer
 
                     if (StatusCode.IsNotBad(value.StatusCode) && dataBeforeIgnored)
                     {
-                        value = new DataValue(value.WrappedValue, value.StatusCode.SetCodeBits(StatusCodes.UncertainDataSubNormal), value.SourceTimestamp, value.ServerTimestamp, value.SourcePicoseconds, value.ServerPicoseconds);
+                        value = new DataValue(value.WrappedValue, value.StatusCode.WithCodeBits(StatusCodes.UncertainDataSubNormal), value.SourceTimestamp, value.ServerTimestamp, value.SourcePicoseconds, value.ServerPicoseconds);
                     }
                 }
                 else
@@ -1561,7 +1561,7 @@ namespace Quickstarts.HistoricalAccessServer
 
                     if (StatusCode.IsNotBad(value.StatusCode) && (dataBeforeIgnored || dataAfterIgnored))
                     {
-                        value = new DataValue(value.WrappedValue, value.StatusCode.SetCodeBits(StatusCodes.UncertainDataSubNormal), value.SourceTimestamp, value.ServerTimestamp, value.SourcePicoseconds, value.ServerPicoseconds);
+                        value = new DataValue(value.WrappedValue, value.StatusCode.WithCodeBits(StatusCodes.UncertainDataSubNormal), value.SourceTimestamp, value.ServerTimestamp, value.SourcePicoseconds, value.ServerPicoseconds);
                     }
                 }
 

--- a/Workshop/HistoricalAccess/Server/Model/SegmentBrowser.cs
+++ b/Workshop/HistoricalAccess/Server/Model/SegmentBrowser.cs
@@ -169,7 +169,7 @@ namespace Quickstarts.HistoricalAccessServer
             NodeId targetId = null;
 
             // check if a specific browse name is requested.
-            if (!QualifiedName.IsNull(base.BrowseName))
+            if (!(base.BrowseName).IsNull)
             {
                 // check if match found previously.
                 if (m_position == Int32.MaxValue)

--- a/Workshop/HistoricalAccess/Server/Program.cs
+++ b/Workshop/HistoricalAccess/Server/Program.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2019 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -270,10 +270,10 @@ namespace Quickstarts.HistoricalAccessServer
 
                     switch (fields[2 * testId])
                     {
-                        case "GI": { statusCode = statusCode.SetAggregateBits(AggregateBits.Interpolated); break; }
-                        case "GC": { statusCode = statusCode.SetAggregateBits(AggregateBits.Calculated); break; }
-                        case "UC": { statusCode = StatusCodes.UncertainSubNormal.SetAggregateBits(AggregateBits.Calculated); break; }
-                        case "UI": { statusCode = StatusCodes.UncertainSubNormal.SetAggregateBits(AggregateBits.Interpolated); break; }
+                        case "GI": { statusCode = statusCode.WithAggregateBits(AggregateBits.Interpolated); break; }
+                        case "GC": { statusCode = statusCode.WithAggregateBits(AggregateBits.Calculated); break; }
+                        case "UC": { statusCode = StatusCodes.UncertainSubNormal.WithAggregateBits(AggregateBits.Calculated); break; }
+                        case "UI": { statusCode = StatusCodes.UncertainSubNormal.WithAggregateBits(AggregateBits.Interpolated); break; }
                         case "UR": { statusCode = StatusCodes.Uncertain; break; }
                         case "BR": { statusCode = StatusCodes.BadNoData; break; }
                         case "BD": { statusCode = StatusCodes.Bad; break; }
@@ -360,8 +360,8 @@ namespace Quickstarts.HistoricalAccessServer
 
                 if (StatusCode.IsNotBad(values[ii].StatusCode))
                 {
-                    double value1 = Math.Round(Convert.ToDouble(values[ii].Value), 4);
-                    double value2 = Math.Round(Convert.ToDouble(expectedValues[ii].Value), 4);
+                    double value1 = Math.Round(Convert.ToDouble(values[ii].WrappedValue.AsBoxedObject()), 4);
+                    double value2 = Math.Round(Convert.ToDouble(expectedValues[ii].WrappedValue.AsBoxedObject()), 4);
 
                     if (value1 != value2)
                     {

--- a/Workshop/HistoricalAccess/Server/UnderlyingSystem/ArchiveFolderBrowser.cs
+++ b/Workshop/HistoricalAccess/Server/UnderlyingSystem/ArchiveFolderBrowser.cs
@@ -186,7 +186,7 @@ namespace Quickstarts.HistoricalAccessServer
             NodeId targetId = NodeId.Null;
 
             // check if a specific browse name is requested.
-            if (!QualifiedName.IsNull(base.BrowseName))
+            if (!(base.BrowseName).IsNull)
             {
                 // check if match found previously.
                 if (m_position == Int32.MaxValue)

--- a/Workshop/HistoricalAccess/Server/UnderlyingSystem/ArchiveItemState.cs
+++ b/Workshop/HistoricalAccess/Server/UnderlyingSystem/ArchiveItemState.cs
@@ -219,12 +219,12 @@ namespace Quickstarts.HistoricalAccessServer
             {
                 TypeInfo typeInfo = value.WrappedValue.TypeInfo;
 
-                if (typeInfo == null)
+                if (typeInfo.IsUnknown)
                 {
                     typeInfo = TypeInfo.Construct(value.WrappedValue.AsBoxedObject());
                 }
 
-                if (typeInfo == null || typeInfo.BuiltInType != m_archiveItem.DataType || typeInfo.ValueRank != ValueRanks.Scalar)
+                if (typeInfo.IsUnknown || typeInfo.BuiltInType != m_archiveItem.DataType || typeInfo.ValueRank != ValueRanks.Scalar)
                 {
                     return StatusCodes.BadTypeMismatch.Code;
                 }
@@ -279,7 +279,7 @@ namespace Quickstarts.HistoricalAccessServer
                 modifiedRow[1] = value.ServerTimestamp;
                 modifiedRow[2] = value;
 
-                if (value.WrappedValue.TypeInfo != null)
+                if (!value.WrappedValue.TypeInfo.IsUnknown)
                 {
                     modifiedRow[3] = value.WrappedValue.TypeInfo.BuiltInType;
                     modifiedRow[4] = value.WrappedValue.TypeInfo.ValueRank;
@@ -303,7 +303,7 @@ namespace Quickstarts.HistoricalAccessServer
             row[1] = value.ServerTimestamp;
             row[2] = value;
 
-            if (value.WrappedValue.TypeInfo != null)
+            if (!value.WrappedValue.TypeInfo.IsUnknown)
             {
                 row[3] = value.WrappedValue.TypeInfo.BuiltInType;
                 row[4] = value.WrappedValue.TypeInfo.ValueRank;

--- a/Workshop/HistoricalAccess/Server/UnderlyingSystem/ArchiveItemState.cs
+++ b/Workshop/HistoricalAccess/Server/UnderlyingSystem/ArchiveItemState.cs
@@ -221,7 +221,7 @@ namespace Quickstarts.HistoricalAccessServer
 
                 if (typeInfo == null)
                 {
-                    typeInfo = TypeInfo.Construct(value.Value);
+                    typeInfo = TypeInfo.Construct(value.WrappedValue.AsBoxedObject());
                 }
 
                 if (typeInfo == null || typeInfo.BuiltInType != m_archiveItem.DataType || typeInfo.ValueRank != ValueRanks.Scalar)

--- a/Workshop/HistoricalAccess/Server/UnderlyingSystem/DataFileReader.cs
+++ b/Workshop/HistoricalAccess/Server/UnderlyingSystem/DataFileReader.cs
@@ -326,7 +326,7 @@ namespace Quickstarts.HistoricalAccessServer
         {
             DataSet dataset = CreateDataSet();
 
-            ServiceMessageContext messageContext = new ServiceMessageContext(m_telemetry);
+            ServiceMessageContext messageContext = ServiceMessageContext.Create(m_telemetry);
 
             if (context != null)
             {
@@ -460,7 +460,7 @@ namespace Quickstarts.HistoricalAccessServer
                     row[1] = dataValue.ServerTimestamp;
                     row[2] = dataValue;
                     row[3] = valueType;
-                    row[4] = (value.TypeInfo != null) ? value.TypeInfo.ValueRank : ValueRanks.Any;
+                    row[4] = (!value.TypeInfo.IsUnknown) ? value.TypeInfo.ValueRank : ValueRanks.Any;
 
                     dataset.Tables[0].Rows.Add(row);
                 }
@@ -473,7 +473,7 @@ namespace Quickstarts.HistoricalAccessServer
                     row[1] = dataValue.ServerTimestamp;
                     row[2] = dataValue;
                     row[3] = valueType;
-                    row[4] = (value.TypeInfo != null) ? value.TypeInfo.ValueRank : ValueRanks.Any;
+                    row[4] = (!value.TypeInfo.IsUnknown) ? value.TypeInfo.ValueRank : ValueRanks.Any;
                     row[5] = recordType;
 
                     ModificationInfo info = new ModificationInfo();
@@ -503,7 +503,7 @@ namespace Quickstarts.HistoricalAccessServer
                     row[1] = dataValue.ServerTimestamp;
                     row[2] = dataValue;
                     row[3] = valueType;
-                    row[4] = (value.TypeInfo != null) ? value.TypeInfo.ValueRank : ValueRanks.Any;
+                    row[4] = (!value.TypeInfo.IsUnknown) ? value.TypeInfo.ValueRank : ValueRanks.Any;
                     row[5] = annotation;
 
                     dataset.Tables[2].Rows.Add(row);

--- a/Workshop/HistoricalAccess/Server/UnderlyingSystem/NodeTypes.cs
+++ b/Workshop/HistoricalAccess/Server/UnderlyingSystem/NodeTypes.cs
@@ -72,7 +72,7 @@ namespace Quickstarts.HistoricalAccessServer
             }
 
             // parent must have a string identifier.
-            string parentId = instance.Parent.NodeId.Identifier as string;
+            string parentId = instance.Parent.NodeId.TryGetValue(out string id) ? id : null;
 
             if (parentId == null)
             {

--- a/Workshop/HistoricalAccess/Tester/MainForm.cs
+++ b/Workshop/HistoricalAccess/Tester/MainForm.cs
@@ -577,13 +577,13 @@ namespace Quickstarts
                 {
                     if (result.TypeInfo.BuiltInType == BuiltInType.Double)
                     {
-                        if (Math.Truncate((double)result.Value) == (double)result.Value)
+                        if (Math.Truncate((double)result.AsBoxedObject()) == (double)result.AsBoxedObject())
                         {
-                            buffer.AppendFormat("{0}", (long)(double)result.Value);
+                            buffer.AppendFormat("{0}", (long)(double)result.AsBoxedObject());
                         }
                         else
                         {
-                            buffer.AppendFormat("{0:F3}", result.Value);
+                            buffer.AppendFormat("{0:F3}", result.AsBoxedObject());
                         }
                     }
                     else
@@ -883,7 +883,7 @@ namespace Quickstarts
                 {
                     Variant expectedValue = TestData.ValidateValue(row[3]);
 
-                    StatusCode? statusValue1 = expectedValue.Value as StatusCode?;
+                    StatusCode? statusValue1 = expectedValue.AsBoxedObject() as StatusCode?;
 
                     if (statusValue1 != null)
                     {
@@ -898,7 +898,7 @@ namespace Quickstarts
 
                     else
                     {
-                        double value1 = Math.Round(Convert.ToDouble(expectedValue.Value), 4);
+                        double value1 = Math.Round(Convert.ToDouble(expectedValue.AsBoxedObject()), 4);
                         double value2 = Math.Round(Convert.ToDouble(actualValue.Value), 4);
 
                         if (value1 != value2)
@@ -1346,13 +1346,13 @@ namespace Quickstarts
                     {
                         if (value.TypeInfo.BuiltInType == BuiltInType.Double)
                         {
-                            if (Math.Truncate((double)value.Value) == (double)value.Value)
+                            if (Math.Truncate((double)value.AsBoxedObject()) == (double)value.AsBoxedObject())
                             {
-                                buffer.AppendFormat("{0}", (long)(double)value.Value);
+                                buffer.AppendFormat("{0}", (long)(double)value.AsBoxedObject());
                             }
                             else
                             {
-                                buffer.AppendFormat("{0:F3}", value.Value);
+                                buffer.AppendFormat("{0:F3}", value.AsBoxedObject());
                             }
                         }
                         else

--- a/Workshop/HistoricalAccess/Tester/MainForm.cs
+++ b/Workshop/HistoricalAccess/Tester/MainForm.cs
@@ -573,7 +573,7 @@ namespace Quickstarts
 
                 Variant result = TestData.ValidateValue(value.Value);
 
-                if (result.TypeInfo != null)
+                if (!result.TypeInfo.IsUnknown)
                 {
                     if (result.TypeInfo.BuiltInType == BuiltInType.Double)
                     {
@@ -1342,7 +1342,7 @@ namespace Quickstarts
 
                     Variant value = TestData.ValidateValue(row[3]);
 
-                    if (value.TypeInfo != null)
+                    if (!value.TypeInfo.IsUnknown)
                     {
                         if (value.TypeInfo.BuiltInType == BuiltInType.Double)
                         {

--- a/Workshop/HistoricalAccess/Tester/TestDataHelpers.cs
+++ b/Workshop/HistoricalAccess/Tester/TestDataHelpers.cs
@@ -236,7 +236,7 @@ namespace Quickstarts
             public DataValue() { m_value = new Opc.Ua.DataValue(); }
             public DataValue(Opc.Ua.DataValue value) { m_value = value; }
             public string Comment { get; set; }
-            public object Value { get { return m_value.WrappedValue.AsBoxedObject(); } set { m_value = new Opc.Ua.DataValue(new Variant(value), m_value.StatusCode, m_value.SourceTimestamp, m_value.ServerTimestamp, m_value.SourcePicoseconds, m_value.ServerPicoseconds); } }
+            public object Value { get { return m_value.WrappedValue.AsBoxedObject(); } set { WrappedValue = value is Variant variant ? variant : Variant.Null; } }
             public Variant WrappedValue { get { return m_value.WrappedValue; } set { m_value = new Opc.Ua.DataValue(value, m_value.StatusCode, m_value.SourceTimestamp, m_value.ServerTimestamp, m_value.SourcePicoseconds, m_value.ServerPicoseconds); } }
             public DateTime SourceTimestamp { get { return (DateTime)m_value.SourceTimestamp; } set { m_value = new Opc.Ua.DataValue(m_value.WrappedValue, m_value.StatusCode, value, m_value.ServerTimestamp, m_value.SourcePicoseconds, m_value.ServerPicoseconds); } }
             public StatusCode StatusCode { get { return m_value.StatusCode; } set { m_value = new Opc.Ua.DataValue(m_value.WrappedValue, value, m_value.SourceTimestamp, m_value.ServerTimestamp, m_value.SourcePicoseconds, m_value.ServerPicoseconds); } }
@@ -430,24 +430,24 @@ namespace Quickstarts
 
             if (String.Equals(value, "true", StringComparison.OrdinalIgnoreCase))
             {
-                return new Variant(true, TypeInfo.Scalars.Boolean);
+                return Variant.From(true);
             }
 
             if (String.Equals(value, "false", StringComparison.OrdinalIgnoreCase))
             {
-                return new Variant(false, TypeInfo.Scalars.Boolean);
+                return Variant.From(false);
             }
 
             try
             {
-                return new Variant(Convert.ToDouble(value), TypeInfo.Scalars.Double);
+                return Variant.From(Convert.ToDouble(value));
             }
             catch
             {
                 try
                 {
                     StatusCode code = (StatusCode)typeof(StatusCodes).GetField(value).GetValue(null);
-                    return new Variant(code, TypeInfo.Scalars.StatusCode);
+                    return Variant.From(code);
                 }
                 catch
                 {

--- a/Workshop/HistoricalAccess/Tester/TestDataHelpers.cs
+++ b/Workshop/HistoricalAccess/Tester/TestDataHelpers.cs
@@ -236,7 +236,7 @@ namespace Quickstarts
             public DataValue() { m_value = new Opc.Ua.DataValue(); }
             public DataValue(Opc.Ua.DataValue value) { m_value = value; }
             public string Comment { get; set; }
-            public object Value { get { return m_value.Value; } set { m_value = new Opc.Ua.DataValue(new Variant(value), m_value.StatusCode, m_value.SourceTimestamp, m_value.ServerTimestamp, m_value.SourcePicoseconds, m_value.ServerPicoseconds); } }
+            public object Value { get { return m_value.WrappedValue.AsBoxedObject(); } set { m_value = new Opc.Ua.DataValue(new Variant(value), m_value.StatusCode, m_value.SourceTimestamp, m_value.ServerTimestamp, m_value.SourcePicoseconds, m_value.ServerPicoseconds); } }
             public Variant WrappedValue { get { return m_value.WrappedValue; } set { m_value = new Opc.Ua.DataValue(value, m_value.StatusCode, m_value.SourceTimestamp, m_value.ServerTimestamp, m_value.SourcePicoseconds, m_value.ServerPicoseconds); } }
             public DateTime SourceTimestamp { get { return (DateTime)m_value.SourceTimestamp; } set { m_value = new Opc.Ua.DataValue(m_value.WrappedValue, m_value.StatusCode, value, m_value.ServerTimestamp, m_value.SourcePicoseconds, m_value.ServerPicoseconds); } }
             public StatusCode StatusCode { get { return m_value.StatusCode; } set { m_value = new Opc.Ua.DataValue(m_value.WrappedValue, value, m_value.SourceTimestamp, m_value.ServerTimestamp, m_value.SourcePicoseconds, m_value.ServerPicoseconds); } }
@@ -308,7 +308,7 @@ namespace Quickstarts
                 return String.Empty;
             }
 
-            double? doubleValue = value.Value as double?;
+            double? doubleValue = value.AsBoxedObject() as double?;
 
             if (doubleValue != null)
             {
@@ -499,13 +499,13 @@ namespace Quickstarts
                 switch (parts[ii].Trim())
                 {
                     case "I":
-                    case "Interpolated": { statusCode = statusCode.SetAggregateBits(statusCode.AggregateBits | AggregateBits.Interpolated); break; }
-                    case "C": { statusCode = statusCode.SetAggregateBits(statusCode.AggregateBits | AggregateBits.Calculated); break; }
-                    case "Calculated": { statusCode = statusCode.SetAggregateBits(statusCode.AggregateBits | AggregateBits.Calculated); break; }
-                    case "P": { statusCode = statusCode.SetAggregateBits(statusCode.AggregateBits | AggregateBits.Partial); break; }
-                    case "Partial": { statusCode = statusCode.SetAggregateBits(statusCode.AggregateBits | AggregateBits.Partial); break; }
-                    case "M": { statusCode = statusCode.SetAggregateBits(statusCode.AggregateBits | AggregateBits.MultipleValues); break; }
-                    case "MultipleValues": { statusCode = statusCode.SetAggregateBits(statusCode.AggregateBits | AggregateBits.MultipleValues); break; }
+                    case "Interpolated": { statusCode = statusCode.WithAggregateBits(statusCode.AggregateBits | AggregateBits.Interpolated); break; }
+                    case "C": { statusCode = statusCode.WithAggregateBits(statusCode.AggregateBits | AggregateBits.Calculated); break; }
+                    case "Calculated": { statusCode = statusCode.WithAggregateBits(statusCode.AggregateBits | AggregateBits.Calculated); break; }
+                    case "P": { statusCode = statusCode.WithAggregateBits(statusCode.AggregateBits | AggregateBits.Partial); break; }
+                    case "Partial": { statusCode = statusCode.WithAggregateBits(statusCode.AggregateBits | AggregateBits.Partial); break; }
+                    case "M": { statusCode = statusCode.WithAggregateBits(statusCode.AggregateBits | AggregateBits.MultipleValues); break; }
+                    case "MultipleValues": { statusCode = statusCode.WithAggregateBits(statusCode.AggregateBits | AggregateBits.MultipleValues); break; }
 
                     default:
                     {

--- a/Workshop/HistoricalAccess/Tester/TestDataHelpers.cs
+++ b/Workshop/HistoricalAccess/Tester/TestDataHelpers.cs
@@ -236,13 +236,66 @@ namespace Quickstarts
             public DataValue() { m_value = new Opc.Ua.DataValue(); }
             public DataValue(Opc.Ua.DataValue value) { m_value = value; }
             public string Comment { get; set; }
-            public object Value { get { return m_value.WrappedValue.AsBoxedObject(); } set { WrappedValue = value is Variant variant ? variant : Variant.Null; } }
+            public object Value { get { return m_value.WrappedValue.AsBoxedObject(); } set { WrappedValue = ToVariant(value); } }
             public Variant WrappedValue { get { return m_value.WrappedValue; } set { m_value = new Opc.Ua.DataValue(value, m_value.StatusCode, m_value.SourceTimestamp, m_value.ServerTimestamp, m_value.SourcePicoseconds, m_value.ServerPicoseconds); } }
             public DateTime SourceTimestamp { get { return (DateTime)m_value.SourceTimestamp; } set { m_value = new Opc.Ua.DataValue(m_value.WrappedValue, m_value.StatusCode, value, m_value.ServerTimestamp, m_value.SourcePicoseconds, m_value.ServerPicoseconds); } }
             public StatusCode StatusCode { get { return m_value.StatusCode; } set { m_value = new Opc.Ua.DataValue(m_value.WrappedValue, value, m_value.SourceTimestamp, m_value.ServerTimestamp, m_value.SourcePicoseconds, m_value.ServerPicoseconds); } }
 
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Existing sample API exposes explicit conversion only.")]
             public static explicit operator Opc.Ua.DataValue(DataValue value) { return value.m_value; }
+
+            private static Variant ToVariant(object value)
+            {
+                switch (value)
+                {
+                    case null: return Variant.Null;
+                    case Variant v: return v;
+                    case bool v: return Variant.From(v);
+                    case sbyte v: return Variant.From(v);
+                    case byte v: return Variant.From(v);
+                    case short v: return Variant.From(v);
+                    case ushort v: return Variant.From(v);
+                    case int v: return Variant.From(v);
+                    case uint v: return Variant.From(v);
+                    case long v: return Variant.From(v);
+                    case ulong v: return Variant.From(v);
+                    case float v: return Variant.From(v);
+                    case double v: return Variant.From(v);
+                    case string v: return Variant.From(v);
+                    case DateTime v: return Variant.From(new DateTimeUtc(v));
+                    case Guid v: return Variant.From(new Uuid(v));
+                    case ByteString v: return Variant.From(v);
+                    case byte[] v: return Variant.From(v.ToByteString());
+                    case NodeId v: return Variant.From(v);
+                    case ExpandedNodeId v: return Variant.From(v);
+                    case StatusCode v: return Variant.From(v);
+                    case QualifiedName v: return Variant.From(v);
+                    case LocalizedText v: return Variant.From(v);
+                    case ExtensionObject v: return Variant.From(v);
+                    case bool[] v: return Variant.From(new ArrayOf<bool>(v));
+                    case sbyte[] v: return Variant.From(new ArrayOf<sbyte>(v));
+                    case short[] v: return Variant.From(new ArrayOf<short>(v));
+                    case ushort[] v: return Variant.From(new ArrayOf<ushort>(v));
+                    case int[] v: return Variant.From(new ArrayOf<int>(v));
+                    case uint[] v: return Variant.From(new ArrayOf<uint>(v));
+                    case long[] v: return Variant.From(new ArrayOf<long>(v));
+                    case ulong[] v: return Variant.From(new ArrayOf<ulong>(v));
+                    case float[] v: return Variant.From(new ArrayOf<float>(v));
+                    case double[] v: return Variant.From(new ArrayOf<double>(v));
+                    case string[] v: return Variant.From(new ArrayOf<string>(v));
+                    case DateTime[] v: return Variant.From(new ArrayOf<DateTimeUtc>(Array.ConvertAll(v, x => new DateTimeUtc(x))));
+                    case Guid[] v: return Variant.From(new ArrayOf<Uuid>(Array.ConvertAll(v, x => new Uuid(x))));
+                    case ByteString[] v: return Variant.From(new ArrayOf<ByteString>(v));
+                    case NodeId[] v: return Variant.From(new ArrayOf<NodeId>(v));
+                    case ExpandedNodeId[] v: return Variant.From(new ArrayOf<ExpandedNodeId>(v));
+                    case StatusCode[] v: return Variant.From(new ArrayOf<StatusCode>(v));
+                    case QualifiedName[] v: return Variant.From(new ArrayOf<QualifiedName>(v));
+                    case LocalizedText[] v: return Variant.From(new ArrayOf<LocalizedText>(v));
+                    case ExtensionObject[] v: return Variant.From(new ArrayOf<ExtensionObject>(v));
+                    case IEncodeable v: return Variant.From(new ExtensionObject(v, false));
+                    default: return Variant.Null;
+                }
+            }
 
             private Opc.Ua.DataValue m_value;
         }

--- a/Workshop/HistoricalEvents/Client/EventListView.cs
+++ b/Workshop/HistoricalEvents/Client/EventListView.cs
@@ -342,7 +342,7 @@ namespace Quickstarts.HistoricalEvents.Client
                 string text = null;
 
                 // check for missing fields.
-                if (fieldValues[ii].Value == null)
+                if (fieldValues[ii].AsBoxedObject() == null)
                 {
                     text = String.Empty;
                 }
@@ -350,7 +350,7 @@ namespace Quickstarts.HistoricalEvents.Client
                 // display the name of a node instead of the node id.
                 else if (fieldValues[ii].TypeInfo.BuiltInType == BuiltInType.NodeId)
                 {
-                    INode node = await m_session.NodeCache.FindAsync((NodeId)fieldValues[ii].Value, ct);
+                    INode node = await m_session.NodeCache.FindAsync((NodeId)fieldValues[ii].AsBoxedObject(), ct);
 
                     if (node != null)
                     {
@@ -361,7 +361,7 @@ namespace Quickstarts.HistoricalEvents.Client
                 // display local time for any time fields.
                 else if (fieldValues[ii].TypeInfo.BuiltInType == BuiltInType.DateTime)
                 {
-                    DateTime value = (DateTime)fieldValues[ii].Value;
+                    DateTime value = (DateTime)fieldValues[ii].AsBoxedObject();
 
                     if (m_filter.Fields[ii - 1].InstanceDeclaration.DisplayName.Contains("Time", StringComparison.Ordinal))
                     {
@@ -474,7 +474,7 @@ namespace Quickstarts.HistoricalEvents.Client
         /// </summary>
         private async Task ReadHistoryAsync(ReadEventDetails details, NodeId areaId, CancellationToken ct = default)
         {
-            HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+            List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
             HistoryReadValueId nodeToRead = new HistoryReadValueId();
             nodeToRead.NodeId = areaId;
             nodesToRead.Add(nodeToRead);
@@ -553,7 +553,7 @@ namespace Quickstarts.HistoricalEvents.Client
 
                 if (e.Count > index)
                 {
-                    eventId = e[index].Value as byte[];
+                    eventId = e[index].AsBoxedObject() as byte[];
                 }
 
                 details.EventIds = details.EventIds.AddItem(eventId.ToByteString());

--- a/Workshop/HistoricalEvents/Client/MainForm.cs
+++ b/Workshop/HistoricalEvents/Client/MainForm.cs
@@ -33,6 +33,7 @@ using System.Drawing;
 using System.Security.Cryptography.X509Certificates;
 using System.Windows.Forms;
 using System.IO;
+using System.Threading;
 using Opc.Ua;
 using Opc.Ua.Client;
 using Opc.Ua.Client.Controls;
@@ -307,7 +308,7 @@ namespace Quickstarts.HistoricalEvents.Client
                 }
 
                 ConnectServerCTRL.PreferredLocales = new string[] { locale };
-                m_session.ChangePreferredLocales(new List<string>(ConnectServerCTRL.PreferredLocales));
+                await m_session.ChangePreferredLocalesAsync(new List<string>(ConnectServerCTRL.PreferredLocales), CancellationToken.None);
             }
             catch (Exception exception)
             {

--- a/Workshop/HistoricalEvents/Client/Quickstarts.HistoricalEvents.Classes.cs
+++ b/Workshop/HistoricalEvents/Client/Quickstarts.HistoricalEvents.Classes.cs
@@ -233,7 +233,7 @@ namespace Quickstarts.HistoricalEvents
             bool createOrReplace,
             BaseInstanceState replacement)
         {
-            if (QualifiedName.IsNull(browseName))
+            if ((browseName).IsNull)
             {
                 return null;
             }
@@ -502,7 +502,7 @@ namespace Quickstarts.HistoricalEvents
             bool createOrReplace,
             BaseInstanceState replacement)
         {
-            if (QualifiedName.IsNull(browseName))
+            if ((browseName).IsNull)
             {
                 return null;
             }
@@ -725,7 +725,7 @@ namespace Quickstarts.HistoricalEvents
             bool createOrReplace,
             BaseInstanceState replacement)
         {
-            if (QualifiedName.IsNull(browseName))
+            if ((browseName).IsNull)
             {
                 return null;
             }

--- a/Workshop/HistoricalEvents/Client/ReadEventHistoryDlg.cs
+++ b/Workshop/HistoricalEvents/Client/ReadEventHistoryDlg.cs
@@ -150,7 +150,7 @@ namespace Quickstarts.HistoricalEvents.Client
         {
             if (m_details != null)
             {
-                HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+                List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
                 nodesToRead.Add(m_nodeToRead);
 
                 HistoryReadResponse response = await m_session.HistoryReadAsync(
@@ -191,7 +191,7 @@ namespace Quickstarts.HistoricalEvents.Client
             HistoryReadValueId nodeToRead = new HistoryReadValueId();
             nodeToRead.NodeId = m_areaId;
 
-            HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+            List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
             nodesToRead.Add(nodeToRead);
 
             HistoryReadResponse response = await m_session.HistoryReadAsync(
@@ -243,7 +243,7 @@ namespace Quickstarts.HistoricalEvents.Client
             }
 
             // get the event time.
-            DateTime? eventTime = data.Events[0].EventFields[0].Value as DateTime?;
+            DateTime? eventTime = data.Events[0].EventFields[0].AsBoxedObject() as DateTime?;
 
             if (eventTime == null)
             {
@@ -295,7 +295,7 @@ namespace Quickstarts.HistoricalEvents.Client
         /// </summary>
         private async Task ReadNextAsync(ReadEventDetails details, HistoryReadValueId nodeToRead, CancellationToken ct = default)
         {
-            HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection();
+            List<HistoryReadValueId> nodesToRead = new List<HistoryReadValueId>();
             nodesToRead.Add(nodeToRead);
 
             HistoryReadResponse response = await m_session.HistoryReadAsync(

--- a/Workshop/HistoricalEvents/Client/SelectEventTypeDlg.cs
+++ b/Workshop/HistoricalEvents/Client/SelectEventTypeDlg.cs
@@ -165,12 +165,12 @@ namespace Quickstarts.HistoricalEvents.Client
                 filter.EventTypeId = eventTypeId;
 
                 // collect all of the fields defined for the event.
-                SimpleAttributeOperandCollection fields = new SimpleAttributeOperandCollection();
+                List<SimpleAttributeOperand> fields = new List<SimpleAttributeOperand>();
                 List<NodeId> declarationIds = new List<NodeId>();
                 FormUtils.CollectFieldsForType(m_session, eventTypeId, fields, declarationIds);
                 
                 // need to read the description and datatype for each field. 
-                ReadValueIdCollection valuesToRead = new ReadValueIdCollection();
+                List<ReadValueId> valuesToRead = new List<ReadValueId>();
 
                 for (int ii = 0; ii < declarationIds.Count; ii++)
                 {
@@ -190,7 +190,7 @@ namespace Quickstarts.HistoricalEvents.Client
                     valuesToRead.Add(valueToRead);
                 }
 
-                DataValueCollection results = null;
+                List<DataValue> results = null;
                 DiagnosticInfoCollection diagnosticInfos = null;
 
                 m_session.Read(
@@ -319,7 +319,7 @@ namespace Quickstarts.HistoricalEvents.Client
                 }
                 
                 // add the childen to the control.
-                ReferenceDescriptionCollection references = FormUtils.Browse(m_session, nodeToBrowse, false);
+                List<ReferenceDescription> references = FormUtils.Browse(m_session, nodeToBrowse, false);
                 
                 for (int ii = 0; ii < references.Count; ii++)
                 {

--- a/Workshop/HistoricalEvents/Client/SelectTypeDlg.cs
+++ b/Workshop/HistoricalEvents/Client/SelectTypeDlg.cs
@@ -76,7 +76,7 @@ namespace Quickstarts.HistoricalEvents.Client
             }
 
             // set default root.
-            if (NodeId.IsNull(rootId))
+            if ((rootId).IsNull)
             {
                 rootId = Opc.Ua.ObjectTypeIds.BaseEventType;
             }

--- a/Workshop/HistoricalEvents/Client/SetValueDlg.cs
+++ b/Workshop/HistoricalEvents/Client/SetValueDlg.cs
@@ -74,7 +74,7 @@ namespace Quickstarts.HistoricalEvents.Client
                 return Variant.Null;
             }
 
-            return new Variant(ValueTB.Text, new TypeInfo(builtInType, ValueRanks.Scalar));
+            return Variant.From(ValueTB.Text);
         }
         #endregion
 

--- a/Workshop/HistoricalEvents/Client/SetValueDlg.cs
+++ b/Workshop/HistoricalEvents/Client/SetValueDlg.cs
@@ -31,6 +31,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
+using System.Globalization;
 using System.Text;
 using System.Windows.Forms;
 using Opc.Ua;
@@ -74,7 +75,115 @@ namespace Quickstarts.HistoricalEvents.Client
                 return Variant.Null;
             }
 
-            return Variant.From(ValueTB.Text);
+            return ConvertToVariant(ValueTB.Text, builtInType);
+        }
+        #endregion
+
+        #region Private Methods
+        private static Variant ConvertToVariant(string text, BuiltInType builtInType)
+        {
+            switch (builtInType)
+            {
+                case BuiltInType.Boolean:
+                {
+                    return Variant.From(Convert.ToBoolean(text, CultureInfo.InvariantCulture));
+                }
+
+                case BuiltInType.SByte:
+                {
+                    return Variant.From(Convert.ToSByte(text, CultureInfo.InvariantCulture));
+                }
+
+                case BuiltInType.Byte:
+                {
+                    return Variant.From(Convert.ToByte(text, CultureInfo.InvariantCulture));
+                }
+
+                case BuiltInType.Int16:
+                {
+                    return Variant.From(Convert.ToInt16(text, CultureInfo.InvariantCulture));
+                }
+
+                case BuiltInType.UInt16:
+                {
+                    return Variant.From(Convert.ToUInt16(text, CultureInfo.InvariantCulture));
+                }
+
+                case BuiltInType.Int32:
+                {
+                    return Variant.From(Convert.ToInt32(text, CultureInfo.InvariantCulture));
+                }
+
+                case BuiltInType.UInt32:
+                {
+                    return Variant.From(Convert.ToUInt32(text, CultureInfo.InvariantCulture));
+                }
+
+                case BuiltInType.Int64:
+                {
+                    return Variant.From(Convert.ToInt64(text, CultureInfo.InvariantCulture));
+                }
+
+                case BuiltInType.UInt64:
+                {
+                    return Variant.From(Convert.ToUInt64(text, CultureInfo.InvariantCulture));
+                }
+
+                case BuiltInType.Float:
+                {
+                    return Variant.From(Convert.ToSingle(text, CultureInfo.InvariantCulture));
+                }
+
+                case BuiltInType.Double:
+                {
+                    return Variant.From(Convert.ToDouble(text, CultureInfo.InvariantCulture));
+                }
+
+                case BuiltInType.DateTime:
+                {
+                    return Variant.From(new DateTimeUtc(Convert.ToDateTime(text, CultureInfo.InvariantCulture)));
+                }
+
+                case BuiltInType.Guid:
+                {
+                    return Variant.From(new Uuid(Guid.Parse(text)));
+                }
+
+                case BuiltInType.ByteString:
+                {
+                    return Variant.From(ByteString.From(Convert.FromBase64String(text)));
+                }
+
+                case BuiltInType.NodeId:
+                {
+                    return Variant.From(NodeId.Parse(text));
+                }
+
+                case BuiltInType.ExpandedNodeId:
+                {
+                    return Variant.From(ExpandedNodeId.Parse(text));
+                }
+
+                case BuiltInType.StatusCode:
+                {
+                    return Variant.From(new StatusCode(UInt32.Parse(text, CultureInfo.InvariantCulture)));
+                }
+
+                case BuiltInType.QualifiedName:
+                {
+                    return Variant.From(QualifiedName.Parse(text));
+                }
+
+                case BuiltInType.LocalizedText:
+                {
+                    return Variant.From(new LocalizedText(text));
+                }
+
+                default:
+                {
+                    return Variant.From(text);
+                }
+            }
         }
         #endregion
 

--- a/Workshop/HistoricalEvents/Client/ViewEventDetailsDlg.cs
+++ b/Workshop/HistoricalEvents/Client/ViewEventDetailsDlg.cs
@@ -71,7 +71,7 @@ namespace Quickstarts.HistoricalEvents.Client
                 string text = null;
 
                 // check for missing fields.
-                if (fields.Count <= ii || fields[ii].Value == null)
+                if (fields.Count <= ii || fields[ii].AsBoxedObject() == null)
                 {
                     text = String.Empty;
                 }

--- a/Workshop/HistoricalEvents/Server/HistoricalEventsNodeManager.cs
+++ b/Workshop/HistoricalEvents/Server/HistoricalEventsNodeManager.cs
@@ -480,7 +480,7 @@ namespace Quickstarts.HistoricalEvents.Server
             foreach (SimpleAttributeOperand clause in request.Filter.SelectClauses)
             {
                 // get the value of the attribute (apply localization).
-                object value = instance.GetAttributeValue(
+                Variant value = instance.GetAttributeValue(
                     request.FilterContext,
                     clause.TypeDefinitionId,
                     clause.BrowsePath,
@@ -488,16 +488,16 @@ namespace Quickstarts.HistoricalEvents.Server
                     clause.ParsedIndexRange);
 
                 // add the value to the list of event fields.
-                if (value != null)
+                if (!value.IsNull)
                 {
                     // translate any localized text.
-                    if (value is LocalizedText text && !text.IsNullOrEmpty)
+                    if (value.AsBoxedObject() is LocalizedText text && !text.IsNullOrEmpty)
                     {
-                        value = Server.ResourceManager.Translate(request.FilterContext.PreferredLocales, text);
+                        value = Variant.From(Server.ResourceManager.Translate(request.FilterContext.PreferredLocales, text));
                     }
 
                     // add value.
-                    fields.EventFields = fields.EventFields.AddItem(new Variant(value));
+                    fields.EventFields = fields.EventFields.AddItem(value);
                 }
 
                 // add a dummy entry for missing values.
@@ -527,12 +527,12 @@ namespace Quickstarts.HistoricalEvents.Server
                 using DataView view = handle.Node is WellState
                     ? m_generator.ReadHistoryForWellId(
                         ii,
-                        (string)handle.Node.NodeId.Identifier,
+                        handle.Node.NodeId.TryGetValue(out string wellId) ? wellId : null,
                         (DateTime)details.StartTime,
                         (DateTime)details.EndTime)
                     : m_generator.ReadHistoryForArea(
                         ii,
-                        handle.Node.NodeId.Identifier as string,
+                        handle.Node.NodeId.TryGetValue(out string areaId) ? areaId : null,
                         (DateTime)details.StartTime,
                         (DateTime)details.EndTime);
 

--- a/Workshop/HistoricalEvents/Server/Model/Quickstarts.HistoricalEvents.Classes.cs
+++ b/Workshop/HistoricalEvents/Server/Model/Quickstarts.HistoricalEvents.Classes.cs
@@ -233,7 +233,7 @@ namespace Quickstarts.HistoricalEvents
             bool createOrReplace,
             BaseInstanceState replacement)
         {
-            if (QualifiedName.IsNull(browseName))
+            if ((browseName).IsNull)
             {
                 return null;
             }
@@ -502,7 +502,7 @@ namespace Quickstarts.HistoricalEvents
             bool createOrReplace,
             BaseInstanceState replacement)
         {
-            if (QualifiedName.IsNull(browseName))
+            if ((browseName).IsNull)
             {
                 return null;
             }
@@ -725,7 +725,7 @@ namespace Quickstarts.HistoricalEvents
             bool createOrReplace,
             BaseInstanceState replacement)
         {
-            if (QualifiedName.IsNull(browseName))
+            if ((browseName).IsNull)
             {
                 return null;
             }

--- a/Workshop/Methods/Client/MainForm.cs
+++ b/Workshop/Methods/Client/MainForm.cs
@@ -170,7 +170,7 @@ namespace Quickstarts.MethodsClient
                     browsePaths);
 
                 // subscribe to the state if available.
-                if (nodes.Count > 0 && !NodeId.IsNull(nodes[0]))
+                if (nodes.Count > 0 && !(nodes[0]).IsNull)
                 {
                     m_subscription = new Subscription(m_telemetry);
 
@@ -283,8 +283,8 @@ namespace Quickstarts.MethodsClient
 
                 if (outputArguments != null && outputArguments.Count > 1)
                 {
-                    RevisedInitialStateTB.Text = String.Format("{0}", outputArguments[0].Value);
-                    RevisedFinalStateTB.Text = String.Format("{0}", outputArguments[1].Value);
+                    RevisedInitialStateTB.Text = String.Format("{0}", outputArguments[0].AsBoxedObject());
+                    RevisedFinalStateTB.Text = String.Format("{0}", outputArguments[1].AsBoxedObject());
                 }
             }
             catch (Exception exception)

--- a/Workshop/Methods/Server/MethodsNodeManager.cs
+++ b/Workshop/Methods/Server/MethodsNodeManager.cs
@@ -45,12 +45,12 @@ namespace Quickstarts.MethodsServer
     {
         public ArrayOf<Argument> GetValue(Variant value)
         {
-            if (value.Value is Argument[] arguments)
+            if (value.AsBoxedObject() is Argument[] arguments)
             {
                 return arguments.ToArrayOf();
             }
 
-            if (value.Value is ArrayOf<Argument> arrayOfArguments)
+            if (value.AsBoxedObject() is ArrayOf<Argument> arrayOfArguments)
             {
                 return arrayOfArguments;
             }
@@ -263,8 +263,8 @@ namespace Quickstarts.MethodsServer
             }
 
             // check the data type of the input arguments.
-            uint? initialState = inputArguments[0].Value as uint?;
-            uint? finalState = inputArguments[1].Value as uint?;
+            uint? initialState = inputArguments[0].AsBoxedObject() as uint?;
+            uint? finalState = inputArguments[1].AsBoxedObject() as uint?;
 
             if (initialState == null || finalState == null)
             {

--- a/Workshop/Methods/Server/MethodsNodeManager.cs
+++ b/Workshop/Methods/Server/MethodsNodeManager.cs
@@ -60,7 +60,7 @@ namespace Quickstarts.MethodsServer
 
         public Variant WithValue(ArrayOf<Argument> value)
         {
-            return new Variant(value.ToArray());
+            return Variant.FromStructure<Argument>(value, false);
         }
     }
 

--- a/Workshop/PerfTest/Client/Tester.cs
+++ b/Workshop/PerfTest/Client/Tester.cs
@@ -164,7 +164,7 @@ namespace Quickstarts.PerfTestClient
             session.AddSubscription(subscription);
             await subscription.CreateAsync();
 
-            DateTime start = HiResClock.UtcNow;
+            DateTime start = DateTime.UtcNow;
 
             for (int ii = 0; ii < m_itemCount; ii++)
             {
@@ -182,13 +182,13 @@ namespace Quickstarts.PerfTestClient
             }
 
             await subscription.ApplyChangesAsync();
-            DateTime end = HiResClock.UtcNow;
+            DateTime end = DateTime.UtcNow;
 
             ReportMessage("Time to add {1} items {0}ms.", (end - start).TotalMilliseconds, m_itemCount);
 
-            start = HiResClock.UtcNow;
+            start = DateTime.UtcNow;
             await subscription.SetPublishingModeAsync(true);
-            end = HiResClock.UtcNow;
+            end = DateTime.UtcNow;
 
             ReportMessage("Time to emable publishing {0}ms.", (end - start).TotalMilliseconds);
         }
@@ -253,7 +253,9 @@ namespace Quickstarts.PerfTestClient
 
                 for (int ii = 0; ii < e.NotificationMessage.NotificationData.Count; ii++)
                 {
-                    DataChangeNotification notification = e.NotificationMessage.NotificationData[ii].Body as DataChangeNotification;
+                    DataChangeNotification notification = e.NotificationMessage.NotificationData[ii].TryGetValue<DataChangeNotification>(out var decodedNotification, ServiceMessageContext.CreateEmpty(null))
+                        ? decodedNotification
+                        : null;
 
                     if (notification == null)
                     {

--- a/Workshop/PerfTest/Server/MemoryRegisterState.cs
+++ b/Workshop/PerfTest/Server/MemoryRegisterState.cs
@@ -224,7 +224,7 @@ namespace Quickstarts.PerfTestServer
             NodeId targetId = NodeId.Null;
 
             // check if a specific browse name is requested.
-            if (!QualifiedName.IsNull(base.BrowseName))
+            if (!(base.BrowseName).IsNull)
             {
                 // browse name must be qualified by the correct namespace.
                 if (m_parent.BrowseName.NamespaceIndex != base.BrowseName.NamespaceIndex)

--- a/Workshop/PerfTest/Server/PerfTestNodeManager.cs
+++ b/Workshop/PerfTest/Server/PerfTestNodeManager.cs
@@ -153,7 +153,10 @@ namespace Quickstarts.PerfTestServer
                 handle.NodeId = nodeId;
                 handle.Validated = true;
 
-                uint id = (uint)nodeId.Identifier;
+                if (!nodeId.TryGetValue(out uint id))
+                {
+                    return null;
+                }
 
                 // find register
                 int registerId = (int)((id & 0xFF000000) >> 24);

--- a/Workshop/PerfTest/Server/UnderlyingSystem.cs
+++ b/Workshop/PerfTest/Server/UnderlyingSystem.cs
@@ -183,7 +183,7 @@ namespace Quickstarts.PerfTestServer
             {
                 lock (m_lock)
                 {
-                    DateTime start = HiResClock.UtcNow;
+                    DateTime start = DateTime.UtcNow;
                     int delta = m_values.Length / 2;
 
                     for (int ii = m_start; ii < delta + m_start && ii < m_values.Length; ii++)
@@ -194,7 +194,7 @@ namespace Quickstarts.PerfTestServer
 
                         if (monitoredItems != null)
                         {
-                            DataValue value = new DataValue(new Variant(m_values[ii]), StatusCodes.Good, DateTime.UtcNow, DateTime.UtcNow);
+                            DataValue value = new DataValue(Variant.From(m_values[ii]), StatusCodes.Good, DateTime.UtcNow, DateTime.UtcNow);
 
                             for (int jj = 0; jj < monitoredItems.Length; jj++)
                             {
@@ -210,9 +210,9 @@ namespace Quickstarts.PerfTestServer
                         m_start = 0;
                     }
 
-                    if ((HiResClock.UtcNow - start).TotalMilliseconds > 50)
+                    if ((DateTime.UtcNow - start).TotalMilliseconds > 50)
                     {
-                        m_logger.LogWarning("Update took {ElapsedMs}ms.", (HiResClock.UtcNow - start).TotalMilliseconds);
+                        m_logger.LogWarning("Update took {ElapsedMs}ms.", (DateTime.UtcNow - start).TotalMilliseconds);
                     }
                 }
             }

--- a/Workshop/SimpleEvents/Client/MainForm.cs
+++ b/Workshop/SimpleEvents/Client/MainForm.cs
@@ -308,7 +308,7 @@ namespace Quickstarts.SimpleEvents.Client
                 NodeId eventTypeId = ClientUtils.FindEventType(monitoredItem, notification);
 
                 // ignore unknown events.
-                if (NodeId.IsNull(eventTypeId))
+                if ((eventTypeId).IsNull)
                 {
                     return;
                 }

--- a/Workshop/SimpleEvents/Client/MainForm.cs
+++ b/Workshop/SimpleEvents/Client/MainForm.cs
@@ -437,7 +437,7 @@ namespace Quickstarts.SimpleEvents.Client
                 }
 
                 ConnectServerCTRL.PreferredLocales = new string[] { locale };
-                m_session.ChangePreferredLocales(new List<string>(ConnectServerCTRL.PreferredLocales));
+                await m_session.ChangePreferredLocalesAsync(new List<string>(ConnectServerCTRL.PreferredLocales));
             }
             catch (Exception exception)
             {

--- a/Workshop/SimpleEvents/Client/Quickstarts.SimpleEvents.Classes.cs
+++ b/Workshop/SimpleEvents/Client/Quickstarts.SimpleEvents.Classes.cs
@@ -415,7 +415,7 @@ namespace Quickstarts.SimpleEvents
 
             public Variant WithValue(CycleStepDataType[] value)
             {
-                return new Variant(value);
+                return Variant.FromStructure<CycleStepDataType>(value, false);
             }
         }
 

--- a/Workshop/SimpleEvents/Client/Quickstarts.SimpleEvents.Classes.cs
+++ b/Workshop/SimpleEvents/Client/Quickstarts.SimpleEvents.Classes.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2021 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -178,7 +178,7 @@ namespace Quickstarts.SimpleEvents
             bool createOrReplace,
             BaseInstanceState replacement)
         {
-            if (QualifiedName.IsNull(browseName))
+            if ((browseName).IsNull)
             {
                 return null;
             }
@@ -366,7 +366,7 @@ namespace Quickstarts.SimpleEvents
             bool createOrReplace,
             BaseInstanceState replacement)
         {
-            if (QualifiedName.IsNull(browseName))
+            if ((browseName).IsNull)
             {
                 return null;
             }
@@ -410,7 +410,7 @@ namespace Quickstarts.SimpleEvents
         {
             public CycleStepDataType[] GetValue(Variant value)
             {
-                return value.Value as CycleStepDataType[];
+                return value.AsBoxedObject() as CycleStepDataType[];
             }
 
             public Variant WithValue(CycleStepDataType[] value)
@@ -545,7 +545,7 @@ namespace Quickstarts.SimpleEvents
             bool createOrReplace,
             BaseInstanceState replacement)
         {
-            if (QualifiedName.IsNull(browseName))
+            if ((browseName).IsNull)
             {
                 return null;
             }

--- a/Workshop/SimpleEvents/Server/Quickstarts.SimpleEvents.Classes.cs
+++ b/Workshop/SimpleEvents/Server/Quickstarts.SimpleEvents.Classes.cs
@@ -415,7 +415,7 @@ namespace Quickstarts.SimpleEvents
 
             public Variant WithValue(CycleStepDataType[] value)
             {
-                return new Variant(value);
+                return Variant.FromStructure<CycleStepDataType>(value, false);
             }
         }
 

--- a/Workshop/SimpleEvents/Server/Quickstarts.SimpleEvents.Classes.cs
+++ b/Workshop/SimpleEvents/Server/Quickstarts.SimpleEvents.Classes.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2021 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -178,7 +178,7 @@ namespace Quickstarts.SimpleEvents
             bool createOrReplace,
             BaseInstanceState replacement)
         {
-            if (QualifiedName.IsNull(browseName))
+            if ((browseName).IsNull)
             {
                 return null;
             }
@@ -366,7 +366,7 @@ namespace Quickstarts.SimpleEvents
             bool createOrReplace,
             BaseInstanceState replacement)
         {
-            if (QualifiedName.IsNull(browseName))
+            if ((browseName).IsNull)
             {
                 return null;
             }
@@ -410,7 +410,7 @@ namespace Quickstarts.SimpleEvents
         {
             public CycleStepDataType[] GetValue(Variant value)
             {
-                return value.Value as CycleStepDataType[];
+                return value.AsBoxedObject() as CycleStepDataType[];
             }
 
             public Variant WithValue(CycleStepDataType[] value)
@@ -545,7 +545,7 @@ namespace Quickstarts.SimpleEvents
             bool createOrReplace,
             BaseInstanceState replacement)
         {
-            if (QualifiedName.IsNull(browseName))
+            if ((browseName).IsNull)
             {
                 return null;
             }

--- a/Workshop/UserAuthentication/Client/MainForm.cs
+++ b/Workshop/UserAuthentication/Client/MainForm.cs
@@ -487,7 +487,7 @@ namespace Quickstarts.UserAuthenticationClient
                 value.NodeId = m_logFileNodeId;
                 value.AttributeId = Attributes.Value;
 
-                ReadValueIdCollection valuesToRead = new ReadValueIdCollection();
+                List<ReadValueId> valuesToRead = new List<ReadValueId>();
                 valuesToRead.Add(value);
 
                 ReadResponse response = await m_session.ReadAsync(
@@ -538,7 +538,7 @@ namespace Quickstarts.UserAuthenticationClient
                 value.AttributeId = Attributes.Value;
                 value.Value = new DataValue(new Variant(LogFilePathTB.Text));
 
-                WriteValueCollection valuesToWrite = new WriteValueCollection();
+                List<WriteValue> valuesToWrite = new List<WriteValue>();
                 valuesToWrite.Add(value);
 
                 WriteResponse response = await m_session.WriteAsync(

--- a/Workshop/UserAuthentication/Client/MainForm.cs
+++ b/Workshop/UserAuthentication/Client/MainForm.cs
@@ -341,7 +341,7 @@ namespace Quickstarts.UserAuthenticationClient
         #endregion
 
         #region Event Handlers
-        private void UserNameImpersonateBTN_Click(object sender, EventArgs e)
+        private async void UserNameImpersonateBTN_Click(object sender, EventArgs e)
         {
             if (m_session == null)
             {
@@ -357,7 +357,7 @@ namespace Quickstarts.UserAuthenticationClient
                 UserIdentity identity = new UserIdentity(UserNameTB.Text, Encoding.UTF8.GetBytes(PasswordTB.Text));
 #pragma warning restore CA2000
                 string[] preferredLocales = PreferredLocalesTB.Text.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
-                m_session.UpdateSession(identity, preferredLocales);
+                await m_session.UpdateSessionAsync(identity, preferredLocales);
 
                 MessageBox.Show("User identity changed.", "Impersonate User", MessageBoxButtons.OK, MessageBoxIcon.Information);
             }
@@ -371,7 +371,7 @@ namespace Quickstarts.UserAuthenticationClient
             }
         }
 
-        private void CertificateImpersonateBTN_Click(object sender, EventArgs e)
+        private async void CertificateImpersonateBTN_Click(object sender, EventArgs e)
         {
             if (m_session == null)
             {
@@ -395,7 +395,7 @@ namespace Quickstarts.UserAuthenticationClient
                 UserIdentity identity = new UserIdentity(new X509IdentityToken { CertificateData = certificate.RawData.ToByteString() });
 #pragma warning restore CA2000
                 string[] preferredLocales = PreferredLocalesTB.Text.Split([','], StringSplitOptions.RemoveEmptyEntries);
-                m_session.UpdateSession(identity, preferredLocales);
+                await m_session.UpdateSessionAsync(identity, preferredLocales);
 
                 MessageBox.Show("User identity changed.", "Impersonate User", MessageBoxButtons.OK, MessageBoxIcon.Information);
             }
@@ -409,7 +409,7 @@ namespace Quickstarts.UserAuthenticationClient
             }
         }
 
-        private void AnonymousImpersonateBTN_Click(object sender, EventArgs e)
+        private async void AnonymousImpersonateBTN_Click(object sender, EventArgs e)
         {
             if (m_session == null)
             {
@@ -423,7 +423,7 @@ namespace Quickstarts.UserAuthenticationClient
 
                 string[] preferredLocales = PreferredLocalesTB.Text.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
 #pragma warning disable CA2000 // Justification: UserIdentity and token ownership is transferred to the active session.
-                m_session.UpdateSession(new UserIdentity(new AnonymousIdentityToken()), preferredLocales);
+                await m_session.UpdateSessionAsync(new UserIdentity(new AnonymousIdentityToken()), preferredLocales);
 #pragma warning restore CA2000
 
                 MessageBox.Show("User identity changed.", "Impersonate User", MessageBoxButtons.OK, MessageBoxIcon.Information);
@@ -438,7 +438,7 @@ namespace Quickstarts.UserAuthenticationClient
             }
         }
 
-        private void KerberosImpersonateBTN_Click(object sender, EventArgs e)
+        private async void KerberosImpersonateBTN_Click(object sender, EventArgs e)
         {
             if (m_session == null)
             {
@@ -454,7 +454,7 @@ namespace Quickstarts.UserAuthenticationClient
                 m_session.ReturnDiagnostics = DiagnosticsMasks.All;
 
                 string[] preferredLocales = PreferredLocalesTB.Text.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
-                m_session.UpdateSession(identity, preferredLocales);
+                await m_session.UpdateSessionAsync(identity, preferredLocales);
 
                 MessageBox.Show("User identity changed.", "Impersonate User", MessageBoxButtons.OK, MessageBoxIcon.Information);
             }

--- a/Workshop/UserAuthentication/Server/UserAuthenticationNodeManager.cs
+++ b/Workshop/UserAuthentication/Server/UserAuthenticationNodeManager.cs
@@ -168,7 +168,7 @@ namespace Quickstarts.UserAuthenticationServer
             // attempt to update file system.
             try
             {
-                string filePath = value.Value as string;
+                string filePath = value.AsBoxedObject() as string;
                 PropertyState<string> variable = node as PropertyState<string>;
 
                 if (!String.IsNullOrEmpty(variable.Value))

--- a/Workshop/UserAuthentication/Server/UserAuthenticationServer.cs
+++ b/Workshop/UserAuthentication/Server/UserAuthenticationServer.cs
@@ -36,6 +36,7 @@ using System.Text;
 using System.Xml;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using Opc.Ua;
 using Opc.Ua.Server;
 using Microsoft.Extensions.Logging;
@@ -86,8 +87,9 @@ namespace Quickstarts.UserAuthenticationServer
         {
             base.OnServerStarted(server);
 
-            // request notifications when the user identity is changed. all valid users are accepted by default.
-            server.SessionManager.ImpersonateUser += new ImpersonateEventHandler(SessionManager_ImpersonateUser);
+            // Register authenticators for user identity changes.
+            server.IdentityRegistry.Register(new UserNamePasswordAuthenticator(AuthenticateUserNameAsync));
+            server.IdentityRegistry.Register(new X509Authenticator(AuthenticateX509Async));
         }
 
         /// <summary>
@@ -188,51 +190,30 @@ namespace Quickstarts.UserAuthenticationServer
             }
         }
 
-        /// <summary>
-        /// Called when a client tries to change its user identity.
-        /// </summary>
-        private void SessionManager_ImpersonateUser(ISession session, ImpersonateEventArgs args)
+        private ValueTask<IUserIdentity> AuthenticateUserNameAsync(UserNameIdentityTokenHandler handler, System.Threading.CancellationToken ct)
         {
-
-#if TODO
-            // check for a WSS token.
-            IssuedIdentityToken wssToken = args.NewIdentity as IssuedIdentityToken;
-
-            if (wssToken != null)
+            UserNameIdentityToken userNameToken = handler.Token as UserNameIdentityToken;
+            VerifyPassword(userNameToken.UserName, Encoding.UTF8.GetString(userNameToken.Password.ToArray()));
+            IUserIdentity identity = new UserIdentity(userNameToken);
+            if (m_logger.IsEnabled(LogLevel.Information))
             {
-                SecurityToken kerberosToken = ParseAndVerifyKerberosToken(wssToken.DecryptedTokenData);
-                args.Identity = new UserIdentity(kerberosToken);
-                Utils.Trace("Kerberos Token Accepted: {0}", args.Identity.DisplayName);
-                return;
-            }
-#endif
-            // check for a user name token.
-            UserNameIdentityToken userNameToken = args.NewIdentity as UserNameIdentityToken;
-
-            if (userNameToken != null)
-            {
-                VerifyPassword(userNameToken.UserName, Encoding.UTF8.GetString(userNameToken.Password.ToArray()));
-                args.Identity = new UserIdentity(userNameToken);
-                if (m_logger.IsEnabled(LogLevel.Information))
-                {
-                    m_logger.LogInformation("UserName Token Accepted: {DisplayName}", args.Identity.DisplayName);
-                }
-                return;
+                m_logger.LogInformation("UserName Token Accepted: {DisplayName}", identity.DisplayName);
             }
 
-            // check for x509 user token.
-            X509IdentityToken x509Token = args.NewIdentity as X509IdentityToken;
+            return new ValueTask<IUserIdentity>(identity);
+        }
 
-            if (x509Token != null)
+        private ValueTask<IUserIdentity> AuthenticateX509Async(X509IdentityTokenHandler handler, System.Threading.CancellationToken ct)
+        {
+            X509IdentityToken x509Token = handler.Token as X509IdentityToken;
+            VerifyCertificate(new X509Certificate2(x509Token.CertificateData.ToArray()));
+            IUserIdentity identity = new UserIdentity(x509Token);
+            if (m_logger.IsEnabled(LogLevel.Information))
             {
-                VerifyCertificate(new X509Certificate2(x509Token.CertificateData.ToArray()));
-                args.Identity = new UserIdentity(x509Token);
-                if (m_logger.IsEnabled(LogLevel.Information))
-                {
-                    m_logger.LogInformation("X509 Token Accepted: {DisplayName}", args.Identity.DisplayName);
-                }
-                return;
+                m_logger.LogInformation("X509 Token Accepted: {DisplayName}", identity.DisplayName);
             }
+
+            return new ValueTask<IUserIdentity>(identity);
         }
 
         /// <summary>

--- a/Workshop/Views/Client/MainForm.cs
+++ b/Workshop/Views/Client/MainForm.cs
@@ -222,7 +222,7 @@ namespace Quickstarts.ViewsClient
 
                 ReferenceDescription reference = ViewCB.SelectedItem as ReferenceDescription;
 
-                if (reference != null && !NodeId.IsNull(reference.NodeId))
+                if (reference != null && !(reference.NodeId).IsNull)
                 {
                     view = new ViewDescription();
                     view.ViewId = ExpandedNodeId.ToNodeId(reference.NodeId, m_session.NamespaceUris);

--- a/Workshop/Views/Server/Model/Quickstarts.Views.Classes.cs
+++ b/Workshop/Views/Server/Model/Quickstarts.Views.Classes.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2021 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -227,7 +227,7 @@ namespace Quickstarts.Views
             bool createOrReplace,
             BaseInstanceState replacement)
         {
-            if (QualifiedName.IsNull(browseName))
+            if ((browseName).IsNull)
             {
                 return null;
             }
@@ -681,7 +681,7 @@ namespace Quickstarts.Views
             bool createOrReplace,
             BaseInstanceState replacement)
         {
-            if (QualifiedName.IsNull(browseName))
+            if ((browseName).IsNull)
             {
                 return null;
             }

--- a/targets.props
+++ b/targets.props
@@ -1,8 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <!-- OPC UA 2.0 migration shims use C# 14 'extension' members; require LangVersion 14.0. -->
-    <LangVersion>14.0</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <Choose>
@@ -44,12 +43,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302" PrivateAssets="All" />
-  </ItemGroup>
-
-  <!-- OPC UA 1.5.378 -> 2.0 migration analyzer/generator/runtime shim.
-       Build-only dependency; remove once the migration is complete and the build is warning-free. -->
-  <ItemGroup>
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.MigrationAnalyzer" Version="2.0.158.59919-preview" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Completes the OPC UA .NET Standard 1.5.378 → 2.0 migration for the samples repo: resolves all remaining OPC-migration build warnings for a clean build across all four sample solutions, switches `xyCollection` types to `List<xy>`/`ArrayOf<xy>` where needed, and removes the build-only `MigrationAnalyzer` package.

All four solutions (**UA Aggregation**, **UA Global Discovery Server**, **UA Quickstart Applications**, **UA Sample Applications**) now build with **0 errors and 0 in-scope migration warnings**, with the analyzer/shim package fully removed.

## Changes

- **Obsolete `object → Variant` APIs**: rerouted to non-obsolete `Variant.From` / `Variant.FromStructure<T>` / typed constructors / `new Variant(new ExtensionObject(...))` across NodeManagers, filter builders (`ContentFilter.Push`), and UI value controls. Rewrote the Aggregation `NamespaceMapper` array/element mapping onto a runtime-type dispatch that avoids the obsolete `object`-based `Variant` constructors.
- **`CertificateFactory`**: obsolete static calls → instance methods (`CreateWithPrivateKey` / `CreateWithPEMPrivateKey`).
- **`NodeId`/`ExpandedNodeId.TryGetValue`**: dropped invalid generic type args (these overloads are non-generic) and typed the resulting `out` vars to fix ambiguity.
- **`ServiceMessageContext.GlobalContext` / `ThreadContext`** (both obsolete): → `ServiceMessageContext.CreateEmpty(null)`.
- **Collections**: `xyCollection` shims migrated to `List<xy>` at build/mutation sites (`ArrayOf<xy>` at read-only boundaries) — no shim references remain now that the generator package is gone.
- **Package removal**: removed `OPCFoundation.NetStandard.Opc.Ua.MigrationAnalyzer` from `targets.props` and relaxed `LangVersion` (the C#14 `extension`-member shim is no longer referenced).

## Deferred (tracked separately)

Two remaining `CS0618` sites require architectural refactors beyond the mechanical warning cleanup. Each is wrapped in a scoped `#pragma warning disable CS0618` with a comment pointing to its tracking issue:

- `QuickstartNodeManager` uses the obsolete `MonitoredItem` constructor because the non-obsolete overloads require an `IAsyncNodeManager` — see #723.
- `SampleServer` uses the obsolete `ISessionManager.ImpersonateUser` event, replaced by the `IUserTokenAuthenticator` + `IServerIdentityRegistry` identity architecture — see #724.

## Verification

`dotnet build <sln> -t:Rebuild` for all four solutions → 0 errors, 0 in-scope migration warnings (CS0618/CS0612/CS8073/UA00xx/MIG01). Pre-existing non-migration analyzer diagnostics (CA/Roslynator/etc.) are intentionally left as-is per scope.