### PR TITLE
Add private key password support to GDS Client certificate flows

### DIFF
--- a/Samples/GDS/Client/Controls/ApplicationCertificateControl.Designer.cs
+++ b/Samples/GDS/Client/Controls/ApplicationCertificateControl.Designer.cs
@@ -34,6 +34,8 @@
             this.WarningLabel = new System.Windows.Forms.Label();
             this.CertificateControl = new Opc.Ua.Gds.Client.Controls.EditValueCtrl();
             this.RegistrationButtonsPanel = new System.Windows.Forms.Panel();
+            this.PrivateKeyPasswordTextBox = new System.Windows.Forms.TextBox();
+            this.PrivateKeyPasswordLabel = new System.Windows.Forms.Label();
             this.ApplyChangesButton = new System.Windows.Forms.Button();
             this.RequestNewButton = new System.Windows.Forms.Button();
             this.CertificateRequestTimer = new System.Windows.Forms.Timer(this.components);
@@ -94,6 +96,8 @@
             // RegistrationButtonsPanel
             // 
             this.RegistrationButtonsPanel.BackColor = System.Drawing.Color.MidnightBlue;
+            this.RegistrationButtonsPanel.Controls.Add(this.PrivateKeyPasswordTextBox);
+            this.RegistrationButtonsPanel.Controls.Add(this.PrivateKeyPasswordLabel);
             this.RegistrationButtonsPanel.Controls.Add(this.ApplyChangesButton);
             this.RegistrationButtonsPanel.Controls.Add(this.RequestNewButton);
             this.RegistrationButtonsPanel.Dock = System.Windows.Forms.DockStyle.Bottom;
@@ -101,6 +105,27 @@
             this.RegistrationButtonsPanel.Name = "RegistrationButtonsPanel";
             this.RegistrationButtonsPanel.Size = new System.Drawing.Size(879, 32);
             this.RegistrationButtonsPanel.TabIndex = 13;
+            // 
+            // PrivateKeyPasswordLabel
+            // 
+            this.PrivateKeyPasswordLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.PrivateKeyPasswordLabel.AutoSize = true;
+            this.PrivateKeyPasswordLabel.ForeColor = System.Drawing.Color.White;
+            this.PrivateKeyPasswordLabel.Location = new System.Drawing.Point(524, 9);
+            this.PrivateKeyPasswordLabel.Name = "PrivateKeyPasswordLabel";
+            this.PrivateKeyPasswordLabel.Size = new System.Drawing.Size(115, 13);
+            this.PrivateKeyPasswordLabel.TabIndex = 5;
+            this.PrivateKeyPasswordLabel.Text = "Private Key Password:";
+            // 
+            // PrivateKeyPasswordTextBox
+            // 
+            this.PrivateKeyPasswordTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.PrivateKeyPasswordTextBox.Location = new System.Drawing.Point(645, 6);
+            this.PrivateKeyPasswordTextBox.Name = "PrivateKeyPasswordTextBox";
+            this.PrivateKeyPasswordTextBox.Size = new System.Drawing.Size(225, 20);
+            this.PrivateKeyPasswordTextBox.TabIndex = 6;
+            this.PrivateKeyPasswordTextBox.UseSystemPasswordChar = true;
+            this.PrivateKeyPasswordTextBox.TextChanged += new System.EventHandler(this.PrivateKeyPasswordTextBox_TextChanged);
             // 
             // ApplyChangesButton
             // 
@@ -163,5 +188,7 @@
         private System.Windows.Forms.Timer CertificateRequestTimer;
         private System.Windows.Forms.Label RequestProgressLabel;
         private System.Windows.Forms.Button ApplyChangesButton;
+        private System.Windows.Forms.Label PrivateKeyPasswordLabel;
+        private System.Windows.Forms.TextBox PrivateKeyPasswordTextBox;
     }
 }

--- a/Samples/GDS/Client/Controls/ApplicationCertificateControl.cs
+++ b/Samples/GDS/Client/Controls/ApplicationCertificateControl.cs
@@ -74,6 +74,7 @@ namespace Opc.Ua.Gds.Client
             m_certificate = null;
             m_temporaryCertificateCreated = false;
             m_certificatePassword = null;
+            PrivateKeyPasswordTextBox.Text = string.Empty;
 
             CertificateRequestTimer.Enabled = false;
             RequestProgressLabel.Visible = false;
@@ -260,9 +261,46 @@ certificateRequest);
             return null;
         }
 
