### PR TITLE
Merge registered servers' AliasNames into a GDS master list

### DIFF
--- a/Samples/GDS/Common/AliasMergingGlobalDiscoverySampleServer.cs
+++ b/Samples/GDS/Common/AliasMergingGlobalDiscoverySampleServer.cs
@@ -1,0 +1,77 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using Opc.Ua.Gds.Server.Database;
+using Opc.Ua.Server;
+using Opc.Ua.Server.UserDatabase;
+
+namespace Opc.Ua.Gds.Server
+{
+    /// <summary>
+    /// A <see cref="GlobalDiscoverySampleServer"/> that also serves the GDS
+    /// master AliasNames list (issue #274 / OPC 10000-12).
+    /// </summary>
+    /// <remarks>
+    /// The only behavioural addition over the base GDS server is that, once
+    /// the server has started, the supplied
+    /// <see cref="GlobalDiscoveryServerAliasMerger"/>'s master
+    /// <c>InMemoryAliasNameStore</c> is registered with the server-wide
+    /// alias-name store registry. From then on the standard well-known
+    /// <c>Aliases</c> / <c>TagVariables</c> / <c>Topics</c> nodes on the GDS
+    /// dispatch <c>FindAlias</c> through the merged master list.
+    /// </remarks>
+    public class AliasMergingGlobalDiscoverySampleServer : GlobalDiscoverySampleServer
+    {
+        private readonly GlobalDiscoveryServerAliasMerger m_merger;
+
+        /// <summary>
+        /// Creates the alias-merging GDS server.
+        /// </summary>
+        public AliasMergingGlobalDiscoverySampleServer(
+            IApplicationsDatabase database,
+            ICertificateRequest request,
+            ICertificateGroup certificateGroup,
+            IUserDatabase userDatabase,
+            ITelemetryContext telemetry,
+            GlobalDiscoveryServerAliasMerger merger,
+            bool autoApprove = true)
+            : base(database, request, certificateGroup, userDatabase, telemetry, autoApprove)
+        {
+            m_merger = merger ?? throw new ArgumentNullException(nameof(merger));
+        }
+
+        /// <inheritdoc/>
+        protected override void OnServerStarted(IServerInternal server)
+        {
+            base.OnServerStarted(server);
+            m_merger.RegisterWithServer(server);
+        }
+    }
+}

