### PR TITLE
Fix #739: allow editing ByteString values when writing a node

### DIFF
--- a/Samples/ClientControls.Net4/Configuration/Common (OLD)/GuiUtils.cs
+++ b/Samples/ClientControls.Net4/Configuration/Common (OLD)/GuiUtils.cs
@@ -547,6 +547,23 @@ namespace Opc.Ua.Client.Controls
                     #pragma warning restore CA2000
                 }
 
+                case BuiltInType.ByteString:
+                {
+                    byte[] bytes = value as byte[];
+                    string hex = FormatByteString(bytes);
+
+                    #pragma warning disable CA2000 // Justification: ownership is transferred to WinForms/control owner or existing sample lifetime is preserved.
+                    string edited = new StringValueEditDlg().ShowDialog(hex);
+                    #pragma warning restore CA2000
+
+                    if (edited == null)
+                    {
+                        return null;
+                    }
+
+                    return ParseByteString(edited);
+                }
+
                 case BuiltInType.LocalizedText:
                 {
                     LocalizedText ltext = (LocalizedText)value;
@@ -567,6 +584,110 @@ namespace Opc.Ua.Client.Controls
             #pragma warning disable CA2000 // Justification: ownership is transferred to WinForms/control owner or existing sample lifetime is preserved.
             return new ComplexValueEditDlg().ShowDialog(value, telemetry);
             #pragma warning restore CA2000
+        }
+
+        /// <summary>
+        /// Formats a byte array as a whitespace separated hex string for editing.
+        /// </summary>
+        private static string FormatByteString(byte[] bytes)
+        {
+            if (bytes == null)
+            {
+                return String.Empty;
+            }
+
+            var builder = new StringBuilder(bytes.Length * 3);
+
+            for (int ii = 0; ii < bytes.Length; ii++)
+            {
+                if (ii > 0)
+                {
+                    builder.Append(' ');
+                }
+
+                builder.AppendFormat(System.Globalization.CultureInfo.InvariantCulture, "{0:X2}", bytes[ii]);
+            }
+
+            return builder.ToString();
+        }
+
+        /// <summary>
+        /// Parses an edited ByteString. Accepts hex (with optional whitespace, commas
+        /// or 0x prefixes) or, as a fallback, a base64 encoded string.
+        /// </summary>
+        private static byte[] ParseByteString(string text)
+        {
+            if (String.IsNullOrWhiteSpace(text))
+            {
+                return Array.Empty<byte>();
+            }
+
+            // Strip common separators and prefixes so both "0x0A, 0x0B" and "0A0B" work.
+            string cleaned = text
+                .Replace("0x", String.Empty)
+                .Replace("0X", String.Empty)
+                .Replace(",", String.Empty)
+                .Replace("-", String.Empty);
+
+            var hexOnly = new StringBuilder(cleaned.Length);
+
+            foreach (char ch in cleaned)
+            {
+                if (Char.IsWhiteSpace(ch))
+                {
+                    continue;
+                }
+
+                hexOnly.Append(ch);
+            }
+
+            string hex = hexOnly.ToString();
+
+            if (hex.Length > 0 &&
+                hex.Length % 2 == 0 &&
+                IsHexString(hex))
+            {
+                var bytes = new byte[hex.Length / 2];
+
+                for (int ii = 0; ii < bytes.Length; ii++)
+                {
+                    bytes[ii] = Convert.ToByte(hex.Substring(ii * 2, 2), 16);
+                }
+
+                return bytes;
+            }
+
+            // Fall back to base64 if the text is not valid hex.
+            try
+            {
+                return Convert.FromBase64String(text.Trim());
+            }
+            catch (FormatException)
+            {
+                throw new FormatException(
+                    "The value could not be interpreted as a ByteString. Enter the bytes as hex (e.g. '0A 1B 2C') or as a base64 string.");
+            }
+        }
+
+        /// <summary>
+        /// Returns true if every character in the string is a hexadecimal digit.
+        /// </summary>
+        private static bool IsHexString(string text)
+        {
+            foreach (char ch in text)
+            {
+                bool isHexDigit =
+                    (ch >= '0' && ch <= '9') ||
+                    (ch >= 'a' && ch <= 'f') ||
+                    (ch >= 'A' && ch <= 'F');
+
+                if (!isHexDigit)
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
## Proposed changes

When writing a node whose value is a `ByteString`/byte array in the UA Sample Client, the value editor did not let the user modify the bytes. `GuiUtils.EditValue` had no `BuiltInType.ByteString` case, so a ByteString fell through to the read-only `ComplexValueEditDlg` where `DataListCtrl` renders the bytes as 16-byte blocks and disables the **Edit** action.

This change adds a dedicated `BuiltInType.ByteString` case to `GuiUtils.EditValue` (in `Samples/ClientControls.Net4/Configuration/Common (OLD)/GuiUtils.cs`). It renders the current bytes as a space-separated hex string, opens the existing `StringValueEditDlg` for editing, and parses the edited text back into a `byte[]`.

Parsing is lenient: `ParseByteString` accepts hex with optional `0x` prefixes, commas, dashes, and whitespace (so both `0A 1B 2C` and `0x0A,0x0B` work), and falls back to base64 when the input is not valid hex. Invalid input raises a clear `FormatException` describing the accepted formats. Reusing `StringValueEditDlg` keeps the change small and avoids a new dialog.

## Related Issues

- Fixes #739

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines.
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

The client sample project builds successfully with the change (only pre-existing warnings remain). This is a WinForms sample control with no automated UI test coverage, so the fix was validated by building and by reasoning through the edit/parse round-trip.