### PR TITLE
Bump OPC UA packages to 2.0.0-preview.2 and migrate the breaking API changes

### DIFF
--- a/Samples/Client.Net4/UA Sample Client.csproj
+++ b/Samples/Client.Net4/UA Sample Client.csproj
@@ -40,7 +40,7 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Bindings.Https">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
     </ItemGroup>
   <PropertyGroup />

--- a/Samples/ClientControls.Net4/Configuration/Common (OLD)/NumericValueEditDlg.cs
+++ b/Samples/ClientControls.Net4/Configuration/Common (OLD)/NumericValueEditDlg.cs
@@ -147,15 +147,15 @@ namespace Opc.Ua.Client.Controls
 
             if (type == typeof(float))
             {
-                ValueCTRL.Minimum = Decimal.MinValue;
-                ValueCTRL.Maximum = Decimal.MaxValue;
+                ValueCTRL.Minimum = decimal.MinValue;
+                ValueCTRL.Maximum = decimal.MaxValue;
                 ValueCTRL.DecimalPlaces = 6;
             }
 
             if (type == typeof(double))
             {
-                ValueCTRL.Minimum = Decimal.MinValue;
-                ValueCTRL.Maximum = Decimal.MaxValue;
+                ValueCTRL.Minimum = decimal.MinValue;
+                ValueCTRL.Maximum = decimal.MaxValue;
                 ValueCTRL.DecimalPlaces = 15;
             }
         }

--- a/Samples/ClientControls.Net4/Configuration/SelectProfileCtrl.cs
+++ b/Samples/ClientControls.Net4/Configuration/SelectProfileCtrl.cs
@@ -90,7 +90,7 @@ namespace Opc.Ua.Client.Controls
                                     builder.Append(", ");
                                 }
 
-                                builder.Append(SecurityPolicies.GetDisplayName(value[ii].ProfileUri));
+                                builder.Append(SecurityPolicies.Default.GetDisplayName(value[ii].ProfileUri));
                             }
                         }
                     }

--- a/Samples/ClientControls.Net4/Endpoints/ConfiguredServerDlg.cs
+++ b/Samples/ClientControls.Net4/Endpoints/ConfiguredServerDlg.cs
@@ -209,7 +209,7 @@ namespace Opc.Ua.Client.Controls
             {
                 m_endpointDescription = endpointDescription;
                 m_protocol = new Protocol(endpointDescription);
-                m_currentPolicy = SecurityPolicies.GetDisplayName(endpointDescription.SecurityPolicyUri);
+                m_currentPolicy = SecurityPolicies.Default.GetDisplayName(endpointDescription.SecurityPolicyUri);
                 m_messageSecurityMode = endpointDescription.SecurityMode;
 
                 switch (m_endpointDescription.EncodingSupport)
@@ -280,7 +280,7 @@ namespace Opc.Ua.Client.Controls
             {
                 m_stringRepresentation = m_protocol.ToString() + " - ";
                 m_stringRepresentation += m_endpointDescription.SecurityMode + " - ";
-                m_stringRepresentation += SecurityPolicies.GetDisplayName(m_endpointDescription.SecurityPolicyUri) + " - ";
+                m_stringRepresentation += SecurityPolicies.Default.GetDisplayName(m_endpointDescription.SecurityPolicyUri) + " - ";
 
                 switch (m_endpointDescription.EncodingSupport)
                 {
@@ -585,7 +585,7 @@ namespace Opc.Ua.Client.Controls
                         continue;
                     }
 
-                    if (currentPolicy != SecurityPolicies.GetDisplayName(endpoint.SecurityPolicyUri))
+                    if (currentPolicy != SecurityPolicies.Default.GetDisplayName(endpoint.SecurityPolicyUri))
                     {
                         continue;
                     }
@@ -875,7 +875,7 @@ namespace Opc.Ua.Client.Controls
             // set all available security policies.
             if (m_showAllOptions)
             {
-                SecurityPolicyCB.Items.AddRange(SecurityPolicies.GetDisplayNames());
+                SecurityPolicyCB.Items.AddRange(SecurityPolicies.Default.GetDisplayNames());
             }
 
             // find all unique security policies.
@@ -899,7 +899,7 @@ namespace Opc.Ua.Client.Controls
                                 continue;
                             }
 
-                            string policyName = SecurityPolicies.GetDisplayName(endpoint.SecurityPolicyUri);
+                            string policyName = SecurityPolicies.Default.GetDisplayName(endpoint.SecurityPolicyUri);
 
                             if (policyName != null)
                             {
@@ -918,7 +918,7 @@ namespace Opc.Ua.Client.Controls
             // add at least one policy.
             if (SecurityPolicyCB.Items.Count == 0)
             {
-                SecurityPolicyCB.Items.Add(SecurityPolicies.GetDisplayName(SecurityPolicies.None));
+                SecurityPolicyCB.Items.Add(SecurityPolicies.Default.GetDisplayName(SecurityPolicies.None));
             }
 
             // set the current value.
@@ -955,13 +955,13 @@ namespace Opc.Ua.Client.Controls
             if (endpoint != null)
             {
                 Protocol protocol = new Protocol(endpoint);
-                String securityPolicy = SecurityPolicies.GetDisplayName(endpoint.SecurityPolicyUri);
+                String securityPolicy = SecurityPolicies.Default.GetDisplayName(endpoint.SecurityPolicyUri);
 
                 foreach (EndpointDescription endpointDescription in endpoints)
                 {
                     if ((protocol.Matches(Utils.ParseUri(endpointDescription.EndpointUrl))) &&
                         (endpoint.SecurityMode == endpointDescription.SecurityMode) &&
-                        (securityPolicy == SecurityPolicies.GetDisplayName(endpointDescription.SecurityPolicyUri)))
+                        (securityPolicy == SecurityPolicies.Default.GetDisplayName(endpointDescription.SecurityPolicyUri)))
                     {
                         switch (endpointDescription.EncodingSupport)
                         {
@@ -1355,7 +1355,7 @@ namespace Opc.Ua.Client.Controls
             endpoint = new EndpointDescription();
             endpoint.EndpointUrl = builder.ToString();
             endpoint.SecurityMode = (MessageSecurityMode)SecurityModeCB.SelectedItem;
-            endpoint.SecurityPolicyUri = SecurityPolicies.GetUri((string)SecurityPolicyCB.SelectedItem);
+            endpoint.SecurityPolicyUri = SecurityPolicies.Default.GetUri((string)SecurityPolicyCB.SelectedItem);
             endpoint.Server.ApplicationName = new LocalizedText(endpoint.EndpointUrl);
             endpoint.Server.ApplicationType = ApplicationType.Server;
             endpoint.Server.ApplicationUri = endpoint.EndpointUrl;
@@ -1791,7 +1791,7 @@ namespace Opc.Ua.Client.Controls
                     {
                         m_statusObject.SetStatus(StatusChannel.SecurityPolicyUri, "Error: Security Policy URI is missing.", StatusType.Warning);
                     }
-                    else if (string.IsNullOrEmpty(SecurityPolicies.GetDisplayName(m_currentDescription.SecurityPolicyUri)))
+                    else if (string.IsNullOrEmpty(SecurityPolicies.Default.GetDisplayName(m_currentDescription.SecurityPolicyUri)))
                     {
                         m_statusObject.SetStatus(StatusChannel.SecurityPolicyUri, "Error: Security Policy URI is invalid.", StatusType.Warning);
                     }

--- a/Samples/ClientControls.Net4/Endpoints/ConfiguredServerListCtrl.cs
+++ b/Samples/ClientControls.Net4/Endpoints/ConfiguredServerListCtrl.cs
@@ -152,7 +152,7 @@ namespace Opc.Ua.Client.Controls
 
             listItem.SubItems[3].Text = String.Format(
                 "{0}/{1}",
-                SecurityPolicies.GetDisplayName(endpoint.Description.SecurityPolicyUri),
+                SecurityPolicies.Default.GetDisplayName(endpoint.Description.SecurityPolicyUri),
                 endpoint.Description.SecurityMode);
 
             listItem.SubItems[4].Text = "<Unknown>";

--- a/Samples/ClientControls.Net4/UA Client Controls.csproj
+++ b/Samples/ClientControls.Net4/UA Client Controls.csproj
@@ -185,16 +185,16 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Core">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client.ComplexTypes">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup Label="Compile items now included by globbing that were not in the original project file">

--- a/Samples/Controls.Net4/Common/PerformanceTestDlg.cs
+++ b/Samples/Controls.Net4/Common/PerformanceTestDlg.cs
@@ -159,7 +159,7 @@ namespace Opc.Ua.Sample.Controls
                 writer.Write("{0}", uri);
                 writer.Write(",{0}", uri.Scheme);
                 writer.Write(",{0}", endpoint.SecurityMode);
-                writer.Write(",{0}", SecurityPolicies.GetDisplayName(endpoint.SecurityPolicyUri));
+                writer.Write(",{0}", SecurityPolicies.Default.GetDisplayName(endpoint.SecurityPolicyUri));
                 writer.Write(",{0}", (results[ii].Endpoint.Configuration.UseBinaryEncoding) ? "Binary" : "XML");
 
                 foreach (KeyValuePair<int, double> result in results[ii].Results)

--- a/Samples/Controls.Net4/Sessions/SecuritySettingsDlg.cs
+++ b/Samples/Controls.Net4/Sessions/SecuritySettingsDlg.cs
@@ -57,7 +57,7 @@ namespace Opc.Ua.Sample.Controls
                 SecurityModeCB.Items.Add(value);
             }
 
-            SecurityPolicyUriCB.Items.AddRange(SecurityPolicies.GetDisplayNames());
+            SecurityPolicyUriCB.Items.AddRange(SecurityPolicies.Default.GetDisplayNames());
         }
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace Opc.Ua.Sample.Controls
 
             if (!String.IsNullOrEmpty(securityPolicyUri))
             {
-                SecurityPolicyUriCB.SelectedItem = SecurityPolicies.GetDisplayName(securityPolicyUri);
+                SecurityPolicyUriCB.SelectedItem = SecurityPolicies.Default.GetDisplayName(securityPolicyUri);
             }
 
             // show dialog.
@@ -88,7 +88,7 @@ namespace Opc.Ua.Sample.Controls
             }
 
             securityMode = (MessageSecurityMode)SecurityModeCB.SelectedItem;
-            securityPolicyUri = SecurityPolicies.GetUri((string)SecurityPolicyUriCB.SelectedItem);
+            securityPolicyUri = SecurityPolicies.Default.GetUri((string)SecurityPolicyUriCB.SelectedItem);
             useNativeStack = UseNativeStackCK.Checked;
 
             return true;

--- a/Samples/Controls.Net4/Subscriptions/DataChangeFilterEditDlg.cs
+++ b/Samples/Controls.Net4/Subscriptions/DataChangeFilterEditDlg.cs
@@ -117,8 +117,8 @@ namespace Opc.Ua.Sample.Controls
             }
             else
             {
-                DeadbandNC.Minimum = Decimal.MinValue;
-                DeadbandNC.Maximum = Decimal.MaxValue;
+                DeadbandNC.Minimum = decimal.MinValue;
+                DeadbandNC.Maximum = decimal.MaxValue;
             }
         }
     }