--- a/Samples/GDS/Common/GlobalDiscoveryServerAliasMerger.cs
+++ b/Samples/GDS/Common/GlobalDiscoveryServerAliasMerger.cs
@@ -1,0 +1,547 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Opc.Ua.Client;
+using Opc.Ua.Client.AliasNames;
+using Opc.Ua.Gds.Server.Database;
+using Opc.Ua.Server;
+using Opc.Ua.Server.AliasNames;
+
+// Justification: sample diagnostics log exception type/message directly; the
+// extra evaluation when logging is disabled is negligible for a sample tool.
+#pragma warning disable CA1873
+
+namespace Opc.Ua.Gds.Server
+{
+    /// <summary>
+    /// Maintains the GDS master AliasNames list defined by OPC 10000-12
+    /// (Part 12) and OPC 10000-17 (Part 17).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This implements the alias-name merge feature tracked in issue #274.
+    /// The spec states that when a Server registers with the GDS, the GDS
+    /// shall merge the AliasNames of the registering Server into a master
+    /// AliasNames list on the GDS.
+    /// </para>
+    /// <para>
+    /// The master list is a Part 17 <see cref="InMemoryAliasNameStore"/>
+    /// that this class registers with the GDS server's
+    /// <see cref="IAliasNameStoreRegistry"/> so the standard well-known
+    /// <c>Aliases (i=23470)</c> / <c>TagVariables (i=23479)</c> /
+    /// <c>Topics (i=23488)</c> nodes on the GDS serve the aggregated view.
+    /// </para>
+    /// <para>
+    /// To collect a registered server's aliases the GDS acts as a UA client
+    /// and calls Part 17 <c>FindAlias</c> against that server. Because the
+    /// GDS never captures user credentials during registration, the pull is
+    /// performed <b>anonymously over a secured (Sign / SignAndEncrypt)
+    /// channel</b> authenticated with the GDS application instance
+    /// certificate. Servers that require a named user or a user certificate
+    /// to read their aliases are simply skipped (the failure is logged).
+    /// </para>
+    /// </remarks>
+    public sealed class GlobalDiscoveryServerAliasMerger : IDisposable
+    {
+        private readonly ITelemetryContext m_telemetry;
+        private readonly ILogger m_logger;
+        private readonly InMemoryAliasNameStore m_masterStore;
+
+        // Tracks the alias entries contributed by each registered server so a
+        // re-registration (or periodic refresh) can replace them cleanly.
+        private readonly Dictionary<string, List<AliasDeleteRequest>> m_contributions =
+            new Dictionary<string, List<AliasDeleteRequest>>(StringComparer.OrdinalIgnoreCase);
+        private readonly SemaphoreSlim m_mergeLock = new SemaphoreSlim(1, 1);
+
+        private ApplicationConfiguration m_configuration;
+        private IApplicationsDatabase m_database;
+        private CancellationTokenSource m_workerCts;
+        private Task m_workerTask;
+        private bool m_disposed;
+
+        /// <summary>
+        /// The session timeout (ms) used for the short-lived pull sessions.
+        /// </summary>
+        private const uint kSessionTimeout = 60000;
+
+        /// <summary>
+        /// The discovery timeout (ms) used when selecting an endpoint.
+        /// </summary>
+        private const int kDiscoverTimeout = 15000;
+
+        /// <summary>
+        /// Creates the merger and its master AliasNames store.
+        /// </summary>
+        public GlobalDiscoveryServerAliasMerger(ITelemetryContext telemetry)
+        {
+            m_telemetry = telemetry ?? throw new ArgumentNullException(nameof(telemetry));
+            m_logger = telemetry.CreateLogger<GlobalDiscoveryServerAliasMerger>();
+            m_masterStore = CreateMasterStore();
+        }
+
+        /// <summary>
+        /// The master AliasNames store served by the GDS. Exposed for tests
+        /// and advanced hosts; most callers only need
+        /// <see cref="RegisterWithServer"/>.
+        /// </summary>
+        public InMemoryAliasNameStore MasterStore => m_masterStore;
+
+        /// <summary>
+        /// The category the merged aliases are written to — the well-known
+        /// <c>Aliases (i=23470)</c> root, whose <c>FindAlias</c> aggregates
+        /// the <c>TagVariables</c> / <c>Topics</c> sub-categories per Part 17
+        /// §6.3.2.
+        /// </summary>
+        public static NodeId MasterCategoryId => Opc.Ua.ObjectIds.Aliases;
+
+        /// <summary>
+        /// Registers the master AliasNames store with the GDS server so the
+        /// standard well-known alias nodes dispatch through it. Call from the
+        /// server's <c>OnServerStarted</c> override.
+        /// </summary>
+        public void RegisterWithServer(IServerInternal server)
+        {
+            if (server == null)
+            {
+                throw new ArgumentNullException(nameof(server));
+            }
+
+            if (server is not IAliasNameStoreRegistryProvider provider)
+            {
+                m_logger.LogWarning(
+                    "GDS alias merge: server does not expose an IAliasNameStoreRegistry - " +
+                    "the master AliasNames list will not be served.");
+                return;
+            }
+
+            provider.AliasNameStoreRegistry.Register(m_masterStore);
+            m_logger.LogInformation("GDS alias merge: master AliasNames store registered.");
+        }
+
+        /// <summary>
+        /// Starts the background worker that periodically re-scans every
+        /// registered server and refreshes the master AliasNames list. The
+        /// first sweep runs immediately.
+        /// </summary>
+        /// <param name="configuration">The GDS application configuration used
+        /// to open client sessions to registered servers.</param>
+        /// <param name="database">The GDS applications database used to
+        /// enumerate registered servers.</param>
+        /// <param name="refreshInterval">How often to refresh. Defaults to
+        /// five minutes when <c>default</c>.</param>
+        public void Start(
+            ApplicationConfiguration configuration,
+            IApplicationsDatabase database,
+            TimeSpan refreshInterval = default)
+        {
+            m_configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            m_database = database ?? throw new ArgumentNullException(nameof(database));
+
+            if (m_workerTask != null)
+            {
+                return;
+            }
+
+            if (refreshInterval <= TimeSpan.Zero)
+            {
+                refreshInterval = TimeSpan.FromMinutes(5);
+            }
+
+            m_workerCts = new CancellationTokenSource();
+            m_workerTask = Task.Run(() => RunWorkerAsync(refreshInterval, m_workerCts.Token));
+            m_logger.LogInformation(
+                "GDS alias merge: background refresh started (interval {Interval}).",
+                refreshInterval);
+        }
+
+        /// <summary>
+        /// Requests an immediate, fire-and-forget merge of a single server's
+        /// aliases. Intended to be called from an applications-database
+        /// registration hook so a newly registered server's aliases are
+        /// merged without waiting for the next periodic sweep.
+        /// </summary>
+        public void QueueMerge(string applicationUri, IList<string> discoveryUrls)
+        {
+            if (m_configuration == null)
+            {
+                // Not started yet - the first periodic sweep will pick it up.
+                return;
+            }
+
+            CancellationToken ct = m_workerCts?.Token ?? CancellationToken.None;
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await MergeServerAsync(applicationUri, discoveryUrls, ct).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    m_logger.LogError(
+                        "GDS alias merge: background merge for {ApplicationUri} failed. Error=({ExceptionType}){Message}",
+                        applicationUri, ex.GetType().Name, ex.Message);
+                }
+            }, ct);
+        }
+
+        /// <summary>
+        /// Enumerates every registered server in the GDS database and merges
+        /// its aliases into the master list.
+        /// </summary>
+        public async Task MergeAllRegisteredAsync(CancellationToken ct = default)
+        {
+            if (m_configuration == null || m_database == null)
+            {
+                throw new InvalidOperationException(
+                    "The merger must be started with a configuration and database before merging.");
+            }
+
+            ApplicationDescription[] applications;
+            try
+            {
+                applications = m_database.QueryApplications(
+                    startingRecordId: 0,
+                    maxRecordsToReturn: 0,
+                    applicationName: string.Empty,
+                    applicationUri: string.Empty,
+                    applicationType: 0,
+                    productUri: string.Empty,
+                    serverCapabilities: ArrayOf<string>.Empty,
+                    lastCounterResetTime: out _,
+                    nextRecordId: out _);
+            }
+            catch (Exception ex)
+            {
+                m_logger.LogError(
+                    "GDS alias merge: QueryApplications failed. Error=({ExceptionType}){Message}",
+                    ex.GetType().Name, ex.Message);
+                return;
+            }
+
+            if (applications == null || applications.Length == 0)
+            {
+                return;
+            }
+
+            foreach (ApplicationDescription application in applications)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                // Only Servers publish AliasNames; skip pure clients and the
+                // discovery servers (LDS / GDS directories).
+                if (application.ApplicationType == ApplicationType.Client ||
+                    application.ApplicationType == ApplicationType.DiscoveryServer)
+                {
+                    continue;
+                }
+
+                IList<string> discoveryUrls = application.DiscoveryUrls.IsNull
+                    ? new List<string>()
+                    : application.DiscoveryUrls.ToArray();
+
+                await MergeServerAsync(application.ApplicationUri, discoveryUrls, ct)
+                    .ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Connects to a single registered server, reads its AliasNames and
+        /// merges them into the master list, replacing any aliases previously
+        /// contributed by the same server.
+        /// </summary>
+        /// <param name="applicationUri">The registering server's application
+        /// URI; used as the origin (<c>TargetServer</c>) of the merged
+        /// aliases and as the replace key.</param>
+        /// <param name="discoveryUrls">The server's discovery URLs.</param>
+        /// <param name="ct">A cancellation token.</param>
+        public async Task MergeServerAsync(
+            string applicationUri,
+            IList<string> discoveryUrls,
+            CancellationToken ct = default)
+        {
+            if (string.IsNullOrEmpty(applicationUri) || discoveryUrls == null || discoveryUrls.Count == 0)
+            {
+                return;
+            }
+
+            IReadOnlyList<AliasNameDataType> aliases = null;
+
+            foreach (string discoveryUrl in discoveryUrls)
+            {
+                if (string.IsNullOrWhiteSpace(discoveryUrl))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    aliases = await PullAliasesAsync(discoveryUrl, ct).ConfigureAwait(false);
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    m_logger.LogWarning(
+                        "GDS alias merge: could not pull aliases from {DiscoveryUrl} ({ApplicationUri}). Error=({ExceptionType}){Message}",
+                        discoveryUrl, applicationUri, ex.GetType().Name, ex.Message);
+                }
+            }
+
+            if (aliases == null)
+            {
+                return;
+            }
+
+            await ApplyMergeAsync(applicationUri, aliases, ct).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Opens a short-lived anonymous, secured session to the server and
+        /// reads every alias under the well-known <c>Aliases</c> category.
+        /// </summary>
+        private async Task<IReadOnlyList<AliasNameDataType>> PullAliasesAsync(
+            string discoveryUrl,
+            CancellationToken ct)
+        {
+            EndpointDescription endpointDescription = await CoreClientUtils.SelectEndpointAsync(
+                m_configuration,
+                discoveryUrl,
+                useSecurity: true,
+                kDiscoverTimeout,
+                m_telemetry,
+                ct).ConfigureAwait(false);
+
+            EndpointConfiguration endpointConfiguration = EndpointConfiguration.Create(m_configuration);
+            var endpoint = new ConfiguredEndpoint(null, endpointDescription, endpointConfiguration);
+
+            Opc.Ua.Client.ISession session = await new DefaultSessionFactory(m_telemetry).CreateAsync(
+                m_configuration,
+                endpoint,
+                updateBeforeConnect: false,
+                checkDomain: false,
+                sessionName: m_configuration.ApplicationName + " AliasMerge",
+                sessionTimeout: kSessionTimeout,
+                identity: new UserIdentity(),
+                preferredLocales: ArrayOf<string>.Empty,
+                ct).ConfigureAwait(false);
+
+            try
+            {
+                AliasNameClient client = AliasNameClient.OpenStandardAliases(session);
+
+                // "%" is the Part 17 wildcard that matches every alias name.
+                return await client.FindAliasAsync("%", referenceTypeFilter: null, ct)
+                    .ConfigureAwait(false);
+            }
+            finally
+            {
+                try
+                {
+                    await session.CloseAsync(ct).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    m_logger.LogDebug(
+                        "GDS alias merge: closing pull session failed. Error=({ExceptionType}){Message}",
+                        ex.GetType().Name, ex.Message);
+                }
+
+                session.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Replaces the named server's previous contribution with the newly
+        /// pulled aliases in the master store.
+        /// </summary>
+        private async Task ApplyMergeAsync(
+            string applicationUri,
+            IReadOnlyList<AliasNameDataType> aliases,
+            CancellationToken ct)
+        {
+            var additions = new List<AliasAddRequest>();
+            var newContribution = new List<AliasDeleteRequest>();
+
+            foreach (AliasNameDataType alias in aliases)
+            {
+                string name = alias.AliasName.Name;
+                if (string.IsNullOrEmpty(name) || alias.ReferencedNodes.IsNull)
+                {
+                    continue;
+                }
+
+                foreach (ExpandedNodeId target in alias.ReferencedNodes.ToArray())
+                {
+                    if (target.IsNull)
+                    {
+                        continue;
+                    }
+
+                    additions.Add(new AliasAddRequest(
+                        name,
+                        target,
+                        applicationUri,
+                        ReferenceTypeIds.AliasFor));
+                    newContribution.Add(new AliasDeleteRequest(name, target));
+                }
+            }
+
+            await m_mergeLock.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                // Remove what this server contributed previously so stale
+                // aliases do not linger after the server changes them.
+                if (m_contributions.TryGetValue(applicationUri, out List<AliasDeleteRequest> previous) &&
+                    previous.Count > 0)
+                {
+                    await m_masterStore.DeleteAliasesAsync(MasterCategoryId, previous, ct)
+                        .ConfigureAwait(false);
+                }
+
+                if (additions.Count > 0)
+                {
+                    await m_masterStore.AddAliasesAsync(MasterCategoryId, additions, ct)
+                        .ConfigureAwait(false);
+                    m_contributions[applicationUri] = newContribution;
+                }
+                else
+                {
+                    m_contributions.Remove(applicationUri);
+                }
+            }
+            finally
+            {
+                m_mergeLock.Release();
+            }
+
+            m_logger.LogInformation(
+                "GDS alias merge: merged {Count} alias target(s) from {ApplicationUri}.",
+                additions.Count, applicationUri);
+        }
+
+        private async Task RunWorkerAsync(TimeSpan refreshInterval, CancellationToken ct)
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                try
+                {
+                    await MergeAllRegisteredAsync(ct).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    m_logger.LogError(
+                        "GDS alias merge: periodic refresh failed. Error=({ExceptionType}){Message}",
+                        ex.GetType().Name, ex.Message);
+                }
+
+                try
+                {
+                    await Task.Delay(refreshInterval, ct).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Builds the master store: the well-known <c>Aliases</c> root with
+        /// the <c>TagVariables</c> and <c>Topics</c> sub-categories, matching
+        /// the standard Part 17 layout so a client browsing the GDS sees the
+        /// familiar hierarchy.
+        /// </summary>
+        private static InMemoryAliasNameStore CreateMasterStore()
+        {
+            var tagVariables = new AliasNameCategoryDescriptor(
+                Opc.Ua.ObjectIds.TagVariables,
+                QualifiedName.From(Opc.Ua.BrowseNames.TagVariables),
+                AliasNameCapabilities.FindAliasVerbose);
+
+            var topics = new AliasNameCategoryDescriptor(
+                Opc.Ua.ObjectIds.Topics,
+                QualifiedName.From(Opc.Ua.BrowseNames.Topics),
+                AliasNameCapabilities.FindAliasVerbose);
+
+            var aliases = new AliasNameCategoryDescriptor(
+                Opc.Ua.ObjectIds.Aliases,
+                QualifiedName.From(Opc.Ua.BrowseNames.Aliases),
+                AliasNameCapabilities.FindAliasVerbose |
+                AliasNameCapabilities.LastChange |
+                AliasNameCapabilities.AddAliasesToCategory |
+                AliasNameCapabilities.DeleteAliasesFromCategory,
+                subCategories: new[] { tagVariables, topics });
+
+            return new InMemoryAliasNameStore(new[] { aliases });
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            if (m_disposed)
+            {
+                return;
+            }
+            m_disposed = true;
+
+            try
+            {
+                m_workerCts?.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+
+            try
+            {
+                m_workerTask?.Wait(TimeSpan.FromSeconds(5));
+            }
+            catch (Exception ex)
+            {
+                m_logger.LogDebug(
+                    "GDS alias merge: worker shutdown reported {ExceptionType}: {Message}",
+                    ex.GetType().Name, ex.Message);
+            }
+
+            m_workerCts?.Dispose();
+            m_mergeLock.Dispose();
+            m_masterStore.Dispose();
+        }
+    }
+}
+#pragma warning restore CA1873

--- a/Samples/GDS/ConsoleServer/NetCoreGlobalDiscoveryServer.csproj
+++ b/Samples/GDS/ConsoleServer/NetCoreGlobalDiscoveryServer.csproj
@@ -12,9 +12,15 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\Common\GlobalDiscoveryServerAliasMerger.cs" Link="Common\GlobalDiscoveryServerAliasMerger.cs" />
+    <Compile Include="..\Common\AliasMergingGlobalDiscoverySampleServer.cs" Link="Common\AliasMergingGlobalDiscoverySampleServer.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="Mono.Options" Version="6.12.0.148" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client" Version="2.0.158.59919-preview" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Gds.Server.Common" Version="2.0.158.59919-preview" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration" Version="2.0.158.59919-preview" />
   </ItemGroup>

--- a/Samples/GDS/ConsoleServer/Program.cs
+++ b/Samples/GDS/ConsoleServer/Program.cs
@@ -166,6 +166,7 @@ namespace Opc.Ua.Gds.Server
         private ApplicationConfiguration m_configuration;
         private IApplicationsDatabase m_database;
         private LdsScannerConfiguration m_ldsScannerConfiguration;
+        private GlobalDiscoveryServerAliasMerger m_aliasMerger;
         #pragma warning disable CA2211 // Justification: Public sample API compatibility is preserved.
         public static ExitCode exitCode;
         #pragma warning restore CA2211
@@ -246,6 +247,9 @@ namespace Opc.Ua.Gds.Server
             if (server != null)
             {
                 Console.WriteLine("Server stopped. Waiting for exit...");
+
+                m_aliasMerger?.Dispose();
+                m_aliasMerger = null;
 
                 using (GlobalDiscoverySampleServer _server = server)
                 {
@@ -406,13 +410,18 @@ namespace Opc.Ua.Gds.Server
 
             bool createStandardUsers = ConfigureUsers(userDatabase);
 
+            // GDS master AliasNames list (issue #274): merge each registered
+            // server's AliasNames into a master list served by this GDS.
+            m_aliasMerger = new GlobalDiscoveryServerAliasMerger(telemetry);
+
             // start the server.
-            server = new GlobalDiscoverySampleServer(
+            server = new AliasMergingGlobalDiscoverySampleServer(
                 database,
                 database,
                 new CertificateGroup(telemetry),
                 userDatabase,
                 telemetry,
+                m_aliasMerger,
                 true);
             await application.StartAsync(server).ConfigureAwait(false);
 
@@ -421,6 +430,10 @@ namespace Opc.Ua.Gds.Server
             m_configuration = config;
             m_database = database;
             m_ldsScannerConfiguration = LdsScannerConfiguration.Parse(config);
+
+            // start periodically refreshing the GDS master AliasNames list
+            // from every registered server.
+            m_aliasMerger.Start(config, database);
 
             // print endpoint info
             IEnumerable<string> endpoints = application.Server.GetEndpoints().ToArray().Select(e => e.EndpointUrl).Distinct();

--- a/Samples/GDS/README.md
+++ b/Samples/GDS/README.md
@@ -148,6 +148,50 @@ The default LDS discovery URL is `opc.tcp://<lds-host>:4840`. In every case make
 application certificate (copy it from the GDS **rejected** store to **trusted/certs**, see
 [GDS Certificate stores](#gds-certificate-stores)) so the discovery calls can use a secure channel.
 
+## Merging AliasNames from registered servers into a GDS master list
+OPC UA Part 17 (AliasNames) lets a server expose an `Aliases` directory that maps human-friendly names (for example
+`TagVariables` and `Topics`) onto the `NodeId`s they resolve to. The GDS is the natural place to aggregate those
+per-server alias directories into a single, global view. This is the feature tracked in
+[issue #274 – *How GDS pulls the AliasNames from Registered servers*](https://github.com/OPCFoundation/UA-.NETStandard-Samples/issues/274):
+> When a Server registers with the GDS, the GDS shall merge the AliasNames of the registering Server into a master
+> AliasNames list on the GDS.
+
+Both sample GDS servers (the Windows **GlobalDiscoveryServer** and the cross-platform
+**NetCoreGlobalDiscoveryServer**) now implement this. The master list is served through the standard Part 17
+well-known nodes on the GDS itself — `Aliases (i=23470)`, `TagVariables (i=23479)` and `Topics (i=23488)` — so any UA
+client can browse the aggregated aliases on the GDS exactly as it would on an individual server.
+
+### How the merge works
+The shared implementation lives in
+[`Samples/GDS/Common/GlobalDiscoveryServerAliasMerger.cs`](Common/GlobalDiscoveryServerAliasMerger.cs) and
+[`Samples/GDS/Common/AliasMergingGlobalDiscoverySampleServer.cs`](Common/AliasMergingGlobalDiscoverySampleServer.cs),
+which are linked into both sample projects.
+
+1. **Master store.** `GlobalDiscoveryServerAliasMerger` owns an in-memory Part 17 `InMemoryAliasNameStore` laid out
+   with the standard `Aliases` root and its `TagVariables` / `Topics` sub-categories. The
+   `AliasMergingGlobalDiscoverySampleServer` subclass registers this store with the server's
+   `IAliasNameStoreRegistry` in `OnServerStarted`, so the well-known alias nodes on the GDS dispatch through it.
+2. **Pull on registration.** When a server registers, the applications database raises a registration event and the
+   merger connects **out to that server as a UA client** and calls the Part 17 `FindAlias` service (with the `%`
+   wildcard) to read every alias the server publishes.
+3. **Merge.** The pulled aliases are written into the GDS master `Aliases` category, tagged with the contributing
+   server's application URI as their `TargetServer`. The merger tracks each server's contribution, so a
+   re-registration (or the periodic refresh) cleanly **replaces** that server's previous aliases instead of
+   duplicating them.
+4. **Periodic refresh.** A background worker re-scans every registered server on an interval (default five minutes)
+   so the master list also reflects alias changes made after registration.
+
+### Authentication of the pull
+The GDS never captures a registering server's user credentials, so it cannot impersonate a named user when reading
+that server's aliases. The pull is therefore performed **anonymously over a secured (Sign / SignAndEncrypt) channel**
+authenticated with the **GDS application instance certificate**. For the merge to succeed:
+- The server must offer a secure endpoint that permits **anonymous** access to the Part 17 `FindAlias` service.
+- The server must **trust the GDS application certificate** (and the GDS must trust the server's certificate) so the
+  secure channel can be established — copy the certificates between the trust lists exactly as for the LDS scan above.
+
+Servers that require a named user or a user certificate to read their aliases are simply skipped, and the failure is
+logged; nothing else about registration is affected.
+
 ## GDS Users
 The sample GDS servers only implement the username/password authentication. The following combinations can be used to connect to the servers:
 - **DiscoveryAdmin**

--- a/Samples/GDS/Server/GlobalDiscoveryServer.csproj
+++ b/Samples/GDS/Server/GlobalDiscoveryServer.csproj
@@ -27,6 +27,10 @@
     <ProjectReference Include="..\..\ServerControls.Net4\UA Server Controls.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\Common\GlobalDiscoveryServerAliasMerger.cs" Link="Common\GlobalDiscoveryServerAliasMerger.cs" />
+    <Compile Include="..\Common\AliasMergingGlobalDiscoverySampleServer.cs" Link="Common\AliasMergingGlobalDiscoverySampleServer.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10">
       <PrivateAssets>all</PrivateAssets>
@@ -36,6 +40,9 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration">
+      <Version>2.0.158.59919-preview</Version>
+    </PackageReference>
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client">
       <Version>2.0.158.59919-preview</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Gds.Server.Common">

--- a/Samples/GDS/Server/Program.cs
+++ b/Samples/GDS/Server/Program.cs
@@ -102,21 +102,40 @@ namespace Opc.Ua.Gds.Server
 
                 // start the server.
                 var database = new SqlApplicationsDatabase();
+
+                // GDS master AliasNames list (issue #274): merge each
+                // registered server's AliasNames into a master list served by
+                // this GDS.
+                var aliasMerger = new GlobalDiscoveryServerAliasMerger(m_telemetry);
+
                 #pragma warning disable CA2000 // Justification: WinForms/sample ownership or lifetime is managed outside the local scope.
-                var server = new GlobalDiscoverySampleServer(
+                var server = new AliasMergingGlobalDiscoverySampleServer(
                 #pragma warning restore CA2000
                     database,
                     database,
                     new CertificateGroup(m_telemetry),
                     userDatabase,
                     m_telemetry,
+                    aliasMerger,
                     true);
                 application.StartAsync(server).Wait();
+
+                // start refreshing the master AliasNames list and merge each
+                // server as soon as it registers.
+                aliasMerger.Start(application.ApplicationConfiguration, database);
+                database.ApplicationRegistered += (sender, app) =>
+                    aliasMerger.QueueMerge(
+                        app.ApplicationUri,
+                        app.DiscoveryUrls.IsNull
+                            ? new List<string>()
+                            : app.DiscoveryUrls.ToArray());
 
                 // run the application interactively.
                 #pragma warning disable CA2000 // Justification: WinForms/sample ownership or lifetime is managed outside the local scope.
                 System.Windows.Forms.Application.Run(new ServerForm(server, application.ApplicationConfiguration, m_telemetry));
                 #pragma warning restore CA2000
+
+                aliasMerger.Dispose();
             }
             catch (Exception e)
             {

--- a/Samples/GDS/Server/SqlApplicationsDatabase.cs
+++ b/Samples/GDS/Server/SqlApplicationsDatabase.cs
@@ -40,6 +40,13 @@ namespace Opc.Ua.Gds.Server.Database.Sql
 {
     public class SqlApplicationsDatabase : ApplicationsDatabaseBase, ICertificateRequest
     {
+        /// <summary>
+        /// Raised after a server successfully (re-)registers with the GDS.
+        /// The GDS host uses this to merge the newly registered server's
+        /// AliasNames into the master AliasNames list (issue #274).
+        /// </summary>
+        public event EventHandler<ApplicationRecordDataType> ApplicationRegistered;
+
         #region IApplicationsDatabase Members
         public override void Initialize()
         {
@@ -148,6 +155,9 @@ namespace Opc.Ua.Gds.Server.Database.Sql
 
                 entities.SaveChanges();
                 m_lastCounterResetTime = DateTime.UtcNow;
+
+                ApplicationRegistered?.Invoke(this, application);
+
                 return new NodeId(applicationId, NamespaceIndex); ;
             }
         }


### PR DESCRIPTION
## Proposed changes

The OPC UA v2.0 stack ships Part 17 AliasNames support, but the GDS samples never used it. Per OPC 10000-12, when a server registers with the GDS the GDS should merge that server's AliasNames into a master AliasNames list, so a client can browse one aggregated alias directory on the GDS instead of querying every server individually. This PR implements that for both GDS samples.

The core is a reusable `GlobalDiscoveryServerAliasMerger` (in a new `Samples/GDS/Common/` folder, linked into both projects) that:

- Owns an in-memory Part 17 master store laid out with the standard well-known nodes (`Aliases` / `TagVariables` / `Topics`), registered with the server's `IAliasNameStoreRegistry` via the `AliasMergingGlobalDiscoverySampleServer` subclass. As a result the standard alias nodes on the GDS itself serve the aggregated view.
- On each registration (and on a periodic background refresh, default 5 min) connects out to the registered server as a UA client, calls Part 17 `FindAlias("%")`, and merges the results into the master `Aliases` category, tagged with the contributing server's application URI. Contributions are tracked per server so a re-registration cleanly replaces stale aliases instead of duplicating them.

Wiring:
- **NetCoreGlobalDiscoveryServer** (console) uses the subclass and starts the merger; the periodic sweep picks up registrations.
- **GlobalDiscoveryServer** (WinForms/SQL) additionally gets immediate merges: `SqlApplicationsDatabase` now raises an `ApplicationRegistered` event that triggers a merge as soon as a server registers.

**Authentication note worth a careful look:** the GDS never captures a registering server's user credentials, so the pull is performed anonymously over a secured (Sign / SignAndEncrypt) channel authenticated with the GDS application instance certificate. Servers that require a named user or a user certificate to read their aliases are skipped (and the failure is logged); nothing else about registration is affected. This design choice was confirmed during implementation. Both the WinForms and console projects gain an explicit `Opc.Ua.Client` package reference since the client assembly is not transitive.

Both sample projects build cleanly. The feature and its auth model are documented in `Samples/GDS/README.md`.

## Related Issues

- Fixes #274

## Types of changes

What types of changes does your code introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines.
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

The merge logic is shared between both samples rather than duplicated, so behavior stays consistent. The console sample relies on the periodic refresh to discover new registrations, while the SQL-backed WinForms sample also fires an immediate merge via the new `ApplicationRegistered` event; the periodic worker is the common baseline. An alternative considered was extending the base `ApplicationsDatabaseBase` with the registration event, but that was avoided to keep the change scoped to the sample and not touch shared SDK-facing surface.