### PR TITLE
Migrate SampleServer user impersonation to IUserTokenAuthenticator

### DIFF
--- a/Samples/Opc.Ua.Sample/SampleServer.UserAuthentication.cs
+++ b/Samples/Opc.Ua.Sample/SampleServer.UserAuthentication.cs
@@ -29,8 +29,10 @@
 
 using System;
 using System.Security.Cryptography.X509Certificates;
-using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Opc.Ua.Identity;
 using Opc.Ua.Security.Certificates;
 using Opc.Ua.Server;
 
@@ -65,48 +67,70 @@ namespace Opc.Ua.Sample
         }
 
         /// <summary>
-        /// Called when a client tries to change its user identity.
+        /// Registers the user token authenticators supported by this sample with the server
+        /// identity registry. This replaces the obsolete <c>ISessionManager.ImpersonateUser</c>
+        /// event with the <see cref="IUserTokenAuthenticator"/> +
+        /// <see cref="IServerIdentityRegistry"/> model.
         /// </summary>
-        private void SessionManager_ImpersonateUser(ISession session, ImpersonateEventArgs args)
+        internal void RegisterUserTokenAuthenticators(IServerInternal server)
         {
-            // check for a WSS token.
-            IssuedIdentityToken wssToken = args.UserIdentityTokenHandler?.Token as IssuedIdentityToken;
+            server.IdentityRegistry.Register(new UserNameTokenAuthenticator(this));
+            server.IdentityRegistry.Register(new CertificateTokenAuthenticator(this));
+        }
 
-            // check for a user name token.
-            UserNameIdentityToken userNameToken = args.UserIdentityTokenHandler?.Token as UserNameIdentityToken;
-
-            if (userNameToken != null)
+        /// <summary>
+        /// Validates a UserName identity token and produces the associated user identity.
+        /// </summary>
+        private AuthenticationResult AuthenticateUserNameToken(UserNameIdentityTokenHandler tokenHandler)
+        {
+            try
             {
-                VerifyPassword(userNameToken.UserName, Encoding.UTF8.GetString(userNameToken.Password.Span.ToArray()));
-                args.Identity = new UserIdentity(userNameToken);
+                VerifyPassword(tokenHandler.UserName, tokenHandler.DecryptedPassword);
+
+                var identity = new UserIdentity(tokenHandler);
                 if (m_logger.IsEnabled(LogLevel.Information))
                 {
-                    m_logger.LogInformation("UserName Token Accepted: {DisplayName}", args.Identity.DisplayName);
+                    m_logger.LogInformation("UserName Token Accepted: {DisplayName}", identity.DisplayName);
                 }
-                return;
+
+                return AuthenticationResult.Accept(identity);
             }
-
-            // check for x509 user token.
-            X509IdentityToken x509Token = args.UserIdentityTokenHandler?.Token as X509IdentityToken;
-
-            if (x509Token != null)
+            catch (ServiceResultException e)
             {
-                VerifyCertificate(x509Token.CertificateData);
-                args.Identity = new UserIdentity(x509Token);
+                return AuthenticationResult.Reject(e.Result);
+            }
+        }
+
+        /// <summary>
+        /// Validates an X509 identity token and produces the associated user identity.
+        /// </summary>
+        private AuthenticationResult AuthenticateCertificateToken(X509IdentityTokenHandler tokenHandler)
+        {
+            try
+            {
+                var wireToken = (X509IdentityToken)tokenHandler.Token;
+                VerifyCertificate(wireToken.CertificateData);
+
+                var identity = new UserIdentity(tokenHandler);
                 if (m_logger.IsEnabled(LogLevel.Information))
                 {
-                    m_logger.LogInformation("X509 Token Accepted: {DisplayName}", args.Identity.DisplayName);
+                    m_logger.LogInformation("X509 Token Accepted: {DisplayName}", identity.DisplayName);
                 }
-                return;
+
+                return AuthenticationResult.Accept(identity);
+            }
+            catch (ServiceResultException e)
+            {
+                return AuthenticationResult.Reject(e.Result);
             }
         }
 
         /// <summary>
         /// Validates the password for a username token.
         /// </summary>