--- a/Samples/Controls.Net4/UA Sample Controls.csproj
+++ b/Samples/Controls.Net4/UA Sample Controls.csproj
@@ -104,10 +104,10 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client.ComplexTypes">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup Label="EmbeddedResource items now included by globbing that were not in the original project file">

--- a/Samples/GDS/Client/GlobalDiscoveryClient.csproj
+++ b/Samples/GDS/Client/GlobalDiscoveryClient.csproj
@@ -50,10 +50,10 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Gds.Client.Common">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Samples/GDS/ClientControls/Controls/DiscoveryControl.cs
+++ b/Samples/GDS/ClientControls/Controls/DiscoveryControl.cs
@@ -611,7 +611,7 @@ namespace Opc.Ua.Gds.Client.Controls
 
                 row[0] = endpoint.EndpointUrl;
                 row[1] = endpoint.SecurityMode.ToString();
-                row[2] = SecurityPolicies.GetDisplayName(endpoint.SecurityPolicyUri);
+                row[2] = SecurityPolicies.Default.GetDisplayName(endpoint.SecurityPolicyUri);
                 row[3] = endpoint;
 
                 EndpointsTable.Rows.Add(row);

--- a/Samples/GDS/ClientControls/GlobalDiscoveryClientControls.csproj
+++ b/Samples/GDS/ClientControls/GlobalDiscoveryClientControls.csproj
@@ -30,10 +30,10 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Gds.Client.Common">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Samples/GDS/ConsoleServer/NetCoreGlobalDiscoveryServer.csproj
+++ b/Samples/GDS/ConsoleServer/NetCoreGlobalDiscoveryServer.csproj
@@ -20,9 +20,9 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="Mono.Options" Version="6.12.0.148" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client" Version="2.0.158.59919-preview" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Gds.Server.Common" Version="2.0.158.59919-preview" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration" Version="2.0.158.59919-preview" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client" Version="2.0.0-preview.2" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Gds.Server.Common" Version="2.0.0-preview.2" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration" Version="2.0.0-preview.2" />
   </ItemGroup>
 
 </Project>

--- a/Samples/GDS/ConsoleServer/Program.cs
+++ b/Samples/GDS/ConsoleServer/Program.cs
@@ -531,23 +531,22 @@ namespace Opc.Ua.Gds.Server
 
         private void PrintSessionStatus(ISession session, string reason, bool lastContact = false)
         {
-            lock (session.DiagnosticsLock)
+            // The session owns its diagnostics lock and no longer exposes it;
+            // ReadDiagnostics applies each projection while holding that lock.
+            string item = Utils.Format("{0,9}:{1,20}:", reason, session.ReadDiagnostics(d => d.SessionName));
+            if (lastContact)
             {
-                string item = Utils.Format("{0,9}:{1,20}:", reason, session.SessionDiagnostics.SessionName);
-                if (lastContact)
-                {
-                    item += Utils.Format("Last Event:{0:HH:mm:ss}", session.SessionDiagnostics.ClientLastContactTime.ToLocalTime());
-                }
-                else
-                {
-                    if (session.Identity != null)
-                    {
-                        item += Utils.Format(":{0,20}", session.Identity.DisplayName);
-                    }
-                    item += Utils.Format(":{0}", session.Id);
-                }
-                Console.WriteLine(item);
+                item += Utils.Format("Last Event:{0:HH:mm:ss}", session.ReadDiagnostics(d => d.ClientLastContactTime).ToLocalTime());
             }
+            else
+            {
+                if (session.Identity != null)
+                {
+                    item += Utils.Format(":{0,20}", session.Identity.DisplayName);
+                }
+                item += Utils.Format(":{0}", session.Id);
+            }
+            Console.WriteLine(item);
         }
 
         private async void StatusThreadAsync()

--- a/Samples/GDS/Server/GlobalDiscoveryServer.csproj
+++ b/Samples/GDS/Server/GlobalDiscoveryServer.csproj
@@ -40,13 +40,13 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Gds.Server.Common">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup />

--- a/Samples/LDS/ConsoleServer/ConsoleLds.csproj
+++ b/Samples/LDS/ConsoleServer/ConsoleLds.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Lds.Server" Version="2.0.158.59919-preview" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Lds.Server" Version="2.0.0-preview.2" />
   </ItemGroup>
 
 </Project>

--- a/Samples/Opc.Ua.Sample/Base/CustomNodeManager.cs
+++ b/Samples/Opc.Ua.Sample/Base/CustomNodeManager.cs
@@ -2936,6 +2936,32 @@ namespace Opc.Ua.Sample
             IList<bool> processedItems,
             IList<ServiceResult> errors)
         {
+            TransferMonitoredItems(
+                context,
+                sendInitialValues,
+                monitoredItems,
+                processedItems,
+                errors,
+                new MonitoredItemTransferOptions());
+        }
+
+        /// <summary>
+        /// Transfers a set of monitored items.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="sendInitialValues">Whether the subscription should send initial values after transfer.</param>
+        /// <param name="monitoredItems">The set of monitoring items to update.</param>
+        /// <param name="processedItems">The list of bool with items that were already processed.</param>
+        /// <param name="errors">Any errors.</param>
+        /// <param name="transferOptions">Controls how the transfer is executed.</param>
+        public virtual void TransferMonitoredItems(
+            OperationContext context,
+            bool sendInitialValues,
+            IList<IMonitoredItem> monitoredItems,
+            IList<bool> processedItems,
+            IList<ServiceResult> errors,
+            MonitoredItemTransferOptions transferOptions)
+        {
             ServerSystemContext systemContext = m_systemContext.Copy(context);
             IList<IMonitoredItem> transferredItems = new List<IMonitoredItem>();
             lock (Lock)
@@ -2964,7 +2990,7 @@ namespace Opc.Ua.Sample
                     // owned by this node manager.
                     processedItems[ii] = true;
                     transferredItems.Add(monitoredItems[ii]);
-                    if (sendInitialValues)
+                    if (sendInitialValues && !transferOptions.DeferInitialValues)
                     {
                         monitoredItems[ii].SetupResendDataTrigger();
                     }

--- a/Samples/Opc.Ua.Sample/Base/SampleNodeManager.cs
+++ b/Samples/Opc.Ua.Sample/Base/SampleNodeManager.cs
@@ -2957,6 +2957,32 @@ namespace Opc.Ua.Sample
             IList<bool> processedItems,
             IList<ServiceResult> errors)
         {
+            TransferMonitoredItems(
+                context,
+                sendInitialValues,
+                monitoredItems,
+                processedItems,
+                errors,
+                new MonitoredItemTransferOptions());
+        }
+
+        /// <summary>
+        /// Transfers a set of monitored items.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="sendInitialValues">Whether the subscription should send initial values after transfer.</param>
+        /// <param name="monitoredItems">The set of monitoring items to update.</param>
+        /// <param name="processedItems">The list of bool with items that were already processed.</param>
+        /// <param name="errors">Any errors.</param>
+        /// <param name="transferOptions">Controls how the transfer is executed.</param>
+        public virtual void TransferMonitoredItems(
+            OperationContext context,
+            bool sendInitialValues,
+            IList<IMonitoredItem> monitoredItems,
+            IList<bool> processedItems,
+            IList<ServiceResult> errors,
+            MonitoredItemTransferOptions transferOptions)
+        {
             ServerSystemContext systemContext = m_systemContext.Copy(context);
             IList<IMonitoredItem> transferredItems = new List<IMonitoredItem>();
             lock (Lock)
@@ -2982,7 +3008,7 @@ namespace Opc.Ua.Sample
                     processedItems[ii] = true;
                     transferredItems.Add(monitoredItems[ii]);
 
-                    if (sendInitialValues)
+                    if (sendInitialValues && !transferOptions.DeferInitialValues)
                     {
                         monitoredItems[ii].SetupResendDataTrigger();
                     }

--- a/Samples/Opc.Ua.Sample/MemoryBuffer/MemoryBufferBrowser.cs
+++ b/Samples/Opc.Ua.Sample/MemoryBuffer/MemoryBufferBrowser.cs
@@ -80,51 +80,50 @@ namespace MemoryBuffer
         /// <returns></returns>
         public override IReference Next()
         {
-            lock (DataLock)
+            // NodeBrowser instances are single-consumer and perform no
+            // synchronization of their own; the former DataLock is gone.
+            IReference reference = null;
+
+            // enumerate pre-defined references.
+            // always call first to ensure any pushed-back references are returned first.
+            reference = base.Next();
+
+            if (reference != null)
             {
-                IReference reference = null;
+                return reference;
+            }
 
-                // enumerate pre-defined references.
-                // always call first to ensure any pushed-back references are returned first.
-                reference = base.Next();
+            if (m_stage == Stage.Begin)
+            {
+                m_stage = Stage.Components;
+                m_position = 0;
+            }
 
-                if (reference != null)
-                {
-                    return reference;
-                }
-
-                if (m_stage == Stage.Begin)
-                {
-                    m_stage = Stage.Components;
-                    m_position = 0;
-                }
-
-                // don't start browsing huge number of references when only internal references are requested.
-                if (InternalOnly)
-                {
-                    return null;
-                }
-
-                // enumerate components.
-                if (m_stage == Stage.Components)
-                {
-                    if (IsRequired(ReferenceTypeIds.HasComponent, false))
-                    {
-                        reference = NextChild();
-
-                        if (reference != null)
-                        {
-                            return reference;
-                        }
-                    }
-
-                    m_stage = Stage.ModelParents;
-                    m_position = 0;
-                }
-
-                // all done.
+            // don't start browsing huge number of references when only internal references are requested.
+            if (InternalOnly)
+            {
                 return null;
             }
+
+            // enumerate components.
+            if (m_stage == Stage.Components)
+            {
+                if (IsRequired(ReferenceTypeIds.HasComponent, false))
+                {
+                    reference = NextChild();
+
+                    if (reference != null)
+                    {
+                        return reference;
+                    }
+                }
+
+                m_stage = Stage.ModelParents;
+                m_position = 0;
+            }
+
+            // all done.
+            return null;
         }
         #endregion
 

--- a/Samples/Opc.Ua.Sample/Opc.Ua.Sample.csproj
+++ b/Samples/Opc.Ua.Sample/Opc.Ua.Sample.csproj
@@ -32,9 +32,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Core" Version="2.0.158.59919-preview" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server" Version="2.0.158.59919-preview" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.SourceGeneration" Version="2.0.158.59919-preview" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Core" Version="2.0.0-preview.2" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server" Version="2.0.0-preview.2" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.SourceGeneration" Version="2.0.0-preview.2" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
 </Project>

--- a/Samples/Opc.Ua.Sample/TestData/HistoryDataReader.cs
+++ b/Samples/Opc.Ua.Sample/TestData/HistoryDataReader.cs
@@ -43,7 +43,7 @@ namespace TestData
     /// <summary>
     /// A class used to read values from a history data source.
     /// </summary>
-    public class HistoryDataReader : IDisposable
+    public class HistoryDataReader : IHistoryContinuationPoint
     {
         #region Constructors
         /// <summary>

--- a/Samples/Opc.Ua.Sample/TestData/TestDataNodeManager.cs
+++ b/Samples/Opc.Ua.Sample/TestData/TestDataNodeManager.cs
@@ -436,7 +436,7 @@ namespace TestData
                 return null;
             }
 
-            HistoryDataReader reader = context.OperationContext.Session.RestoreHistoryContinuationPoint(continuationPoint.ToByteString()) as HistoryDataReader;
+            HistoryDataReader reader = context.OperationContext.Session.ContinuationPoints.RestoreHistory(continuationPoint.ToByteString()) as HistoryDataReader;
 
             if (reader == null)
             {
@@ -456,7 +456,7 @@ namespace TestData
                 return;
             }
 
-            context.OperationContext.Session.SaveHistoryContinuationPoint(reader.Id, reader);
+            context.OperationContext.Session.ContinuationPoints.SaveHistory(reader);
         }
 
         /// <summary>

