### PR TITLE
Fix ArgumentOutOfRangeException in ClientUtils Browse continuation handling (#25)

### DIFF
--- a/Samples/ClientControls.Net4/ClientUtils.cs
+++ b/Samples/ClientControls.Net4/ClientUtils.cs
@@ -1005,8 +1005,8 @@ namespace Opc.Ua.Client.Controls
                     results = response2.Results.ToList();
                     diagnosticInfos = response2.DiagnosticInfos.ToList();
 
-                    ClientBase.ValidateResponse(results, nodesToBrowse);
-                    ClientBase.ValidateDiagnosticInfos(diagnosticInfos, nodesToBrowse);
+                    ClientBase.ValidateResponse(results, continuationPoints);
+                    ClientBase.ValidateDiagnosticInfos(diagnosticInfos, continuationPoints);
                 }
 
                 //return complete list.

--- a/Workshop/Common/ModelUtils.cs
+++ b/Workshop/Common/ModelUtils.cs
@@ -283,8 +283,8 @@ namespace Quickstarts
                     results = response2.Results.ToList();
                     diagnosticInfos = response2.DiagnosticInfos.ToList();
 
-                    ClientBase.ValidateResponse(results, nodesToBrowse);
-                    ClientBase.ValidateDiagnosticInfos(diagnosticInfos, nodesToBrowse);
+                    ClientBase.ValidateResponse(results, continuationPoints);
+                    ClientBase.ValidateDiagnosticInfos(diagnosticInfos, continuationPoints);
                 }
 
                 //return complete list.


### PR DESCRIPTION
## Summary

Fixes #25 — `System.ArgumentOutOfRangeException` in `ClientUtils` browse when a single level has more than 100 nodes (i.e. `BrowseNext` continuation points are involved).

The core of the original issue (the main `BrowseAsync` continuation loop) was already resolved in #455. This PR fixes the **remaining instance of the same bug class** in the `FindTargetOfReference` "release continuation points" path.

## Problem

In `FindTargetOfReference`, after the initial browse the code releases the outstanding continuation points via `BrowseNext`, then validated the response against the **wrong** list:

```csharp
ClientBase.ValidateResponse(results, nodesToBrowse);        // wrong
ClientBase.ValidateDiagnosticInfos(diagnosticInfos, nodesToBrowse);
```

`BrowseNext` returns one result per continuation point, but only nodes that actually produced a continuation point are in that list. When any browse operation returns an error (or no continuation point), `continuationPoints.Count < nodesToBrowse.Count`, so `ValidateResponse` fails on the count mismatch — the same class of failure reported in #25.

## Fix

Validate the `BrowseNext` response against `continuationPoints`, which matches the request:

```csharp
ClientBase.ValidateResponse(results, continuationPoints);
ClientBase.ValidateDiagnosticInfos(diagnosticInfos, continuationPoints);
```

Applied in both copies of this utility:
- `Samples/ClientControls.Net4/ClientUtils.cs`
- `Workshop/Common/ModelUtils.cs`

## Testing

- `UA Client Controls.csproj` builds cleanly (0 errors; only pre-existing analyzer warnings).