### PR TITLE
Close aggregation downstream sessions on client disconnect (#26)

### DIFF
--- a/Workshop/Aggregation/Server/AggregationNodeManager.cs
+++ b/Workshop/Aggregation/Server/AggregationNodeManager.cs
@@ -30,6 +30,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Reflection;
 using Opc.Ua;
 using Opc.Ua.Server;
@@ -119,6 +120,11 @@ namespace AggregationServer
         {
             if (disposing)
             {
+                if (m_sessionManager != null)
+                {
+                    m_sessionManager.SessionClosing -= SessionManager_SessionClosing;
+                    m_sessionManager = null;
+                }
                 m_metadataUpdateTimer?.Dispose();
                 m_metadataUpdateTimer = null;
                 m_root = null;
@@ -224,6 +230,15 @@ namespace AggregationServer
                 AddPredefinedNode(SystemContext, status);
 
                 StartMetadataUpdates(DoMetadataUpdateAsync, null, DefaultMetadataInitDelay, DefaultMetadataRefresh);
+
+                // Close the downstream session that was opened for a client session
+                // as soon as that client session is closed, so connections to the
+                // underlying servers are not leaked when clients disconnect (issue #26).
+                m_sessionManager = Server.SessionManager;
+                if (m_sessionManager != null)
+                {
+                    m_sessionManager.SessionClosing += SessionManager_SessionClosing;
+                }
             }
         }
 
@@ -1757,6 +1772,71 @@ namespace AggregationServer
         #endregion
 
         #region Private Methods
+        /// <summary>
+        /// Closes the downstream session opened for a client session when that
+        /// client session is closed on the aggregation server (issue #26).
+        /// </summary>
+        private void SessionManager_SessionClosing(Opc.Ua.Server.ISession session, Opc.Ua.Server.SessionEventReason reason)
+        {
+            NodeId clientSessionId = session?.Id ?? NodeId.Null;
+            if (clientSessionId.IsNull)
+            {
+                return;
+            }
+
+            AggregationClientSession clientSession;
+            lock (m_clientsLock)
+            {
+                if (!m_clients.TryGetValue(clientSessionId, out clientSession) || clientSession == null)
+                {
+                    return;
+                }
+
+                // never tear down the internal metadata session.
+                if (clientSession.IsMetaDataSession)
+                {
+                    return;
+                }
+
+                m_clients.Remove(clientSessionId);
+            }
+
+            // Event sinks must not block the session manager thread, so close the
+            // downstream session on a background task.
+            _ = Task.Run(() => CloseDownstreamSession(clientSessionId, clientSession));
+        }
+
+        /// <summary>
+        /// Closes and disposes the downstream session associated with a client session.
+        /// </summary>
+        private void CloseDownstreamSession(NodeId clientSessionId, AggregationClientSession clientSession)
+        {
+            try
+            {
+                clientSession.ReconnectHandler?.Dispose();
+
+                Opc.Ua.Client.ISession session = clientSession.Session;
+                if (session != null)
+                {
+                    session.KeepAlive -= Client_KeepAlive;
+                    try
+                    {
+                        session.CloseAsync().GetAwaiter().GetResult();
+                    }
+                    finally
+                    {
+                        session.Dispose();
+                    }
+                }
+
+                m_logger.LogInformation("Closed downstream session for client {SessionId}.", clientSessionId);
+            }
+            catch (Exception e)
+            {
+                m_logger.LogError(e, "Error closing downstream session for client {SessionId}.", clientSessionId);
+            }
+        }
+
         private void Client_KeepAlive(Opc.Ua.Client.ISession session, Opc.Ua.Client.KeepAliveEventArgs e)
         {
             if (e.Status != null && ServiceResult.IsNotGood(e.Status))
@@ -1850,6 +1930,7 @@ namespace AggregationServer
         private Opc.Ua.Client.ReverseConnectManager m_reverseConnectManager;
         private Dictionary<NodeId, AggregationClientSession> m_clients;
         private object m_clientsLock;
+        private Opc.Ua.Server.ISessionManager m_sessionManager;
         private AggregatedTypeCache m_typeCache;
         private bool m_typeCacheInitialized;
         // Justification: disposed via Utils.SilentDispose in Dispose(bool); analyzer does not recognize the helper.


### PR DESCRIPTION
## Proposed changes

The aggregation server opens one downstream session per front-end client session (tracked in `m_clients`, keyed by the client's session id), but it never closed that session when the client disconnected. Cleanup only happened when a *new* request arrived on an already-dead session, which never occurs once a client leaves. As a result, sessions to the underlying servers leaked and stayed alive until their own session timeout expired (reported in #26).

This change makes the aggregation server react to the client lifecycle:

- Subscribe to `SessionManager.SessionClosing` in `CreateAddressSpace`, and unsubscribe in `Dispose`.
- On close, look up the downstream session by the closing client's `session.Id`, remove it from `m_clients` under lock, and skip the internal metadata session.
- Since event sinks must not block the session manager thread, the actual close/dispose runs on a background `Task`. It detaches the keep-alive and any in-progress reconnect handler before closing and disposing the client session.

The metadata session is never torn down here (guarded by `IsMetaDataSession`), so type-cache collection is unaffected.

## Related Issues

- Fixes #26

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines.
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

The downstream close is deliberately offloaded to `Task.Run` because `SessionClosing` sinks are documented to not block the session manager thread. An idle/timeout-based sweep of `m_clients` (using the existing `LastUsed`/`m_sessionTimeout` fields) would be a reasonable follow-up as a backstop, but the disconnect path is the primary leak and is addressed here. Verified with a clean build of the ConsoleAggregationServer sample.