--- a/Samples/ReferenceClient/Reference Client.csproj
+++ b/Samples/ReferenceClient/Reference Client.csproj
@@ -26,16 +26,16 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Bindings.Https">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Core">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup />

--- a/Samples/ReferenceServer/Reference Server.csproj
+++ b/Samples/ReferenceServer/Reference Server.csproj
@@ -30,13 +30,13 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Bindings.Https">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Quickstarts.Servers">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
     <PackageReference Include="Serilog">
       <Version>4.4.0</Version>

--- a/Samples/Server.Net4/ServerDiagnosticsCtrl.cs
+++ b/Samples/Server.Net4/ServerDiagnosticsCtrl.cs
@@ -103,24 +103,23 @@ namespace Opc.Ua.Sample
             {
                 ISession session = sessions[ii];
 
-                lock (session.DiagnosticsLock)
+                // The session owns its diagnostics lock and no longer exposes it;
+                // ReadDiagnostics applies each projection while holding that lock.
+                ListViewItem item = new ListViewItem(session.ReadDiagnostics(d => d.SessionName));
+
+                if (session.Identity != null)
                 {
-                    ListViewItem item = new ListViewItem(session.SessionDiagnostics.SessionName);
-
-                    if (session.Identity != null)
-                    {
-                        item.SubItems.Add(session.Identity.DisplayName);
-                    }
-                    else
-                    {
-                        item.SubItems.Add(String.Empty);
-                    }
-
-                    item.SubItems.Add(String.Format("{0}", session.Id));
-                    item.SubItems.Add(String.Format("{0:HH:mm:ss}", session.SessionDiagnostics.ClientLastContactTime.ToLocalTime()));
-
-                    SessionsLV.Items.Add(item);
+                    item.SubItems.Add(session.Identity.DisplayName);
                 }
+                else
+                {
+                    item.SubItems.Add(String.Empty);
+                }
+
+                item.SubItems.Add(String.Format("{0}", session.Id));
+                item.SubItems.Add(String.Format("{0:HH:mm:ss}", session.ReadDiagnostics(d => d.ClientLastContactTime).ToLocalTime()));
+
+                SessionsLV.Items.Add(item);
             }
 
             // adjust
@@ -148,10 +147,9 @@ namespace Opc.Ua.Sample
                 item.SubItems.Add(String.Format("{0}", (int)subscription.PublishingInterval));
                 item.SubItems.Add(String.Format("{0}", subscription.MonitoredItemCount));
 
-                lock (subscription.DiagnosticsLock)
-                {
-                    item.SubItems.Add(String.Format("{0}", subscription.Diagnostics.NextSequenceNumber));
-                }
+                // Same as above: the subscription reads its own diagnostics under the
+                // lock it owns, replacing the former DiagnosticsLock property.
+                item.SubItems.Add(String.Format("{0}", subscription.ReadDiagnostics(d => d.NextSequenceNumber)));
 
                 SubscriptionsLV.Items.Add(item);
             }

--- a/Samples/Server.Net4/UA Sample Server.csproj
+++ b/Samples/Server.Net4/UA Sample Server.csproj
@@ -39,7 +39,7 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Bindings.Https">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup />

--- a/Samples/ServerControls.Net4/ServerDiagnosticsCtrl.cs
+++ b/Samples/ServerControls.Net4/ServerDiagnosticsCtrl.cs
@@ -102,24 +102,27 @@ namespace Opc.Ua.Server.Controls
             {
                 ISession session = sessions[ii];
 
-                lock (session.DiagnosticsLock)
+                // The session owns its diagnostics lock and no longer exposes it.
+                // ReadDiagnostics applies the projection while holding that lock;
+                // the diagnostics object must not escape the callback.
+                string sessionName = session.ReadDiagnostics(d => d.SessionName);
+                DateTimeUtc lastContactTime = session.ReadDiagnostics(d => d.ClientLastContactTime);
+
+                ListViewItem item = new ListViewItem(sessionName);
+
+                if (session.Identity != null)
                 {
-                    ListViewItem item = new ListViewItem(session.SessionDiagnostics.SessionName);
-
-                    if (session.Identity != null)
-                    {
-                        item.SubItems.Add(session.Identity.DisplayName);
-                    }
-                    else
-                    {
-                        item.SubItems.Add(String.Empty);
-                    }
-
-                    item.SubItems.Add(String.Format("{0}", session.Id));
-                    item.SubItems.Add(String.Format("{0:HH:mm:ss}", session.SessionDiagnostics.ClientLastContactTime.ToLocalTime()));
-
-                    SessionsLV.Items.Add(item);
+                    item.SubItems.Add(session.Identity.DisplayName);
                 }
+                else
+                {
+                    item.SubItems.Add(String.Empty);
+                }
+
+                item.SubItems.Add(String.Format("{0}", session.Id));
+                item.SubItems.Add(String.Format("{0:HH:mm:ss}", lastContactTime.ToLocalTime()));
+
+                SessionsLV.Items.Add(item);
             }
 
             // adjust
@@ -147,10 +150,10 @@ namespace Opc.Ua.Server.Controls
                 item.SubItems.Add(String.Format("{0}", (int)subscription.PublishingInterval));
                 item.SubItems.Add(String.Format("{0}", subscription.MonitoredItemCount));
 
-                lock (subscription.DiagnosticsLock)
-                {
-                    item.SubItems.Add(String.Format("{0}", subscription.Diagnostics.NextSequenceNumber));
-                }
+                // Same as above: the subscription reads its own diagnostics under
+                // the lock it owns, replacing the former DiagnosticsLock property.
+                item.SubItems.Add(String.Format("{0}",
+                    subscription.ReadDiagnostics(d => d.NextSequenceNumber)));
 
                 SubscriptionsLV.Items.Add(item);
             }

--- a/Samples/ServerControls.Net4/UA Server Controls.csproj
+++ b/Samples/ServerControls.Net4/UA Server Controls.csproj
@@ -38,13 +38,13 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Core">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup />

--- a/Workshop/Aggregation/Client/Aggregation Client.csproj
+++ b/Workshop/Aggregation/Client/Aggregation Client.csproj
@@ -31,7 +31,7 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup Label="Compile items now included by globbing that were not in the original project file">

--- a/Workshop/Aggregation/ConsoleAggregationServer/ConsoleAggregationServer.csproj
+++ b/Workshop/Aggregation/ConsoleAggregationServer/ConsoleAggregationServer.csproj
@@ -46,18 +46,18 @@
     </When>
     <When Condition="'$(Configuration)'=='Release'">
       <ItemGroup>
-        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration" Version="2.0.158.59919-preview" />
-        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client" Version="2.0.158.59919-preview" />
-        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server" Version="2.0.158.59919-preview" />
-        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.SourceGeneration" Version="2.0.158.59919-preview" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration" Version="2.0.0-preview.2" />
+        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client" Version="2.0.0-preview.2" />
+        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server" Version="2.0.0-preview.2" />
+        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.SourceGeneration" Version="2.0.0-preview.2" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration.Debug" Version="2.0.158.59919-preview" />
-        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client.Debug" Version="2.0.158.59919-preview" />
-        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server.Debug" Version="2.0.158.59919-preview" />
-        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.SourceGeneration" Version="2.0.158.59919-preview" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration.Debug" Version="2.0.0-preview.2" />
+        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client.Debug" Version="2.0.0-preview.2" />
+        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server.Debug" Version="2.0.0-preview.2" />
+        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.SourceGeneration" Version="2.0.0-preview.2" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/Workshop/Aggregation/ConsoleAggregationServer/Program.cs
+++ b/Workshop/Aggregation/ConsoleAggregationServer/Program.cs
@@ -238,23 +238,22 @@ namespace AggregationServer
 
         private void PrintSessionStatus(ISession session, string reason, bool lastContact = false)
         {
-            lock (session.DiagnosticsLock)
+            // The session owns its diagnostics lock and no longer exposes it;
+            // ReadDiagnostics applies each projection while holding that lock.
+            string item = String.Format("{0,9}:{1,20}:", reason, session.ReadDiagnostics(d => d.SessionName));
+            if (lastContact)
             {
-                string item = String.Format("{0,9}:{1,20}:", reason, session.SessionDiagnostics.SessionName);
-                if (lastContact)
-                {
-                    item += String.Format(":{0:HH:mm:ss}", session.SessionDiagnostics.ClientLastContactTime.ToLocalTime());
-                }
-                else
-                {
-                    if (session.Identity != null)
-                    {
-                        item += String.Format(":{0,20}", session.Identity.DisplayName);
-                    }
-                    item += String.Format(":{0}", session.Id);
-                }
-                Console.WriteLine(item);
+                item += String.Format(":{0:HH:mm:ss}", session.ReadDiagnostics(d => d.ClientLastContactTime).ToLocalTime());
             }
+            else
+            {
+                if (session.Identity != null)
+                {
+                    item += String.Format(":{0,20}", session.Identity.DisplayName);
+                }
+                item += String.Format(":{0}", session.Id);
+            }
+            Console.WriteLine(item);
         }
 
         private async Task StatusThreadAsync()

