### PR TITLE
Fix inverted Data Encoding condition in ReadValueEditDlg

### DIFF
--- a/Samples/Controls.Net4/Subscriptions/ReadValueEditDlg.cs
+++ b/Samples/Controls.Net4/Subscriptions/ReadValueEditDlg.cs
@@ -85,10 +85,9 @@ namespace Opc.Ua.Sample.Controls
             valueId.AttributeId = Attributes.GetIdentifier((string)AttributeIdCB.SelectedItem);
             valueId.IndexRange = IndexRangeTB.Text;
 
-            if (String.IsNullOrEmpty(EncodingCB.Text))
-            {
-                valueId.DataEncoding = new QualifiedName(EncodingCB.Text);
-            }
+            valueId.DataEncoding = !String.IsNullOrEmpty(EncodingCB.Text)
+                ? new QualifiedName(EncodingCB.Text)
+                : QualifiedName.Null;
 
             return true;
         }


### PR DESCRIPTION
## Proposed changes

In the Read value dialog, the Data Encoding the user typed (e.g. Default Binary / Default XML) was silently discarded, so reads were always sent with a null/empty `DataEncoding`.

The root cause was an inverted condition in `ReadValueEditDlg.ShowDialogAsync`: it only assigned `valueId.DataEncoding` when the encoding text was **empty**, and then assigned an empty `QualifiedName`. When the user actually entered an encoding, the assignment was skipped entirely.

This change assigns the entered encoding when present and clears it to `QualifiedName.Null` when the field is blank.

## Related Issues

- Fixes #737

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines.
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

N/A