-        private Task<X509Certificate2> LoadPrivateKeyAsync(CertificateIdentifier id, X509Certificate2 certificate, char[] password)
+        private async Task<X509Certificate2> LoadPrivateKeyAsync(CertificateIdentifier id, X509Certificate2 certificate, char[] password)
         {
-            return Task.FromResult(certificate);
+            if (certificate == null)
+            {
+                return null;
+            }
+
+            // Certificate already carries an exportable private key, nothing to load.
+            if (certificate.HasPrivateKey)
+            {
+                return certificate;
+            }
+
+            if (id == null || String.IsNullOrEmpty(id.StorePath))
+            {
+                return certificate;
+            }
+
+            var storeIdentifier = new CertificateStoreIdentifier(id.StorePath, false);
+            using (ICertificateStore store = storeIdentifier.OpenStore(m_telemetry))
+            {
+                if (store == null || !store.SupportsLoadPrivateKey)
+                {
+                    return certificate;
+                }
+
+                Certificate withPrivateKey = await store.LoadPrivateKeyAsync(
+                    certificate.Thumbprint,
+                    certificate.Subject,
+                    null,
+                    id.CertificateType,
+                    (password != null && password.Length > 0) ? password : null);
+
+                if (withPrivateKey != null)
+                {
+                    return withPrivateKey.AsX509Certificate2();
+                }
+            }
+
+            return certificate;
         }
         private async Task RequestNewCertificatePullModeAsync(object sender, EventArgs e)
         {
@@ -410,7 +448,7 @@ certificateRequest);
                                 X509Certificate2 oldCertificate = await FindCertificateAsync(cid);
                                 if (oldCertificate != null && oldCertificate.HasPrivateKey)
                                 {
-                                    oldCertificate = await LoadPrivateKeyAsync(cid, oldCertificate, []);
+                                    oldCertificate = await LoadPrivateKeyAsync(cid, oldCertificate, m_certificatePassword?.ToCharArray());
                                     newCert = DefaultCertificateFactory.Instance.CreateWithPrivateKey(Certificate.From(newCert), Certificate.From(m_temporaryCertificateCreated ? m_certificate : oldCertificate)).AsX509Certificate2();
                                     await store.DeleteAsync(oldCertificate.Thumbprint);
                                 }
@@ -421,7 +459,7 @@ certificateRequest);
                             }
                             else
                             {
-                                newCert = GdsCertificateLoader.LoadPkcs12(privateKeyPFX.ToArray(), string.Empty, X509KeyStorageFlags.Exportable);
+                                newCert = GdsCertificateLoader.LoadPkcs12(privateKeyPFX.ToArray(), m_certificatePassword ?? string.Empty, X509KeyStorageFlags.Exportable);
                             }
                             await store.AddAsync(Certificate.From(newCert));
                             if (m_temporaryCertificateCreated)
@@ -609,6 +647,11 @@ certificate,
         private void Button_MouseLeave(object sender, EventArgs e)
         {
             ((Control)sender).BackColor = Color.MidnightBlue;
+        }
+
+        private void PrivateKeyPasswordTextBox_TextChanged(object sender, EventArgs e)
+        {
+            m_certificatePassword = PrivateKeyPasswordTextBox.Text;
         }
 
     }


### PR DESCRIPTION
## Proposed changes

The GDS Client had a `m_certificatePassword` field that was threaded through the request, signing, and PFX code paths but was only ever initialized to `null`. There was no UI element to enter a private key password, so every flow resolved to an empty/null password and password-protected keys could not be used.

This change adds a masked password input to `ApplicationCertificateControl` and wires it into all relevant flows:

- A `Private Key Password` text box (`UseSystemPasswordChar`) in the registration buttons panel, synced into `m_certificatePassword` on change and reset on initialization.
- The password now feeds new key-pair requests, CSR signing (PFX/PEM private-key read), and PFX read/write on certificate merge.
- `LoadPrivateKeyAsync` was a no-op stub that ignored its password argument. It now opens the certificate store and loads the private key using the supplied password (falling back to the public-only certificate when the store does not support key loading or no match is found).
- Fixed a latent bug where the GDS-returned PFX (pull mode) was loaded with `string.Empty` instead of the request password, which would fail to decrypt a password-protected PFX.

Verified with a local build of `GlobalDiscoveryClient.csproj` (0 warnings, 0 errors).

## Related Issues

- Fixes #743

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

This is a WinForms sample control, so the change is UI-driven and not covered by automated tests. The password is read directly from the text box into the existing field, keeping the surrounding request/signing/PFX code paths unchanged aside from now receiving a real password. `LoadPrivateKeyAsync` intentionally degrades gracefully to the public certificate rather than throwing, to preserve existing behavior when a store does not support private-key export.