--- a/Workshop/Aggregation/Server/Aggregation Server.csproj
+++ b/Workshop/Aggregation/Server/Aggregation Server.csproj
@@ -41,17 +41,17 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Core">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.SourceGeneration" Version="2.0.158.59919-preview" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.SourceGeneration" Version="2.0.0-preview.2" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 </Project>

--- a/Workshop/Aggregation/Server/AggregationNodeManager.cs
+++ b/Workshop/Aggregation/Server/AggregationNodeManager.cs
@@ -1237,7 +1237,7 @@ namespace AggregationServer
             if (context != null)
             {
                 sessionId = context.SessionId ?? NodeId.Null;
-                sessionName = context.OperationContext.Session.SessionDiagnostics.SessionName;
+                sessionName = context.OperationContext.Session.ReadDiagnostics(d => d.SessionName);
                 userIdentity = context.UserIdentity;
                 preferredLocales = context.PreferredLocales;
             }
@@ -1492,39 +1492,38 @@ namespace AggregationServer
                     "http://opcfoundation.org/UA/Diagnostics"
                 };
 
-                lock (Server.DiagnosticsLock)
+                // The server owns its diagnostics lock and no longer exposes it; this
+                // section does not touch the diagnostics summary it guarded.
+                ushort[] namespaceIndexes = null;
+                lock (Lock)
                 {
-                    ushort[] namespaceIndexes = null;
-                    lock (Lock)
+                    var mapper = new NamespaceMapper();
+                    mapper.TypeSystemNamespaceUris = TypeSystemNamespaceUris;
+                    mapper.Initialize(Server.NamespaceUris, client.NamespaceUris, m_endpoint.Description.Server.ApplicationUri);
+
+                    // set the namespace indexes.
+                    namespaceIndexes = new ushort[mapper.LocalNamespaceIndexes.Length + ((m_ownsTypeModel) ? 1 : 0)];
+
+                    int index = 0;
+                    namespaceIndexes[index++] = (ushort)Server.NamespaceUris.GetIndex(Namespaces.Aggregation);
+
+                    if (m_ownsTypeModel)
                     {
-                        var mapper = new NamespaceMapper();
-                        mapper.TypeSystemNamespaceUris = TypeSystemNamespaceUris;
-                        mapper.Initialize(Server.NamespaceUris, client.NamespaceUris, m_endpoint.Description.Server.ApplicationUri);
-
-                        // set the namespace indexes.
-                        namespaceIndexes = new ushort[mapper.LocalNamespaceIndexes.Length + ((m_ownsTypeModel) ? 1 : 0)];
-
-                        int index = 0;
-                        namespaceIndexes[index++] = (ushort)Server.NamespaceUris.GetIndex(Namespaces.Aggregation);
-
-                        if (m_ownsTypeModel)
-                        {
-                            namespaceIndexes[index++] = (ushort)Server.NamespaceUris.GetIndex(AggregationModel.Namespaces.Aggregation);
-                        }
-
-                        for (int ii = 1; ii < mapper.LocalNamespaceIndexes.Length; ii++)
-                        {
-                            namespaceIndexes[index++] = (ushort)mapper.LocalNamespaceIndexes[ii];
-                        }
-                        m_mapper = mapper;
-                        SetNamespaceIndexes(namespaceIndexes);
+                        namespaceIndexes[index++] = (ushort)Server.NamespaceUris.GetIndex(AggregationModel.Namespaces.Aggregation);
                     }
 
-                    // re-register node manager.
-                    for (int ii = 0; ii < namespaceIndexes.Length; ii++)
+                    for (int ii = 1; ii < mapper.LocalNamespaceIndexes.Length; ii++)
                     {
-                        Server.NodeManager.RegisterNamespaceManager(Server.NamespaceUris.GetString(namespaceIndexes[ii]), this);
+                        namespaceIndexes[index++] = (ushort)mapper.LocalNamespaceIndexes[ii];
                     }
+                    m_mapper = mapper;
+                    SetNamespaceIndexes(namespaceIndexes);
+                }
+
+                // re-register node manager.
+                for (int ii = 0; ii < namespaceIndexes.Length; ii++)
+                {
+                    Server.NodeManager.RegisterNamespaceManager(Server.NamespaceUris.GetString(namespaceIndexes[ii]), this);
                 }
 
                 AggregatedTypeCache cache = new AggregatedTypeCache();

--- a/Workshop/Aggregation/Server/Browser.cs
+++ b/Workshop/Aggregation/Server/Browser.cs
@@ -83,10 +83,9 @@ namespace AggregationServer
         /// <returns>The next reference that meets the browse criteria.</returns>
         public override IReference Next()
         {
-            lock (DataLock)
-            {
-                return NextAsync().Result;
-            }
+            // NodeBrowser instances are single-consumer and perform no
+            // synchronization of their own; the former DataLock is gone.
+            return NextAsync().Result;
         }
 
         public async Task<IReference> NextAsync(CancellationToken ct = default)

--- a/Workshop/AlarmCondition/Client/AlarmCondition Client.csproj
+++ b/Workshop/AlarmCondition/Client/AlarmCondition Client.csproj
@@ -33,7 +33,7 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup Label="Compile items now included by globbing that were not in the original project file">

--- a/Workshop/AlarmCondition/Server/AlarmCondition Server.csproj
+++ b/Workshop/AlarmCondition/Server/AlarmCondition Server.csproj
@@ -33,12 +33,12 @@
             <Version>10.0.10</Version>
         </PackageReference>
         <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
-            <Version>2.0.158.59919-preview</Version>
+            <Version>2.0.0-preview.2</Version>
         </PackageReference>
 
         <PackageReference
           Include="OPCFoundation.NetStandard.Opc.Ua.SourceGeneration"
-          Version="2.0.158.59919-preview"
+          Version="2.0.0-preview.2"
           OutputItemType="Analyzer"
           ReferenceOutputAssembly="false" />
     </ItemGroup>

--- a/Workshop/Boiler/Client/Boiler Client.csproj
+++ b/Workshop/Boiler/Client/Boiler Client.csproj
@@ -32,7 +32,7 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/Workshop/Boiler/Server/Boiler Server.csproj
+++ b/Workshop/Boiler/Server/Boiler Server.csproj
@@ -37,7 +37,7 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/Workshop/Boiler/Server/Quickstarts.Boiler.Classes.cs
+++ b/Workshop/Boiler/Server/Quickstarts.Boiler.Classes.cs
@@ -194,7 +194,8 @@ namespace Quickstarts.Boiler
             ISystemContext context,
             QualifiedName browseName,
             bool createOrReplace,
-            BaseInstanceState replacement)
+            BaseInstanceState replacement,
+            bool assignInstanceNodeIds = true)
         {
             if ((browseName).IsNull)
             {
@@ -274,7 +275,7 @@ namespace Quickstarts.Boiler
                 return instance;
             }
 
-            return base.FindChild(context, browseName, createOrReplace, replacement);
+            return base.FindChild(context, browseName, createOrReplace, replacement, assignInstanceNodeIds);
         }
         #endregion
 
@@ -396,7 +397,8 @@ namespace Quickstarts.Boiler
             ISystemContext context,
             QualifiedName browseName,
             bool createOrReplace,
-            BaseInstanceState replacement)
+            BaseInstanceState replacement,
+            bool assignInstanceNodeIds = true)
         {
             if ((browseName).IsNull)
             {
@@ -434,7 +436,7 @@ namespace Quickstarts.Boiler
                 return instance;
             }
 
-            return base.FindChild(context, browseName, createOrReplace, replacement);
+            return base.FindChild(context, browseName, createOrReplace, replacement, assignInstanceNodeIds);
         }
         #endregion
 
@@ -554,7 +556,8 @@ namespace Quickstarts.Boiler
             ISystemContext context,
             QualifiedName browseName,
             bool createOrReplace,
-            BaseInstanceState replacement)
+            BaseInstanceState replacement,
+            bool assignInstanceNodeIds = true)
         {
             if ((browseName).IsNull)
             {
@@ -592,7 +595,7 @@ namespace Quickstarts.Boiler
                 return instance;
             }
 
-            return base.FindChild(context, browseName, createOrReplace, replacement);
+            return base.FindChild(context, browseName, createOrReplace, replacement, assignInstanceNodeIds);
         }
         #endregion
 
@@ -786,7 +789,8 @@ namespace Quickstarts.Boiler
             ISystemContext context,
             QualifiedName browseName,
             bool createOrReplace,
-            BaseInstanceState replacement)
+            BaseInstanceState replacement,
+            bool assignInstanceNodeIds = true)
         {
             if ((browseName).IsNull)
             {
@@ -887,7 +891,7 @@ namespace Quickstarts.Boiler
                 return instance;
             }
 
-            return base.FindChild(context, browseName, createOrReplace, replacement);
+            return base.FindChild(context, browseName, createOrReplace, replacement, assignInstanceNodeIds);
         }
         #endregion
 
@@ -1415,7 +1419,8 @@ namespace Quickstarts.Boiler
             ISystemContext context,
             QualifiedName browseName,
             bool createOrReplace,
-            BaseInstanceState replacement)
+            BaseInstanceState replacement,
+            bool assignInstanceNodeIds = true)
         {
             if ((browseName).IsNull)
             {
@@ -1474,7 +1479,7 @@ namespace Quickstarts.Boiler
                 return instance;
             }
 
-            return base.FindChild(context, browseName, createOrReplace, replacement);
+            return base.FindChild(context, browseName, createOrReplace, replacement, assignInstanceNodeIds);
         }
         #endregion
 
