### PR TITLE
Fix GDS Client Pull injecting GDS server host into certificate domains

### DIFF
--- a/Samples/GDS/Client/Controls/ApplicationCertificateControl.cs
+++ b/Samples/GDS/Client/Controls/ApplicationCertificateControl.cs
@@ -86,7 +86,14 @@ namespace Opc.Ua.Gds.Client
 
             if (!isHttps)
             {
-                if (server.Endpoint != null && !server.Endpoint.Description.ServerCertificate.IsNull)
+                // Only ServerPush applications may seed the certificate from the connected
+                // server's endpoint. For pull applications (ClientPull/ServerPull) the connected
+                // server is the GDS (or the target server) and its certificate must not be used
+                // as the application certificate, otherwise the GDS/server host name leaks into
+                // the requested certificate's domain list (SANs). See issue #741.
+                if (application?.RegistrationType == RegistrationType.ServerPush
+                    && server.Endpoint != null
+                    && !server.Endpoint.Description.ServerCertificate.IsNull)
                 {
                     certificate = GdsCertificateLoader.LoadCertificate(server.Endpoint.Description.ServerCertificate.ToArray());
                 }


### PR DESCRIPTION
## Proposed changes

In Client Pull management, the hostname of the GDS/target server was sometimes injected into the requested certificate's domain list (SANs), so the CSR ended up asking for domains that belong to the server rather than the application.

The cause is in `ApplicationCertificateControl.InitializeAsync`: for any non-HTTPS case it unconditionally seeded the application certificate from the connected server's endpoint certificate (`server.Endpoint.Description.ServerCertificate`). For a pull application, `m_server` is connected to the GDS/target server, so that server certificate's SANs flowed into `RegisteredApplication.GetDomainNames(...)` and then into the key-pair/signing request.

This change restricts the endpoint-certificate path to `ServerPush` applications, where the managed server's current certificate is legitimately the subject. Pull applications (`ClientPull`/`ServerPull`) now always resolve their own certificate from the configured public-key path or certificate store, so the GDS/server host is never used as the source of the requested domains.

Scope is intentionally sample-side only; the core-library `GetDomainNames` is unchanged.

## Related Issues

- Fixes #741

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines.
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

The GDS Client is a WinForms sample without unit coverage for this UI flow, so the fix was verified by a Release build of the GlobalDiscoveryClient project (0 errors). An alternative of filtering the GDS host out of the computed domain list after the fact was considered but rejected: it would only mask the symptom, whereas the wrong certificate source is the real problem.