### PR TITLE
Fix aggregation metadata session for certificate-only endpoints

### DIFF
--- a/Workshop/Aggregation/Server/AggregationNodeManager.cs
+++ b/Workshop/Aggregation/Server/AggregationNodeManager.cs
@@ -1241,6 +1241,12 @@ namespace AggregationServer
                     sessionId = new NodeId(Guid.NewGuid());
                 }
                 sessionName = $"Aggregation Server({Utils.GetHostName()})";
+
+                // The internal metadata session has no incoming user identity, so
+                // derive one from the endpoint configuration. Defaulting to an
+                // anonymous token fails whenever the remote server only accepts
+                // e.g. a certificate user token policy (see issue #658).
+                userIdentity = GetMetadataUserIdentity();
             }
 
             lock (m_clientsLock)
@@ -1366,6 +1372,53 @@ namespace AggregationServer
 
                 throw new ServiceResultException(StatusCodes.BadNotConnected, "Server not connected.");
             }
+        }
+
+        /// <summary>
+        /// Builds the user identity used for the internal metadata session based
+        /// on the endpoint's selected user token policy.
+        /// </summary>
+        /// <remarks>
+        /// The metadata session is opened by the aggregation server itself and
+        /// therefore has no incoming client identity. When the remote endpoint
+        /// only offers a certificate user token policy, connecting anonymously
+        /// fails with "Endpoint does not support the user identity type provided"
+        /// (issue #658). In that case the aggregation server's own application
+        /// certificate is used as the user certificate. All other cases fall
+        /// back to an anonymous identity.
+        /// </remarks>
+        private IUserIdentity GetMetadataUserIdentity()
+        {
+            try
+            {
+                UserTokenPolicy policy = m_endpoint.SelectedUserTokenPolicy;
+
+                if (policy != null && policy.TokenType == UserTokenType.Certificate)
+                {
+                    CertificateIdentifier applicationCertificate =
+                        m_configuration.SecurityConfiguration.ApplicationCertificate;
+
+                    if (applicationCertificate != null)
+                    {
+                        return UserIdentity.CreateAsync(
+                            applicationCertificate,
+                            m_configuration.SecurityConfiguration.CertificatePasswordProvider,
+                            m_configuration.CertificateManager.CertificateProvider,
+                            default(CancellationToken)).GetAwaiter().GetResult();
+                    }
+
+                    m_logger.LogWarning(
+                        "Endpoint {Endpoint} requires a certificate user token but no application certificate is configured; falling back to an anonymous identity.",
+                        m_endpoint);
+                }
+            }
+            catch (Exception e)
+            {
+                m_logger.LogError(e, "Could not create the user identity for the metadata session; falling back to an anonymous identity.");
+            }
+
+            // default to an anonymous identity
+            return new UserIdentity();
         }
 
         /// <summary>


### PR DESCRIPTION
## Proposed changes

The Aggregation Server could not connect to a remote server whose endpoint only offered a `Certificate` user token policy. The internal metadata session opened by `AggregationNodeManager` (invoked with a `null` context during `DoMetadataUpdate`) always used an anonymous user identity. When the remote endpoint does not accept anonymous tokens, session creation failed with "Endpoint does not support the user identity type provided", leaving the aggregated server permanently unconnected.

The fix derives the metadata session's user identity from the endpoint's `SelectedUserTokenPolicy` instead of hard-coding anonymous:

- When the selected policy is a `Certificate` policy, an identity is built from the aggregation server's own application certificate via `UserIdentity.CreateAsync(...)`, using the configured certificate password provider and certificate provider.
- All other cases (including when no application certificate is configured or lookup fails) fall back to an anonymous identity, preserving the previous behavior.

Note for reviewers: this reuses the aggregation server's application certificate as the *user* certificate, so the remote server must trust/authorize that certificate as a user identity. If a dedicated, separately configured user certificate is preferred, that could be wired through as a follow-up.

## Related Issues

- Fixes #658

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines.
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

The change is localized to `AggregationNodeManager.GetClientSession` plus a small `GetMetadataUserIdentity` helper. The Aggregation Server project builds cleanly (0 errors). Anonymous and username/password scenarios are unaffected since only the metadata session path with no incoming identity is changed, and it still defaults to anonymous unless the endpoint specifically requires a certificate token.