@@ -1596,7 +1601,8 @@ namespace Quickstarts.Boiler
             ISystemContext context,
             QualifiedName browseName,
             bool createOrReplace,
-            BaseInstanceState replacement)
+            BaseInstanceState replacement,
+            bool assignInstanceNodeIds = true)
         {
             if ((browseName).IsNull)
             {
@@ -1634,7 +1640,7 @@ namespace Quickstarts.Boiler
                 return instance;
             }
 
-            return base.FindChild(context, browseName, createOrReplace, replacement);
+            return base.FindChild(context, browseName, createOrReplace, replacement, assignInstanceNodeIds);
         }
         #endregion
 
@@ -1755,7 +1761,8 @@ namespace Quickstarts.Boiler
             ISystemContext context,
             QualifiedName browseName,
             bool createOrReplace,
-            BaseInstanceState replacement)
+            BaseInstanceState replacement,
+            bool assignInstanceNodeIds = true)
         {
             if ((browseName).IsNull)
             {
@@ -1793,7 +1800,7 @@ namespace Quickstarts.Boiler
                 return instance;
             }
 
-            return base.FindChild(context, browseName, createOrReplace, replacement);
+            return base.FindChild(context, browseName, createOrReplace, replacement, assignInstanceNodeIds);
         }
         #endregion
 
@@ -2060,7 +2067,8 @@ namespace Quickstarts.Boiler
             ISystemContext context,
             QualifiedName browseName,
             bool createOrReplace,
-            BaseInstanceState replacement)
+            BaseInstanceState replacement,
+            bool assignInstanceNodeIds = true)
         {
             if ((browseName).IsNull)
             {
@@ -2203,7 +2211,7 @@ namespace Quickstarts.Boiler
                 return instance;
             }
 
-            return base.FindChild(context, browseName, createOrReplace, replacement);
+            return base.FindChild(context, browseName, createOrReplace, replacement, assignInstanceNodeIds);
         }
         #endregion
 

--- a/Workshop/Common/Quickstart Library.csproj
+++ b/Workshop/Common/Quickstart Library.csproj
@@ -46,7 +46,7 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Core">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/Workshop/Common/QuickstartNodeManager.cs
+++ b/Workshop/Common/QuickstartNodeManager.cs
@@ -3882,6 +3882,32 @@ namespace Quickstarts
             IList<bool> processedItems,
             IList<ServiceResult> errors)
         {
+            TransferMonitoredItems(
+                context,
+                sendInitialValues,
+                monitoredItems,
+                processedItems,
+                errors,
+                new MonitoredItemTransferOptions());
+        }
+
+        /// <summary>
+        /// Transfers a set of monitored items.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="sendInitialValues">Whether the subscription should send initial values after transfer.</param>
+        /// <param name="monitoredItems">The set of monitoring items to update.</param>
+        /// <param name="processedItems">The list of bool with items that were already processed.</param>
+        /// <param name="errors">Any errors.</param>
+        /// <param name="transferOptions">Controls how the transfer is executed.</param>
+        public virtual void TransferMonitoredItems(
+            OperationContext context,
+            bool sendInitialValues,
+            IList<IMonitoredItem> monitoredItems,
+            IList<bool> processedItems,
+            IList<ServiceResult> errors,
+            MonitoredItemTransferOptions transferOptions)
+        {
             ServerSystemContext systemContext = m_systemContext.Copy(context);
             List<IMonitoredItem> transferredItems = new List<IMonitoredItem>();
             lock (Lock)
@@ -3905,7 +3931,7 @@ namespace Quickstarts
                     // owned by this node manager.
                     processedItems[ii] = true;
                     transferredItems.Add(monitoredItems[ii]);
-                    if (sendInitialValues)
+                    if (sendInitialValues && !transferOptions.DeferInitialValues)
                     {
                         monitoredItems[ii].SetupResendDataTrigger();
                     }

--- a/Workshop/DataAccess/Client/DataAccess Client.csproj
+++ b/Workshop/DataAccess/Client/DataAccess Client.csproj
@@ -33,7 +33,7 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/Workshop/DataAccess/Server/DataAccess Server.csproj
+++ b/Workshop/DataAccess/Server/DataAccess Server.csproj
@@ -34,7 +34,7 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/Workshop/DataAccess/Server/Model/SegmentBrowser.cs
+++ b/Workshop/DataAccess/Server/Model/SegmentBrowser.cs
@@ -91,70 +91,69 @@ namespace Quickstarts.DataAccessServer
         {
             UnderlyingSystem system = (UnderlyingSystem)this.SystemContext.SystemHandle;
 
-            lock (DataLock)
+            // NodeBrowser instances are single-consumer and perform no
+            // synchronization of their own; the former DataLock is gone.
+            IReference reference = null;
+
+            // enumerate pre-defined references.
+            // always call first to ensure any pushed-back references are returned first.
+            reference = base.Next();
+
+            if (reference != null)
             {
-                IReference reference = null;
+                return reference;
+            }
 
-                // enumerate pre-defined references.
-                // always call first to ensure any pushed-back references are returned first.
-                reference = base.Next();
+            if (m_stage == Stage.Begin)
+            {
+                m_segments = system.FindSegments(m_source.SegmentPath);
+                m_stage = Stage.Segments;
+                m_position = 0;
+            }
 
-                if (reference != null)
-                {
-                    return reference;
-                }
-
-                if (m_stage == Stage.Begin)
-                {
-                    m_segments = system.FindSegments(m_source.SegmentPath);
-                    m_stage = Stage.Segments;
-                    m_position = 0;
-                }
-
-                // don't start browsing huge number of references when only internal references are requested.
-                if (InternalOnly)
-                {
-                    return null;
-                }
-
-                // enumerate segments.
-                if (m_stage == Stage.Segments)
-                {
-                    if (IsRequired(ReferenceTypeIds.Organizes, false))
-                    {
-                        reference = NextChild();
-
-                        if (reference != null)
-                        {
-                            return reference;
-                        }
-                    }
-
-                    m_blocks = system.FindBlocks(m_source.SegmentPath);
-                    m_stage = Stage.Blocks;
-                    m_position = 0;
-                }
-
-                // enumerate blocks.
-                if (m_stage == Stage.Blocks)
-                {
-                    if (IsRequired(ReferenceTypeIds.Organizes, false))
-                    {
-                        reference = NextChild();
-
-                        if (reference != null)
-                        {
-                            return reference;
-                        }
-
-                        m_stage = Stage.Done;
-                        m_position = 0;
-                    }
-                }
-
-                // all done.
+            // don't start browsing huge number of references when only internal references are requested.
+            if (InternalOnly)
+            {
                 return null;
             }
+
+            // enumerate segments.
+            if (m_stage == Stage.Segments)
+            {
+                if (IsRequired(ReferenceTypeIds.Organizes, false))
+                {
+                    reference = NextChild();
+
+                    if (reference != null)
+                    {
+                        return reference;
+                    }
+                }
+
+                m_blocks = system.FindBlocks(m_source.SegmentPath);
+                m_stage = Stage.Blocks;
+                m_position = 0;
+            }
+
+            // enumerate blocks.
+            if (m_stage == Stage.Blocks)
+            {
+                if (IsRequired(ReferenceTypeIds.Organizes, false))
+                {
+                    reference = NextChild();
+
+                    if (reference != null)
+                    {
+                        return reference;
+                    }
+
+                    m_stage = Stage.Done;
+                    m_position = 0;
+                }
+            }
+
+            // all done.
+            return null;
         }
         #endregion
 

--- a/Workshop/DataTypes/Client/DataTypes Client.csproj
+++ b/Workshop/DataTypes/Client/DataTypes Client.csproj
@@ -25,7 +25,7 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup Label="Compile items now included by globbing that were not in the original project file">

--- a/Workshop/DataTypes/Common/DataTypes Library.csproj
+++ b/Workshop/DataTypes/Common/DataTypes Library.csproj
@@ -44,7 +44,7 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Core">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup Label="Compile items now included by globbing that were not in the original project file">

--- a/Workshop/DataTypes/Common/Types/Quickstarts.DataTypes.Types.Classes.cs
+++ b/Workshop/DataTypes/Common/Types/Quickstarts.DataTypes.Types.Classes.cs
@@ -167,7 +167,8 @@ namespace Quickstarts.DataTypes.Types
             ISystemContext context,
             QualifiedName browseName,
             bool createOrReplace,
-            BaseInstanceState replacement)
+            BaseInstanceState replacement,
+            bool assignInstanceNodeIds = true)
         {
             if ((browseName).IsNull)
             {
@@ -226,7 +227,7 @@ namespace Quickstarts.DataTypes.Types
                 return instance;
             }
 
-            return base.FindChild(context, browseName, createOrReplace, replacement);
+            return base.FindChild(context, browseName, createOrReplace, replacement, assignInstanceNodeIds);
         }
         #endregion
 

--- a/Workshop/DataTypes/Server/DataTypes Server.csproj
+++ b/Workshop/DataTypes/Server/DataTypes Server.csproj
@@ -38,7 +38,7 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/Workshop/Empty/Client/Empty Client.csproj
+++ b/Workshop/Empty/Client/Empty Client.csproj
@@ -31,7 +31,7 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/Workshop/Empty/Server/Empty Server.csproj
+++ b/Workshop/Empty/Server/Empty Server.csproj
@@ -31,7 +31,7 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/Workshop/HistoricalAccess/Client/HistoricalAccess Client.csproj
+++ b/Workshop/HistoricalAccess/Client/HistoricalAccess Client.csproj
@@ -30,7 +30,7 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup Label="Compile items now included by globbing that were not in the original project file">

--- a/Workshop/HistoricalAccess/Server/HistoricalAccess Server.csproj
+++ b/Workshop/HistoricalAccess/Server/HistoricalAccess Server.csproj
@@ -59,7 +59,7 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup Label="Compile items now included by globbing that were not in the original project file">

