### PR TITLE
Fix GDS Client cert path placeholder expansion when saving certificates

### DIFF
--- a/Samples/GDS/Client/Controls/ApplicationCertificateControl.cs
+++ b/Samples/GDS/Client/Controls/ApplicationCertificateControl.cs
@@ -473,7 +473,7 @@ certificateRequest);
                     else
                     {
                         DialogResult result = DialogResult.Yes;
-                        string absoluteCertificatePublicKeyPath = Utils.GetAbsoluteFilePath(m_application.CertificatePublicKeyPath, true, false, false) ?? m_application.CertificatePublicKeyPath;
+                        string absoluteCertificatePublicKeyPath = GetSaveFilePath(m_application.CertificatePublicKeyPath);
                         FileInfo file = new FileInfo(absoluteCertificatePublicKeyPath);
                         if (file.Exists)
                         {
@@ -504,7 +504,7 @@ certificateRequest);
                         // if we provided a PFX or P12 with the private key, we need to merge the new cert with the private key
                         if (m_application.GetPrivateKeyFormat((m_server != null ? await m_server.GetSupportedKeyFormatsAsync() : ArrayOf<string>.Empty).ToArray()) == "PFX")
                         {
-                            string absoluteCertificatePrivateKeyPath = Utils.GetAbsoluteFilePath(m_application.CertificatePrivateKeyPath, true, false, false) ?? m_application.CertificatePrivateKeyPath;
+                            string absoluteCertificatePrivateKeyPath = GetSaveFilePath(m_application.CertificatePrivateKeyPath);
                             file = new FileInfo(absoluteCertificatePrivateKeyPath);
                             if (file.Exists)
                             {
@@ -610,6 +610,42 @@ certificate,
                 CertificateRequestTimer.Enabled = false;
                 Opc.Ua.Client.Controls.ExceptionDlg.Show(m_telemetry, Text, exception);
             }
+        }
+
+        /// <summary>
+        /// Resolves a certificate file path for saving.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="Utils.GetAbsoluteFilePath(string, bool, bool, bool)"/> only resolves paths to files that
+        /// already exist. When saving a new certificate the target file does not exist yet, so that call fails
+        /// and the raw path (which may still contain an unexpanded placeholder such as
+        /// <c>%CommonApplicationData%</c>) would be used verbatim. This helper falls back to
+        /// <see cref="Utils.ReplaceSpecialFolderNames(string)"/> so environment/special-folder placeholders are
+        /// consistently expanded and the certificate is written to the intended location.
+        /// </remarks>
+        private static string GetSaveFilePath(string filePath)
+        {
+            if (String.IsNullOrEmpty(filePath))
+            {
+                return filePath;
+            }
+
+            try
+            {
+                // Prefer an already existing file (also handles current-directory lookup).
+                string resolved = Utils.GetAbsoluteFilePath(filePath, true, false, false);
+                if (!String.IsNullOrEmpty(resolved))
+                {
+                    return resolved;
+                }
+            }
+            catch (ServiceResultException)
+            {
+                // File does not exist yet (new certificate): fall back to placeholder expansion below.
+            }
+
+            // Expand special-folder/environment placeholders so a new certificate is saved to the intended path.
+            return Utils.ReplaceSpecialFolderNames(filePath) ?? filePath;
         }
 
         private async void ApplyChangesButton_Click(object sender, EventArgs e)


### PR DESCRIPTION
## Proposed changes

When saving certificates via the GDS Client, environment/special-folder placeholders such as `%CommonApplicationData%` in the public/private key path fields were sometimes not expanded, causing certs to be written to an unexpected literal path (or the save to fail).

The root cause is that `Utils.GetAbsoluteFilePath(...)` only resolves paths to files that **already exist**. When saving a *new* certificate the target file does not exist yet, so the call fails and the code fell back to the raw path (`?? m_application.CertificatePublicKeyPath`), which still contained the unexpanded placeholder.

This change routes the public and private key save paths in `ApplicationCertificateControl` through a new `GetSaveFilePath` helper. The helper first tries `GetAbsoluteFilePath` (to keep existing behavior for files that exist and current-directory lookups), and on failure falls back to `Utils.ReplaceSpecialFolderNames`, which expands placeholders regardless of whether the file exists yet. As a result, placeholders are consistently expanded and certs are written to the intended location. The read/load paths were intentionally left unchanged since those target existing files.

## Related Issues

- Fixes #740

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines.
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

The GDS Client sample is a WinForms app with no automated UI test harness, so this was verified by building the `GlobalDiscoveryClient` project (net10.0-windows) which compiled with 0 errors. The helper is deliberately tolerant of both the throwing and null-returning behaviors of `GetAbsoluteFilePath` across library versions.