### PR TITLE
Fix aggregation metadata session not reconnecting after downstream loss (#312)

### DIFF
--- a/Workshop/Aggregation/Server/AggregationNodeManager.cs
+++ b/Workshop/Aggregation/Server/AggregationNodeManager.cs
@@ -1765,10 +1765,14 @@ namespace AggregationServer
                 {
                     m_logger.LogDebug("{Status} {OutstandingRequestCount}/{DefunctRequestCount}", e.Status, session.OutstandingRequestCount, session.DefunctRequestCount);
                 }
-                var totalBadRequestCount = session.OutstandingRequestCount + session.DefunctRequestCount;
                 Opc.Ua.Client.SessionReconnectHandler reconnectHandler;
-                if (totalBadRequestCount >= 3 &&
-                    !session.SessionId.IsNull)
+                // Any not-good keep-alive status means the connection to the downstream
+                // server is broken, so start reconnecting immediately. Previously this was
+                // gated on OutstandingRequestCount + DefunctRequestCount >= 3, but when a
+                // keep-alive read fails synchronously (e.g. BadConnectionClosed after the
+                // downstream server is restarted or the network is lost) those counters are
+                // never incremented, so the reconnect logic never triggered (issue #312).
+                if (!session.SessionId.IsNull)
                 {
                     lock (m_clientsLock)
                     {


### PR DESCRIPTION
## Proposed changes

The aggregation server's internal "metadata" session never recovered after a downstream server was restarted or the network connection was lost (issue #312). Once the keep-alive went "late", the aggregator kept retrying but never re-established the session.

The root cause is in `Client_KeepAlive` (`Workshop/Aggregation/Server/AggregationNodeManager.cs`). Reconnection was gated on `session.OutstandingRequestCount + session.DefunctRequestCount >= 3`. When the downstream drops, the keep-alive read fails *synchronously* (e.g. `BadConnectionClosed`) before the request is ever registered, so those counters never increment and the gate never opened. The `SessionReconnectHandler` was therefore never started.

This change starts reconnection immediately on any not-good keep-alive status (`ServiceResult.IsNotGood(e.Status)`), keeping only the `!session.SessionId.IsNull` guard. The existing stale-session cleanup in `GetClientSession` remains as a backstop.

Note: the original report also described a stack-level secure-channel "renew instead of recreate" failure (`BadTcpSecureChannelUnknown`) against stack `1.4.368`. This sample now runs on stack `2.0.158-preview`, where that behavior has been reworked, so no samples change is needed for that half.

## Related Issues

- Fixes #312

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines.
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

The removed count-based gate was the specific mechanism the issue reporter identified as never firing. Reconnecting on a bad keep-alive status matches the pattern used by the reference client samples. The Aggregation Server project builds cleanly with this change (remaining warnings are pre-existing and unrelated).