--- a/Workshop/HistoricalAccess/Server/HistoricalAccessNodeManager.cs
+++ b/Workshop/HistoricalAccess/Server/HistoricalAccessNodeManager.cs
@@ -120,17 +120,16 @@ namespace Quickstarts.HistoricalAccessServer
         /// </summary>
         public override void CreateAddressSpace(IDictionary<NodeId, IList<IReference>> externalReferences)
         {
-            lock (Server.DiagnosticsLock)
-            {
-                HistoryServerCapabilitiesState capabilities = Server.DiagnosticsNodeManager.GetDefaultHistoryCapabilitiesAsync(System.Threading.CancellationToken.None).GetAwaiter().GetResult();
-                capabilities.AccessHistoryDataCapability.Value = true;
-                capabilities.InsertDataCapability.Value = true;
-                capabilities.ReplaceDataCapability.Value = true;
-                capabilities.UpdateDataCapability.Value = true;
-                capabilities.DeleteRawCapability.Value = true;
-                capabilities.DeleteAtTimeCapability.Value = true;
-                capabilities.InsertAnnotationCapability.Value = true;
-            }
+            // The server owns its diagnostics lock and no longer exposes it; this
+            // section does not touch the diagnostics summary it guarded.
+            HistoryServerCapabilitiesState capabilities = Server.DiagnosticsNodeManager.GetDefaultHistoryCapabilitiesAsync(System.Threading.CancellationToken.None).GetAwaiter().GetResult();
+            capabilities.AccessHistoryDataCapability.Value = true;
+            capabilities.InsertDataCapability.Value = true;
+            capabilities.ReplaceDataCapability.Value = true;
+            capabilities.UpdateDataCapability.Value = true;
+            capabilities.DeleteRawCapability.Value = true;
+            capabilities.DeleteAtTimeCapability.Value = true;
+            capabilities.InsertAnnotationCapability.Value = true;
 
             lock (Lock)
             {
@@ -1643,13 +1642,18 @@ namespace Quickstarts.HistoricalAccessServer
         /// <summary>
         /// Stores a read history request.
         /// </summary>
-        private sealed class HistoryReadRequest
+        private sealed class HistoryReadRequest : IHistoryContinuationPoint
         {
+            public Guid Id { get; set; }
             public ByteString ContinuationPoint;
             public LinkedList<DataValue> Values;
             public LinkedList<ModificationInfo> ModificationInfos;
             public uint NumValuesPerNode;
             public AggregateFilter Filter;
+
+            public void Dispose()
+            {
+            }
         }
 
         /// <summary>
@@ -1695,7 +1699,7 @@ namespace Quickstarts.HistoricalAccessServer
                 return null;
             }
 
-            HistoryReadRequest request = session.RestoreHistoryContinuationPoint(continuationPoint) as HistoryReadRequest;
+            HistoryReadRequest request = session.ContinuationPoints.RestoreHistory(continuationPoint) as HistoryReadRequest;
 
             if (request == null)
             {
@@ -1719,9 +1723,9 @@ namespace Quickstarts.HistoricalAccessServer
                 return default;
             }
 
-            Guid id = Guid.NewGuid();
-            session.SaveHistoryContinuationPoint(id, request);
-            request.ContinuationPoint = id.ToByteArray().ToByteString();
+            request.Id = Guid.NewGuid();
+            session.ContinuationPoints.SaveHistory(request);
+            request.ContinuationPoint = request.Id.ToByteArray().ToByteString();
             return request.ContinuationPoint;
         }
         #endregion

--- a/Workshop/HistoricalAccess/Server/Model/SegmentBrowser.cs
+++ b/Workshop/HistoricalAccess/Server/Model/SegmentBrowser.cs
@@ -91,70 +91,69 @@ namespace Quickstarts.HistoricalAccessServer
         {
             UnderlyingSystem system = (UnderlyingSystem)this.SystemContext.SystemHandle;
 
-            lock (DataLock)
+            // NodeBrowser instances are single-consumer and perform no
+            // synchronization of their own; the former DataLock is gone.
+            IReference reference = null;
+
+            // enumerate pre-defined references.
+            // always call first to ensure any pushed-back references are returned first.
+            reference = base.Next();
+
+            if (reference != null)
             {
-                IReference reference = null;
+                return reference;
+            }
 
-                // enumerate pre-defined references.
-                // always call first to ensure any pushed-back references are returned first.
-                reference = base.Next();
+            if (m_stage == Stage.Begin)
+            {
+                m_segments = system.FindSegments(m_source.SegmentPath);
+                m_stage = Stage.Segments;
+                m_position = 0;
+            }
 
-                if (reference != null)
-                {
-                    return reference;
-                }
-
-                if (m_stage == Stage.Begin)
-                {
-                    m_segments = system.FindSegments(m_source.SegmentPath);
-                    m_stage = Stage.Segments;
-                    m_position = 0;
-                }
-
-                // don't start browsing huge number of references when only internal references are requested.
-                if (InternalOnly)
-                {
-                    return null;
-                }
-                
-                // enumerate segments.
-                if (m_stage == Stage.Segments)
-                {
-                    if (IsRequired(ReferenceTypeIds.Organizes, false))
-                    {
-                        reference = NextChild();
-
-                        if (reference != null)
-                        {
-                            return reference;
-                        }
-                    }
-
-                    m_blocks = system.FindBlocks(m_source.SegmentPath);
-                    m_stage = Stage.Blocks;
-                    m_position = 0;
-                }
-                
-                // enumerate blocks.
-                if (m_stage == Stage.Blocks)
-                {
-                    if (IsRequired(ReferenceTypeIds.Organizes, false))
-                    {
-                        reference = NextChild();
-
-                        if (reference != null)
-                        {
-                            return reference;
-                        }
-
-                        m_stage = Stage.Done;
-                        m_position = 0;
-                    }
-                }
-
-                // all done.
+            // don't start browsing huge number of references when only internal references are requested.
+            if (InternalOnly)
+            {
                 return null;
             }
+            
+            // enumerate segments.
+            if (m_stage == Stage.Segments)
+            {
+                if (IsRequired(ReferenceTypeIds.Organizes, false))
+                {
+                    reference = NextChild();
+
+                    if (reference != null)
+                    {
+                        return reference;
+                    }
+                }
+
+                m_blocks = system.FindBlocks(m_source.SegmentPath);
+                m_stage = Stage.Blocks;
+                m_position = 0;
+            }
+            
+            // enumerate blocks.
+            if (m_stage == Stage.Blocks)
+            {
+                if (IsRequired(ReferenceTypeIds.Organizes, false))
+                {
+                    reference = NextChild();
+
+                    if (reference != null)
+                    {
+                        return reference;
+                    }
+
+                    m_stage = Stage.Done;
+                    m_position = 0;
+                }
+            }
+
+            // all done.
+            return null;
         }
         #endregion
 

--- a/Workshop/HistoricalAccess/Server/UnderlyingSystem/ArchiveFolderBrowser.cs
+++ b/Workshop/HistoricalAccess/Server/UnderlyingSystem/ArchiveFolderBrowser.cs
@@ -91,87 +91,86 @@ namespace Quickstarts.HistoricalAccessServer
         {
             UnderlyingSystem system = (UnderlyingSystem)this.SystemContext.SystemHandle;
 
-            lock (DataLock)
+            // NodeBrowser instances are single-consumer and perform no
+            // synchronization of their own; the former DataLock is gone.
+            IReference reference = null;
+
+            // enumerate pre-defined references.
+            // always call first to ensure any pushed-back references are returned first.
+            reference = base.Next();
+
+            if (reference != null)
             {
-                IReference reference = null;
+                return reference;
+            }
 
-                // enumerate pre-defined references.
-                // always call first to ensure any pushed-back references are returned first.
-                reference = base.Next();
+            if (m_stage == Stage.Begin)
+            {
+                m_folders = m_source.ArchiveFolder.GetChildFolders();
+                m_stage = Stage.Folders;
+                m_position = 0;
+            }
 
-                if (reference != null)
-                {
-                    return reference;
-                }
-
-                if (m_stage == Stage.Begin)
-                {
-                    m_folders = m_source.ArchiveFolder.GetChildFolders();
-                    m_stage = Stage.Folders;
-                    m_position = 0;
-                }
-
-                // don't start browsing huge number of references when only internal references are requested.
-                if (InternalOnly)
-                {
-                    return null;
-                }
-
-                // enumerate folders.
-                if (m_stage == Stage.Folders)
-                {
-                    if (IsRequired(ReferenceTypeIds.Organizes, false))
-                    {
-                        reference = NextChild();
-
-                        if (reference != null)
-                        {
-                            return reference;
-                        }
-                    }
-
-                    m_items = m_source.ArchiveFolder.GetItems();
-                    m_stage = Stage.Items;
-                    m_position = 0;
-                }
-
-                // enumerate items.
-                if (m_stage == Stage.Items)
-                {
-                    if (IsRequired(ReferenceTypeIds.Organizes, false))
-                    {
-                        reference = NextChild();
-
-                        if (reference != null)
-                        {
-                            return reference;
-                        }
-
-                        m_stage = Stage.Parents;
-                        m_position = 0;
-                    }
-                }
-
-                // enumerate parents.
-                if (m_stage == Stage.Parents)
-                {
-                    if (IsRequired(ReferenceTypeIds.Organizes, true))
-                    {
-                        reference = NextChild();
-
-                        if (reference != null)
-                        {
-                            return reference;
-                        }
-
-                        m_stage = Stage.Done;
-                        m_position = 0;
-                    }
-                }
-
-                // all done.
+            // don't start browsing huge number of references when only internal references are requested.
+            if (InternalOnly)
+            {
                 return null;
             }
+
+            // enumerate folders.
+            if (m_stage == Stage.Folders)
+            {
+                if (IsRequired(ReferenceTypeIds.Organizes, false))
+                {
+                    reference = NextChild();
+
+                    if (reference != null)
+                    {
+                        return reference;
+                    }
+                }
+
+                m_items = m_source.ArchiveFolder.GetItems();
+                m_stage = Stage.Items;
+                m_position = 0;
+            }
+
+            // enumerate items.
+            if (m_stage == Stage.Items)
+            {
+                if (IsRequired(ReferenceTypeIds.Organizes, false))
+                {
+                    reference = NextChild();
+
+                    if (reference != null)
+                    {
+                        return reference;
+                    }
+
+                    m_stage = Stage.Parents;
+                    m_position = 0;
+                }
+            }
+
+            // enumerate parents.
+            if (m_stage == Stage.Parents)
+            {
+                if (IsRequired(ReferenceTypeIds.Organizes, true))
+                {
+                    reference = NextChild();
+
+                    if (reference != null)
+                    {
+                        return reference;
+                    }
+
+                    m_stage = Stage.Done;
+                    m_position = 0;
+                }
+            }
+
+            // all done.
+            return null;
         }
         #endregion
 