-        private void VerifyPassword(string userName, string password)
+        private void VerifyPassword(string userName, byte[] password)
         {
-            if (String.IsNullOrEmpty(password))
+            if (password == null || password.Length == 0)
             {
                 // construct translation object with default text.
                 TranslationInfo info = new TranslationInfo(
@@ -178,6 +202,74 @@ namespace Opc.Ua.Sample
                     "http://opcfoundation.org/UA/Sample/",
                     result,
                     new LocalizedText(info)));
+            }
+        }
+        #endregion
+
+        #region User Token Authenticators
+        /// <summary>
+        /// Authenticates UserName identity tokens supported by the sample server.
+        /// </summary>
+        private sealed class UserNameTokenAuthenticator : IUserTokenAuthenticator
+        {
+            private readonly SampleServer m_server;
+
+            public UserNameTokenAuthenticator(SampleServer server)
+            {
+                m_server = server;
+            }
+
+            /// <inheritdoc/>
+            public UserTokenType TokenType => UserTokenType.UserName;
+
+            /// <inheritdoc/>
+            public string IssuedTokenProfileUri => null;
+
+            /// <inheritdoc/>
+            public ValueTask<AuthenticationResult> AuthenticateAsync(
+                AuthenticationContext context,
+                CancellationToken ct = default)
+            {
+                if (context.TokenHandler is not UserNameIdentityTokenHandler tokenHandler)
+                {
+                    return new ValueTask<AuthenticationResult>(AuthenticationResult.NotHandled);
+                }
+
+                return new ValueTask<AuthenticationResult>(
+                    m_server.AuthenticateUserNameToken(tokenHandler));
+            }
+        }
+
+        /// <summary>
+        /// Authenticates X509 identity tokens supported by the sample server.
+        /// </summary>
+        private sealed class CertificateTokenAuthenticator : IUserTokenAuthenticator
+        {
+            private readonly SampleServer m_server;
+
+            public CertificateTokenAuthenticator(SampleServer server)
+            {
+                m_server = server;
+            }
+
+            /// <inheritdoc/>
+            public UserTokenType TokenType => UserTokenType.Certificate;
+
+            /// <inheritdoc/>
+            public string IssuedTokenProfileUri => null;
+
+            /// <inheritdoc/>
+            public ValueTask<AuthenticationResult> AuthenticateAsync(
+                AuthenticationContext context,
+                CancellationToken ct = default)
+            {
+                if (context.TokenHandler is not X509IdentityTokenHandler tokenHandler)
+                {
+                    return new ValueTask<AuthenticationResult>(AuthenticationResult.NotHandled);
+                }
+
+                return new ValueTask<AuthenticationResult>(
+                    m_server.AuthenticateCertificateToken(tokenHandler));
             }
         }
         #endregion

--- a/Samples/Opc.Ua.Sample/SampleServer.cs
+++ b/Samples/Opc.Ua.Sample/SampleServer.cs
@@ -78,13 +78,10 @@ namespace Opc.Ua.Sample
         {
             base.OnServerStarted(server);
 
-            // request notifications when the user identity is changed. all valid users are accepted by default.
-            // TODO: ISessionManager.ImpersonateUser is replaced by IUserTokenAuthenticator +
-            // IServerIdentityRegistry. Migrating the sample's impersonation flow is tracked
-            // separately. See issue #724.
-#pragma warning disable CS0618 // Type or member is obsolete
-            server.SessionManager.ImpersonateUser += new ImpersonateEventHandler(SessionManager_ImpersonateUser);
-#pragma warning restore CS0618 // Type or member is obsolete
+            // register the user token authenticators for the identity token types supported by
+            // this sample. all valid users are accepted by default (anonymous tokens fall back to
+            // the default identity because no authenticator claims them).
+            RegisterUserTokenAuthenticators(server);
         }
 
         /// <summary>


### PR DESCRIPTION
## Proposed changes

As part of the OPC UA .NET Standard 1.5.378 to 2.0 migration, `SampleServer` subscribed to the obsolete `ISessionManager.ImpersonateUser` event, which raised `CS0618`. Clearing it cleanly required rewriting the sample's user-identity validation onto the new identity-provider architecture rather than suppressing the warning.

This PR replaces the event handler with the `IUserTokenAuthenticator` + `IServerIdentityRegistry` model:

- `RegisterUserTokenAuthenticators` registers two authenticators via `server.IdentityRegistry.Register(...)` from `OnServerStarted`.
- Two `IUserTokenAuthenticator` implementations (`UserNameTokenAuthenticator` and `CertificateTokenAuthenticator`) dispatch by `UserTokenType` and return `NotHandled` for tokens they do not own.
- Token validation reuses the existing `VerifyPassword` / `VerifyCertificate` helpers, mapping success to `AuthenticationResult.Accept` and `ServiceResultException` to `AuthenticationResult.Reject`.
- `VerifyPassword` now consumes the handler's `byte[] DecryptedPassword` directly, dropping the manual UTF-8 decode and the now-unused `System.Text` import.
- The scoped `#pragma warning disable CS0618` and the obsolete event wiring are removed.

Behavior is preserved: UserName and X509 tokens validate exactly as before, and anonymous tokens still fall through to the default identity because no authenticator claims them (matching the prior "all valid users accepted by default" semantics).

## Related Issues

- Fixes #724

## Types of changes

What types of changes does your code introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines.
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

The sample keeps its own `VerifyPassword` / `VerifyCertificate` helpers rather than adopting the built-in `X509Authenticator` / `UserNamePasswordAuthenticator`, so the sample stays self-contained and preserves its localized rejection messages while still demonstrating the new authenticator pattern.

Verified with `dotnet build` across all target frameworks (net48, netstandard2.1, net8.0, net10.0): no new warnings or errors. The one `CA2025` warning on `VerifyCertificate`'s sync-over-async block pre-exists on `master` (confirmed 4 occurrences on the unmodified code) and is left untouched. A live-client smoke test of UserName/X509 activation is still worth doing before merge.