### PR TITLE
Fix GDS client crash when querying servers without a connection

### DIFF
--- a/Samples/GDS/ClientControls/Controls/ViewServersOnNetworkDialog.cs
+++ b/Samples/GDS/ClientControls/Controls/ViewServersOnNetworkDialog.cs
@@ -123,6 +123,13 @@ namespace Opc.Ua.Gds.Client.Controls
                     #pragma warning disable CA2000 // Justification: WinForms/sample ownership or lifetime is managed outside the local scope.
                     new SelectGdsDialog().ShowDialog(null, m_gds, await m_gds.GetDefaultGdsUrlsAsync(null), m_telemetry);
                     #pragma warning restore CA2000
+
+                    // The user may have cancelled the dialog or the connection may have failed.
+                    // Abort the query instead of letting the GDS client connect with a null endpoint.
+                    if (!m_gds.IsConnected)
+                    {
+                        return;
+                    }
                 }
 
                 uint maxNoOfRecords = (uint)NumberOfRecordsUpDown.Value;


### PR DESCRIPTION
## Proposed changes

Registering an application in the GDS demo client crashed with `ArgumentNullException: Value cannot be null. (Parameter name: endpoint)` (issue #702).

The failure happens in the "Query Servers" dialog (`ViewServersOnNetworkDialog.SearchButton_Click`) during Server Push registration. When the GDS is not yet connected, the code opens `SelectGdsDialog` so the user can connect, but then proceeds to call `QueryServersAsync` regardless of the outcome. If the user cancels that dialog or the connection fails, the GDS client stays unconnected with no endpoint, so its internal auto-connect calls `GlobalDiscoveryServerClient.Connect(null)` and throws.

The fix re-checks `m_gds.IsConnected` after the dialog closes and aborts the query if there is still no connection, instead of letting the client connect with a null endpoint. This mirrors the guard already used in `MainForm` (which checks the dialog result before proceeding).

## Related Issues

- Fixes #702

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines.
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

The GDS client library (`GlobalDiscoveryServerClient`) lives in the UA-.NETStandard package, so this sample-side guard is the appropriate place to prevent the confusing null-endpoint exception. The project builds with 0 errors; the remaining warnings are pre-existing v2.0 migration warnings unrelated to this change.