--- a/Workshop/HistoricalAccess/Tester/Aggregate Tester.csproj
+++ b/Workshop/HistoricalAccess/Tester/Aggregate Tester.csproj
@@ -34,10 +34,10 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/Workshop/HistoricalEvents/Client/HistoricalEvents Client.csproj
+++ b/Workshop/HistoricalEvents/Client/HistoricalEvents Client.csproj
@@ -34,7 +34,7 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup Label="Compile items now included by globbing that were not in the original project file">

--- a/Workshop/HistoricalEvents/Client/Quickstarts.HistoricalEvents.Classes.cs
+++ b/Workshop/HistoricalEvents/Client/Quickstarts.HistoricalEvents.Classes.cs
@@ -231,7 +231,8 @@ namespace Quickstarts.HistoricalEvents
             ISystemContext context,
             QualifiedName browseName,
             bool createOrReplace,
-            BaseInstanceState replacement)
+            BaseInstanceState replacement,
+            bool assignInstanceNodeIds = true)
         {
             if ((browseName).IsNull)
             {
@@ -332,7 +333,7 @@ namespace Quickstarts.HistoricalEvents
                 return instance;
             }
 
-            return base.FindChild(context, browseName, createOrReplace, replacement);
+            return base.FindChild(context, browseName, createOrReplace, replacement, assignInstanceNodeIds);
         }
         #endregion
 
@@ -500,7 +501,8 @@ namespace Quickstarts.HistoricalEvents
             ISystemContext context,
             QualifiedName browseName,
             bool createOrReplace,
-            BaseInstanceState replacement)
+            BaseInstanceState replacement,
+            bool assignInstanceNodeIds = true)
         {
             if ((browseName).IsNull)
             {
@@ -559,7 +561,7 @@ namespace Quickstarts.HistoricalEvents
                 return instance;
             }
 
-            return base.FindChild(context, browseName, createOrReplace, replacement);
+            return base.FindChild(context, browseName, createOrReplace, replacement, assignInstanceNodeIds);
         }
         #endregion
 
@@ -723,7 +725,8 @@ namespace Quickstarts.HistoricalEvents
             ISystemContext context,
             QualifiedName browseName,
             bool createOrReplace,
-            BaseInstanceState replacement)
+            BaseInstanceState replacement,
+            bool assignInstanceNodeIds = true)
         {
             if ((browseName).IsNull)
             {
@@ -782,7 +785,7 @@ namespace Quickstarts.HistoricalEvents
                 return instance;
             }
 
-            return base.FindChild(context, browseName, createOrReplace, replacement);
+            return base.FindChild(context, browseName, createOrReplace, replacement, assignInstanceNodeIds);
         }
         #endregion
 

--- a/Workshop/HistoricalEvents/Server/HistoricalEvents Server.csproj
+++ b/Workshop/HistoricalEvents/Server/HistoricalEvents Server.csproj
@@ -36,7 +36,7 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/Workshop/HistoricalEvents/Server/HistoricalEventsNodeManager.cs
+++ b/Workshop/HistoricalEvents/Server/HistoricalEventsNodeManager.cs
@@ -595,14 +595,19 @@ namespace Quickstarts.HistoricalEvents.Server
         /// <summary>
         /// Stores a read history request.
         /// </summary>
-        private sealed class HistoryReadRequest
+        private sealed class HistoryReadRequest : IHistoryContinuationPoint
         {
+            public Guid Id { get; set; }
             public ByteString ContinuationPoint;
             public LinkedList<BaseEventState> Events;
             public bool TimeFlowsBackward;
             public uint NumValuesPerNode;
             public EventFilter Filter;
             public FilterContext FilterContext;
+
+            public void Dispose()
+            {
+            }
         }
 
         /// <summary>
@@ -648,7 +653,7 @@ namespace Quickstarts.HistoricalEvents.Server
                 return null;
             }
 
-            HistoryReadRequest request = session.RestoreHistoryContinuationPoint(continuationPoint) as HistoryReadRequest;
+            HistoryReadRequest request = session.ContinuationPoints.RestoreHistory(continuationPoint) as HistoryReadRequest;
 
             if (request == null)
             {
@@ -672,9 +677,9 @@ namespace Quickstarts.HistoricalEvents.Server
                 return default;
             }
 
-            Guid id = Guid.NewGuid();
-            session.SaveHistoryContinuationPoint(id, request);
-            request.ContinuationPoint = id.ToByteArray().ToByteString();
+            request.Id = Guid.NewGuid();
+            session.ContinuationPoints.SaveHistory(request);
+            request.ContinuationPoint = request.Id.ToByteArray().ToByteString();
             return request.ContinuationPoint;
         }
         #endregion

--- a/Workshop/HistoricalEvents/Server/Model/Quickstarts.HistoricalEvents.Classes.cs
+++ b/Workshop/HistoricalEvents/Server/Model/Quickstarts.HistoricalEvents.Classes.cs
@@ -231,7 +231,8 @@ namespace Quickstarts.HistoricalEvents
             ISystemContext context,
             QualifiedName browseName,
             bool createOrReplace,
-            BaseInstanceState replacement)
+            BaseInstanceState replacement,
+            bool assignInstanceNodeIds = true)
         {
             if ((browseName).IsNull)
             {
@@ -332,7 +333,7 @@ namespace Quickstarts.HistoricalEvents
                 return instance;
             }
 
-            return base.FindChild(context, browseName, createOrReplace, replacement);
+            return base.FindChild(context, browseName, createOrReplace, replacement, assignInstanceNodeIds);
         }
         #endregion
 
@@ -500,7 +501,8 @@ namespace Quickstarts.HistoricalEvents
             ISystemContext context,
             QualifiedName browseName,
             bool createOrReplace,
-            BaseInstanceState replacement)
+            BaseInstanceState replacement,
+            bool assignInstanceNodeIds = true)
         {
             if ((browseName).IsNull)
             {
@@ -559,7 +561,7 @@ namespace Quickstarts.HistoricalEvents
                 return instance;
             }
 
-            return base.FindChild(context, browseName, createOrReplace, replacement);
+            return base.FindChild(context, browseName, createOrReplace, replacement, assignInstanceNodeIds);
         }
         #endregion
 
@@ -723,7 +725,8 @@ namespace Quickstarts.HistoricalEvents
             ISystemContext context,
             QualifiedName browseName,
             bool createOrReplace,
-            BaseInstanceState replacement)
+            BaseInstanceState replacement,
+            bool assignInstanceNodeIds = true)
         {
             if ((browseName).IsNull)
             {
@@ -782,7 +785,7 @@ namespace Quickstarts.HistoricalEvents
                 return instance;
             }
 
-            return base.FindChild(context, browseName, createOrReplace, replacement);
+            return base.FindChild(context, browseName, createOrReplace, replacement, assignInstanceNodeIds);
         }
         #endregion
 

--- a/Workshop/Methods/Client/Methods Client.csproj
+++ b/Workshop/Methods/Client/Methods Client.csproj
@@ -30,7 +30,7 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/Workshop/Methods/Server/Methods Server.csproj
+++ b/Workshop/Methods/Server/Methods Server.csproj
@@ -31,7 +31,7 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/Workshop/PerfTest/Client/PerfTest Client.csproj
+++ b/Workshop/PerfTest/Client/PerfTest Client.csproj
@@ -30,7 +30,7 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/Workshop/PerfTest/Server/MemoryRegisterState.cs
+++ b/Workshop/PerfTest/Server/MemoryRegisterState.cs
@@ -168,48 +168,47 @@ namespace Quickstarts.PerfTestServer
         {
             UnderlyingSystem system = (UnderlyingSystem)this.SystemContext.SystemHandle;
 
-            lock (DataLock)
+            // NodeBrowser instances are single-consumer and perform no
+            // synchronization of their own; the former DataLock is gone.
+            IReference reference = null;
+
+            // enumerate pre-defined references.
+            // always call first to ensure any pushed-back references are returned first.
+            reference = base.Next();
+
+            if (reference != null)
             {
-                IReference reference = null;
+                return reference;
+            }
 
-                // enumerate pre-defined references.
-                // always call first to ensure any pushed-back references are returned first.
-                reference = base.Next();
+            if (m_stage == Stage.Begin)
+            {
+                m_stage = Stage.Tags;
+                m_position = 0;
+            }
 
-                if (reference != null)
-                {
-                    return reference;
-                }
-
-                if (m_stage == Stage.Begin)
-                {
-                    m_stage = Stage.Tags;
-                    m_position = 0;
-                }
-
-                // don't start browsing huge number of references when only internal references are requested.
-                if (InternalOnly)
-                {
-                    return null;
-                }
-
-                // enumerate tags.
-                if (m_stage == Stage.Tags)
-                {
-                    if (IsRequired(ReferenceTypeIds.Organizes, false))
-                    {
-                        reference = NextChild();
-
-                        if (reference != null)
-                        {
-                            return reference;
-                        }
-                    }
-                }
-
-                // all done.
+            // don't start browsing huge number of references when only internal references are requested.
+            if (InternalOnly)
+            {
                 return null;
             }
+
+            // enumerate tags.
+            if (m_stage == Stage.Tags)
+            {
+                if (IsRequired(ReferenceTypeIds.Organizes, false))
+                {
+                    reference = NextChild();
+
+                    if (reference != null)
+                    {
+                        return reference;
+                    }
+                }
+            }
+
+            // all done.
+            return null;
         }
         #endregion
 

--- a/Workshop/PerfTest/Server/PerfTest Server.csproj
+++ b/Workshop/PerfTest/Server/PerfTest Server.csproj
@@ -31,7 +31,7 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/Workshop/SimpleEvents/Client/Quickstarts.SimpleEvents.Classes.cs
+++ b/Workshop/SimpleEvents/Client/Quickstarts.SimpleEvents.Classes.cs
@@ -176,7 +176,8 @@ namespace Quickstarts.SimpleEvents
             ISystemContext context,
             QualifiedName browseName,
             bool createOrReplace,
-            BaseInstanceState replacement)
+            BaseInstanceState replacement,
+            bool assignInstanceNodeIds = true)
         {
             if ((browseName).IsNull)
             {
@@ -235,7 +236,7 @@ namespace Quickstarts.SimpleEvents
                 return instance;
             }
 
-            return base.FindChild(context, browseName, createOrReplace, replacement);
+            return base.FindChild(context, browseName, createOrReplace, replacement, assignInstanceNodeIds);
         }
         #endregion
 
@@ -364,7 +365,8 @@ namespace Quickstarts.SimpleEvents
             ISystemContext context,
             QualifiedName browseName,
             bool createOrReplace,
-            BaseInstanceState replacement)
+            BaseInstanceState replacement,
+            bool assignInstanceNodeIds = true)
         {
             if ((browseName).IsNull)
             {
@@ -402,7 +404,7 @@ namespace Quickstarts.SimpleEvents
                 return instance;
             }
 
-            return base.FindChild(context, browseName, createOrReplace, replacement);
+            return base.FindChild(context, browseName, createOrReplace, replacement, assignInstanceNodeIds);
         }
         #endregion
 
@@ -543,7 +545,8 @@ namespace Quickstarts.SimpleEvents
             ISystemContext context,
             QualifiedName browseName,
             bool createOrReplace,
-            BaseInstanceState replacement)
+            BaseInstanceState replacement,
+            bool assignInstanceNodeIds = true)
         {
             if ((browseName).IsNull)
             {
@@ -581,7 +584,7 @@ namespace Quickstarts.SimpleEvents
                 return instance;
             }
 
-            return base.FindChild(context, browseName, createOrReplace, replacement);
+            return base.FindChild(context, browseName, createOrReplace, replacement, assignInstanceNodeIds);
         }
         #endregion
 

--- a/Workshop/SimpleEvents/Client/SimpleEvents Client.csproj
+++ b/Workshop/SimpleEvents/Client/SimpleEvents Client.csproj
@@ -27,7 +27,7 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Workshop/SimpleEvents/Server/Quickstarts.SimpleEvents.Classes.cs
+++ b/Workshop/SimpleEvents/Server/Quickstarts.SimpleEvents.Classes.cs
@@ -176,7 +176,8 @@ namespace Quickstarts.SimpleEvents
             ISystemContext context,
             QualifiedName browseName,
             bool createOrReplace,
-            BaseInstanceState replacement)
+            BaseInstanceState replacement,
+            bool assignInstanceNodeIds = true)
         {
             if ((browseName).IsNull)
             {
@@ -235,7 +236,7 @@ namespace Quickstarts.SimpleEvents
                 return instance;
             }
 
-            return base.FindChild(context, browseName, createOrReplace, replacement);
+            return base.FindChild(context, browseName, createOrReplace, replacement, assignInstanceNodeIds);
         }
         #endregion
 
@@ -364,7 +365,8 @@ namespace Quickstarts.SimpleEvents
             ISystemContext context,
             QualifiedName browseName,
             bool createOrReplace,
-            BaseInstanceState replacement)
+            BaseInstanceState replacement,
+            bool assignInstanceNodeIds = true)
         {
             if ((browseName).IsNull)
             {
@@ -402,7 +404,7 @@ namespace Quickstarts.SimpleEvents
                 return instance;
             }
 
-            return base.FindChild(context, browseName, createOrReplace, replacement);
+            return base.FindChild(context, browseName, createOrReplace, replacement, assignInstanceNodeIds);
         }
         #endregion
 
@@ -543,7 +545,8 @@ namespace Quickstarts.SimpleEvents
             ISystemContext context,
             QualifiedName browseName,
             bool createOrReplace,
-            BaseInstanceState replacement)
+            BaseInstanceState replacement,
+            bool assignInstanceNodeIds = true)
         {
             if ((browseName).IsNull)
             {
@@ -581,7 +584,7 @@ namespace Quickstarts.SimpleEvents
                 return instance;
             }
 
-            return base.FindChild(context, browseName, createOrReplace, replacement);
+            return base.FindChild(context, browseName, createOrReplace, replacement, assignInstanceNodeIds);
         }
         #endregion
 

--- a/Workshop/SimpleEvents/Server/SimpleEvents Server.csproj
+++ b/Workshop/SimpleEvents/Server/SimpleEvents Server.csproj
@@ -35,7 +35,7 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/Workshop/UserAuthentication/Client/UserAuthentication Client.csproj
+++ b/Workshop/UserAuthentication/Client/UserAuthentication Client.csproj
@@ -30,7 +30,7 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/Workshop/UserAuthentication/Server/UserAuthentication Server.csproj
+++ b/Workshop/UserAuthentication/Server/UserAuthentication Server.csproj
@@ -31,8 +31,8 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.SourceGeneration" Version="2.0.158.59919-preview" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.SourceGeneration" Version="2.0.0-preview.2" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 </Project>

--- a/Workshop/Views/Client/Views Client.csproj
+++ b/Workshop/Views/Client/Views Client.csproj
@@ -30,7 +30,7 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/Workshop/Views/Server/Model/Quickstarts.Views.Classes.cs
+++ b/Workshop/Views/Server/Model/Quickstarts.Views.Classes.cs
@@ -225,7 +225,8 @@ namespace Quickstarts.Views
             ISystemContext context,
             QualifiedName browseName,
             bool createOrReplace,
-            BaseInstanceState replacement)
+            BaseInstanceState replacement,
+            bool assignInstanceNodeIds = true)
         {
             if ((browseName).IsNull)
             {
@@ -326,7 +327,7 @@ namespace Quickstarts.Views
                 return instance;
             }
 
-            return base.FindChild(context, browseName, createOrReplace, replacement);
+            return base.FindChild(context, browseName, createOrReplace, replacement, assignInstanceNodeIds);
         }
         #endregion
 
@@ -679,7 +680,8 @@ namespace Quickstarts.Views
             ISystemContext context,
             QualifiedName browseName,
             bool createOrReplace,
-            BaseInstanceState replacement)
+            BaseInstanceState replacement,
+            bool assignInstanceNodeIds = true)
         {
             if ((browseName).IsNull)
             {
@@ -759,7 +761,7 @@ namespace Quickstarts.Views
                 return instance;
             }
 
-            return base.FindChild(context, browseName, createOrReplace, replacement);
+            return base.FindChild(context, browseName, createOrReplace, replacement, assignInstanceNodeIds);
         }
         #endregion
 

--- a/Workshop/Views/Server/Views Server.csproj
+++ b/Workshop/Views/Server/Views Server.csproj
@@ -41,9 +41,9 @@
       <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
-      <Version>2.0.158.59919-preview</Version>
+      <Version>2.0.0-preview.2</Version>
     </PackageReference>
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.SourceGeneration" Version="2.0.158.59919-preview" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.SourceGeneration" Version="2.0.0-preview.2" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
   <ItemGroup Label="Compile items now included by globbing that were not in the original project file">
     <Compile Remove="Namespaces.cs" />


### PR DESCRIPTION
> Targets `master` and stands alone — one commit, no dependency on #783. Merge this first; #783 then picks up the new version when `master` is merged into it.

## Why CI is failing

The `opcua-preview` feed no longer publishes `2.0.158.59919-preview`. **`2.0.0-preview.2` is now the only version available**, so `nuget restore` fails on any clean machine — including CI. Local builds keep working only because the old package is still in a developer's NuGet cache.

## The bump alone does not fix it

`2.0.0-preview.2` carries breaking API changes. With the old version both CodeQL solutions build with 0 errors; with only the version strings changed they produce ~21 and ~28 distinct errors. So this PR does both: the bump, and the API migration it forces.

**Bump:** all **43** `.csproj` files, covering all **14** `OPCFoundation.NetStandard.Opc.Ua.*` packages. Every one verified present at `2.0.0-preview.2` on the feed before changing anything.

## API migrations

| Change | Sites | Migration |
|---|---|---|
| `SecurityPolicies` no longer static — now `sealed class SecurityPolicies : ISecurityPolicyRegistry` | 17 | Route through `SecurityPolicies.Default`, documented as the registry for "code with no container in scope" — exactly these WinForms dialogs |
| New `Opc.Ua.Decimal` built-in shadows `System.Decimal` | 4 | Use the `decimal` keyword for the `NumericUpDown` bounds |
| `INodeManager.TransferMonitoredItems` gained `MonitoredItemTransferOptions` | 3 classes | Six-arg overload holds the logic, five-arg delegates — the same shape as the SDK's own `CustomNodeManager2` |
| `DiagnosticsLock` removed from Session/Subscription/`IServerInternal`; `ISession.SessionDiagnostics` gone | 6 files | `ReadDiagnostics(d => …)`, which applies the projection while holding the lock the object owns |
| `ISession.Save/RestoreHistoryContinuationPoint` removed | 3 files | `Session.ContinuationPoints.SaveHistory/RestoreHistory`, taking `IHistoryContinuationPoint` |
| `NodeBrowser.DataLock` removed | 6 | Drop the lock — browsers are single-consumer and the base type documents that derived browsers are not expected to synchronize |
| `NodeState.FindChild` gained defaulted `assignInstanceNodeIds` | 23 | Overrides take it and forward to `base` (callers are unaffected; only overrides must match) |

### Judgment calls worth a look

- **`TransferMonitoredItems` honours `DeferInitialValues`** rather than ignoring it: when set, `SetupResendDataTrigger` is skipped so the owning subscription drives it after committing the transfer. Passing the flag through would have been enough to compile; this makes the samples actually correct against the new contract.
- **The two `Server.DiagnosticsLock` blocks simply drop the lock.** Neither touches the server diagnostics summary that lock guarded — one mutates `HistoryServerCapabilities` nodes during `CreateAddressSpace`, the other guards namespace-table mapping. `UpdateServerDiagnostics` is the documented replacement but is the wrong tool for both, and the lock is now private.
- **`HistoryDataReader` / `HistoryReadRequest` now implement `IHistoryContinuationPoint`** and carry their own `Id`, replacing the separately generated `Guid` the old two-argument `SaveHistoryContinuationPoint` took.
- **The `FindChild` changes are in generated model files.** They are edited in place rather than regenerated, matching what the current generator emits. Regenerating those models is a larger, separate job.

## Verification

- All **five** solutions in the repository build clean in Release from this branch alone: both CodeQL solutions (`UA Quickstart Applications.sln`, `UA Sample Applications.sln`) plus `UA Aggregation.sln`, `UA Global Discovery Server.sln` and `UA Samples.slnx`.
- Both CodeQL solutions restore cleanly and resolve to `2.0.0-preview.2`.
- No `2.0.158.59919-preview` reference remains in any project or props file.

## Relationship to #783

#783 (sealing and config migration) adds `SourceGeneration` analyzer `PackageReference`s to nine projects. Those are **not** in this PR — they arrive with #783, and will need the same `2.0.0-preview.2` version when `master` is merged into that branch after this one lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
