### PR TITLE
Fix all build warnings and bump the NuGet packages

### DIFF
--- a/Samples/Client.Net4/Program.cs
+++ b/Samples/Client.Net4/Program.cs
@@ -96,6 +96,11 @@ namespace Opc.Ua.Sample
             {
                 ExceptionDlg.Show(m_telemetry, application.ApplicationName, e);
             }
+            finally
+            {
+                // ApplicationInstance is only IAsyncDisposable, and Main is synchronous
+                application.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
         }
     }
 }

--- a/Samples/Client.Net4/UA Sample Client.csproj
+++ b/Samples/Client.Net4/UA Sample Client.csproj
@@ -34,10 +34,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Bindings.Https">
       <Version>2.0.0-preview.2</Version>

--- a/Samples/ClientControls.Net4/ClientUtils.cs
+++ b/Samples/ClientControls.Net4/ClientUtils.cs
@@ -317,7 +317,7 @@ namespace Opc.Ua.Client.Controls
         /// <returns>
         /// The references found. Null if an error occurred.
         /// </returns>
-        public static Task<List<ReferenceDescription>> BrowseAsync(ISession session, List<BrowseDescription> nodesToBrowse, bool throwOnError, CancellationToken ct = default)
+        public static Task<List<ReferenceDescription>> BrowseAsync(ISession session, IReadOnlyList<BrowseDescription> nodesToBrowse, bool throwOnError, CancellationToken ct = default)
         {
             return BrowseAsync(session, null, nodesToBrowse, throwOnError, ct);
         }
@@ -325,7 +325,7 @@ namespace Opc.Ua.Client.Controls
         /// <summary>
         /// Browses the address space and returns the references found.
         /// </summary>
-        public static async Task<List<ReferenceDescription>> BrowseAsync(ISession session, ViewDescription view, List<BrowseDescription> nodesToBrowse, bool throwOnError, CancellationToken ct = default)
+        public static async Task<List<ReferenceDescription>> BrowseAsync(ISession session, ViewDescription view, IReadOnlyList<BrowseDescription> nodesToBrowse, bool throwOnError, CancellationToken ct = default)
         {
             try
             {
@@ -338,7 +338,7 @@ namespace Opc.Ua.Client.Controls
                         null,
                         view,
                         0,
-                        nodesToBrowse,
+                        nodesToBrowse.ToArrayOf(),
                         ct);
 
                     var results = response.Results.ToList();
@@ -1075,7 +1075,7 @@ namespace Opc.Ua.Client.Controls
 
                     if (!(instance.DataType).IsNull)
                     {
-                        instance.BuiltInType = TypeInfo.GetBuiltInType(instance.DataType, session.TypeTree);
+                        instance.BuiltInType = await TypeInfo.GetBuiltInTypeAsync(instance.DataType, session.TypeTree, ct);
                         instance.DataTypeDisplayText = await session.NodeCache.GetDisplayTextAsync(instance.DataType, ct);
 
                         if (instance.ValueRank >= 0)

--- a/Samples/ClientControls.Net4/Common/Client/EditComplexValue2Dlg.cs
+++ b/Samples/ClientControls.Net4/Common/Client/EditComplexValue2Dlg.cs
@@ -125,7 +125,7 @@ namespace Opc.Ua.Client.Controls
             XmlEncoder encoder = new XmlEncoder(new XmlQualifiedName("Value", Namespaces.OpcUaXsd), writer, m_session.MessageContext);
             #pragma warning restore CA2000
             Variant valueToEncode = m_value;
-            encoder.WriteVariant("Value", ref valueToEncode);
+            encoder.WriteVariant("Value", in valueToEncode);
             writer.Close();
 
             ValueTB.Text = buffer.ToString();

--- a/Samples/ClientControls.Net4/Common/Client/EventListViewCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/EventListViewCtrl.cs
@@ -117,7 +117,7 @@ namespace Opc.Ua.Client.Controls
         /// <summary>
         /// Sets the filter to edit.
         /// </summary>
-        public void DisplayEvent(List<Variant> fields)
+        public void DisplayEvent(IList<Variant> fields)
         {
             if (m_filter != null)
             {

--- a/Samples/ClientControls.Net4/Common/Client/HistoryDataListView.cs
+++ b/Samples/ClientControls.Net4/Common/Client/HistoryDataListView.cs
@@ -694,7 +694,7 @@ namespace Opc.Ua.Client.Controls
             NodeId rootId,
             NodeState parent,
             RelativePath parentPath,
-            List<BrowsePath> browsePaths)
+            IList<BrowsePath> browsePaths)
         {
             List<BaseInstanceState> children = new List<BaseInstanceState>();
             parent.GetChildren(context, children);

--- a/Samples/ClientControls.Net4/Common/Client/HistoryEventCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/HistoryEventCtrl.cs
@@ -257,7 +257,7 @@ namespace Opc.Ua.Client.Controls
             NodeId rootId,
             NodeState parent,
             RelativePath parentPath,
-            List<BrowsePath> browsePaths)
+            IList<BrowsePath> browsePaths)
         {
             List<BaseInstanceState> children = new List<BaseInstanceState>();
             parent.GetChildren(context, children);

--- a/Samples/ClientControls.Net4/Common/Client/SubscribeEventsDlg.cs
+++ b/Samples/ClientControls.Net4/Common/Client/SubscribeEventsDlg.cs
@@ -518,7 +518,7 @@ namespace Opc.Ua.Client.Controls
             m_filter.Fields = fields;
         }
 
-        private void AddDefaultFilter(List<FilterDeclarationField> fields, string browsePath, bool displayInList)
+        private void AddDefaultFilter(IList<FilterDeclarationField> fields, string browsePath, bool displayInList)
         {
             FilterDeclarationField field = new FilterDeclarationField();
             field.InstanceDeclaration = new InstanceDeclaration();

--- a/Samples/ClientControls.Net4/Common/Client/ViewEventDetailsDlg.cs
+++ b/Samples/ClientControls.Net4/Common/Client/ViewEventDetailsDlg.cs
@@ -59,7 +59,7 @@ namespace Opc.Ua.Client.Controls
         /// <summary>
         /// Shows all fields for the current condition.
         /// </summary>
-        public bool ShowDialog(FilterDeclaration filter, List<Variant> fields)
+        public bool ShowDialog(FilterDeclaration filter, IList<Variant> fields)
         {
             // fill in dialog.
             for (int ii = 0; ii < filter.Fields.Count; ii++)

--- a/Samples/ClientControls.Net4/Common/EventListView.cs
+++ b/Samples/ClientControls.Net4/Common/EventListView.cs
@@ -315,7 +315,7 @@ namespace Opc.Ua.Client.Controls
         /// <summary>
         /// Returns the currently selected event at the specified index (null index is not valid).
         /// </summary>
-        public List<Variant> GetSelectedEvent(int index)
+        public IList<Variant> GetSelectedEvent(int index)
         {
             if (EventsLV.SelectedItems.Count > index)
             {

--- a/Samples/ClientControls.Net4/Common/FilterDeclaration.cs
+++ b/Samples/ClientControls.Net4/Common/FilterDeclaration.cs
@@ -50,10 +50,8 @@ namespace Opc.Ua.Client.Controls
         /// <summary>
         /// The fully inhierited list of instance declarations for the type.
         /// </summary>
-        #pragma warning disable CA1002 // Justification: sample public API shape is preserved by design.
         #pragma warning disable CA1051 // Justification: sample public API shape is preserved by design.
-        public List<InstanceDeclaration> Declarations;
-        #pragma warning restore CA1002
+        public IList<InstanceDeclaration> Declarations;
         #pragma warning restore CA1051
     }
 
@@ -73,7 +71,7 @@ namespace Opc.Ua.Client.Controls
         /// The browse path to the instance declaration.
         /// </summary>
         #pragma warning disable CA1051 // Justification: sample public API shape is preserved by design.
-        public List<QualifiedName> BrowsePath;
+        public IList<QualifiedName> BrowsePath;
         #pragma warning restore CA1051
 
         /// <summary>
@@ -339,7 +337,7 @@ namespace Opc.Ua.Client.Controls
         public EventFilter GetFilter()
         {
             EventFilter filter = new EventFilter();
-            filter.SelectClauses = GetSelectClause();
+            filter.SelectClauses = GetSelectClause().ToArrayOf();
             filter.WhereClause = GetWhereClause();
             return filter;
         }
@@ -419,7 +417,7 @@ namespace Opc.Ua.Client.Controls
         /// <summary>
         /// Returns the select clause defined by the filter declaration.
         /// </summary>
-        public List<SimpleAttributeOperand> GetSelectClause()
+        public IList<SimpleAttributeOperand> GetSelectClause()
         {
             List<SimpleAttributeOperand> selectClause = new List<SimpleAttributeOperand>();
 
@@ -435,7 +433,7 @@ namespace Opc.Ua.Client.Controls
                     operand = new SimpleAttributeOperand();
                     operand.TypeDefinitionId = field.InstanceDeclaration.RootTypeId;
                     operand.AttributeId = (field.InstanceDeclaration.NodeClass == NodeClass.Object) ? Attributes.NodeId : Attributes.Value;
-                    operand.BrowsePath = field.InstanceDeclaration.BrowsePath;
+                    operand.BrowsePath = field.InstanceDeclaration.BrowsePath.ToArrayOf();
                     selectClause.Add(operand);
                 }
             }
@@ -460,7 +458,7 @@ namespace Opc.Ua.Client.Controls
                     SimpleAttributeOperand operand1 = new SimpleAttributeOperand();
                     operand1.TypeDefinitionId = field.InstanceDeclaration.RootTypeId;
                     operand1.AttributeId = (field.InstanceDeclaration.NodeClass == NodeClass.Object) ? Attributes.NodeId : Attributes.Value;
-                    operand1.BrowsePath = field.InstanceDeclaration.BrowsePath;
+                    operand1.BrowsePath = field.InstanceDeclaration.BrowsePath.ToArrayOf();
 
                     LiteralOperand operand2 = new LiteralOperand();
                     operand2.Value = field.FilterValue;
@@ -476,7 +474,7 @@ namespace Opc.Ua.Client.Controls
         /// <summary>
         /// Returns the value for the specified browse name.
         /// </summary>
-        public T GetValue<T>(QualifiedName browseName, List<Variant> fields, T defaultValue)
+        public T GetValue<T>(QualifiedName browseName, IList<Variant> fields, T defaultValue)
         {
             if (fields == null || fields.Count == 0)
             {
@@ -521,10 +519,8 @@ namespace Opc.Ua.Client.Controls
         /// <summary>
         /// The list of declarations for the fields.
         /// </summary>
-        #pragma warning disable CA1002 // Justification: sample public API shape is preserved by design.
         #pragma warning disable CA1051 // Justification: sample public API shape is preserved by design.
-        public List<FilterDeclarationField> Fields;
-        #pragma warning restore CA1002
+        public IList<FilterDeclarationField> Fields;
         #pragma warning restore CA1051
     }
 }

--- a/Samples/ClientControls.Net4/Configuration/Common (OLD)/GuiUtils.cs
+++ b/Samples/ClientControls.Net4/Configuration/Common (OLD)/GuiUtils.cs
@@ -624,10 +624,10 @@ namespace Opc.Ua.Client.Controls
 
             // Strip common separators and prefixes so both "0x0A, 0x0B" and "0A0B" work.
             string cleaned = text
-                .Replace("0x", String.Empty)
-                .Replace("0X", String.Empty)
-                .Replace(",", String.Empty)
-                .Replace("-", String.Empty);
+                .Replace("0x", String.Empty, StringComparison.Ordinal)
+                .Replace("0X", String.Empty, StringComparison.Ordinal)
+                .Replace(",", String.Empty, StringComparison.Ordinal)
+                .Replace("-", String.Empty, StringComparison.Ordinal);
 
             var hexOnly = new StringBuilder(cleaned.Length);
 

--- a/Samples/ClientControls.Net4/Configuration/SelectUrlsCtrl.cs
+++ b/Samples/ClientControls.Net4/Configuration/SelectUrlsCtrl.cs
@@ -57,7 +57,7 @@ namespace Opc.Ua.Client.Controls
         #region Private Fields
         private event EventHandler m_UrlsChanged;
         private ITelemetryContext m_telemetry;
-        private List<Uri> m_urls;
+        private IList<Uri> m_urls;
         #endregion
 
         #region Public Interface
@@ -65,10 +65,8 @@ namespace Opc.Ua.Client.Controls
         /// The list of urls.
         /// </summary>
         [System.ComponentModel.DesignerSerializationVisibility(System.ComponentModel.DesignerSerializationVisibility.Hidden)]
-        #pragma warning disable CA1002 // Justification: sample public API shape is preserved by design.
         #pragma warning disable CA2227 // Justification: sample public API shape is preserved by design.
-        public List<Uri> Urls
-        #pragma warning restore CA1002
+        public IList<Uri> Urls
         #pragma warning restore CA2227
         {
             get

--- a/Samples/ClientControls.Net4/Endpoints/ConfiguredServerDlg.cs
+++ b/Samples/ClientControls.Net4/Endpoints/ConfiguredServerDlg.cs
@@ -332,7 +332,7 @@ namespace Opc.Ua.Client.Controls
         #endregion
 
         #region Public Interface
-        public List<EndpointDescription> AvailableEnpoints
+        public IList<EndpointDescription> AvailableEnpoints
         {
             get { return m_availableEndpoints; }
         }

--- a/Samples/ClientControls.Net4/UA Client Controls.csproj
+++ b/Samples/ClientControls.Net4/UA Client Controls.csproj
@@ -182,7 +182,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Core">
       <Version>2.0.0-preview.2</Version>

--- a/Samples/Controls.Net4/Common/ArgumentListCtrl.cs
+++ b/Samples/Controls.Net4/Common/ArgumentListCtrl.cs
@@ -137,7 +137,8 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Returns the argument values
         /// </summary>
-        public List<Variant> GetValues()
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1024:Use properties where appropriate", Justification = "Each call reads the list view and builds a new list, and the matching setter is asynchronous.")]
+        public IList<Variant> GetValues()
         {
             List<Variant> values = new List<Variant>();
 
@@ -157,7 +158,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Updates the argument values.
         /// </summary>
-        public async Task SetValuesAsync(List<Variant> values, CancellationToken ct = default)
+        public async Task SetValuesAsync(IList<Variant> values, CancellationToken ct = default)
         {
             int ii = 0;
 

--- a/Samples/Controls.Net4/Common/CallMethodDlg.cs
+++ b/Samples/Controls.Net4/Common/CallMethodDlg.cs
@@ -111,13 +111,13 @@ namespace Opc.Ua.Sample.Controls
         {
             try
             {
-                List<Variant> inputArguments = InputArgumentsCTRL.GetValues();
+                IList<Variant> inputArguments = InputArgumentsCTRL.GetValues();
 
                 CallMethodRequest request = new CallMethodRequest();
 
                 request.ObjectId = m_objectId;
                 request.MethodId = m_methodId;
-                request.InputArguments = inputArguments;
+                request.InputArguments = inputArguments.ToArrayOf();
 
                 List<CallMethodRequest> requests = new List<CallMethodRequest>();
                 requests.Add(request);

--- a/Samples/Controls.Net4/Common/DataValueListCtrl.cs
+++ b/Samples/Controls.Net4/Common/DataValueListCtrl.cs
@@ -93,12 +93,11 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Sets the nodes in the control.
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1002:Do not expose generic lists", Justification = "Sample code preserves existing public API and behavior.")]
         public async Task InitializeAsync(
             Session session,
-            List<ReadValueId> valueIds,
-            List<DataValue> values,
-            List<ServiceResult> results,
+            IList<ReadValueId> valueIds,
+            IList<DataValue> values,
+            IList<ServiceResult> results,
             CancellationToken ct = default)
         {
             if (session == null) throw new ArgumentNullException(nameof(session));
@@ -139,11 +138,10 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Sets the nodes in the control.
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1002:Do not expose generic lists", Justification = "Sample code preserves existing public API and behavior.")]
         public async Task InitializeAsync(
             Session session,
-            List<WriteValue> values,
-            List<ServiceResult> results,
+            IList<WriteValue> values,
+            IList<ServiceResult> results,
             CancellationToken ct = default)
         {
             if (session == null) throw new ArgumentNullException(nameof(session));

--- a/Samples/Controls.Net4/Common/FindNodeDlg.cs
+++ b/Samples/Controls.Net4/Common/FindNodeDlg.cs
@@ -55,7 +55,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Displays the dialog.
         /// </summary>
-        public List<NodeId> ShowDialog(Session session, NodeId startNodeId)
+        public IList<NodeId> ShowDialog(Session session, NodeId startNodeId)
         {
             m_session = session;
 

--- a/Samples/Controls.Net4/Common/NodeListCtrl.cs
+++ b/Samples/Controls.Net4/Common/NodeListCtrl.cs
@@ -53,7 +53,7 @@ namespace Opc.Ua.Sample.Controls
 
         #region Private Fields
         private Session m_session;
-        private List<NodeId> m_nodeIds;
+        private IList<NodeId> m_nodeIds;
         private NodeClass m_nodeClassMask;
 
         /// <summary>
@@ -80,7 +80,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Sets the nodes in the control.
         /// </summary>
-        public async Task InitializeAsync(Session session, List<NodeId> nodeIds, NodeClass nodeClassMask, ITelemetryContext telemetry, CancellationToken ct = default)
+        public async Task InitializeAsync(Session session, IList<NodeId> nodeIds, NodeClass nodeClassMask, ITelemetryContext telemetry, CancellationToken ct = default)
         {
             if (session == null) throw new ArgumentNullException(nameof(session));
 
@@ -174,7 +174,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Returns the node ids in the control.
         /// </summary>
-        public List<NodeId> GetNodeIds()
+        public IList<NodeId> GetNodeIds()
         {
             List<NodeId> nodeIds = new List<NodeId>();
 

--- a/Samples/Controls.Net4/Common/SelectNodesDlg.cs
+++ b/Samples/Controls.Net4/Common/SelectNodesDlg.cs
@@ -61,10 +61,10 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Displays the dialog.
         /// </summary>
-        public async Task<List<NodeId>> ShowDialogAsync(
+        public async Task<IList<NodeId>> ShowDialogAsync(
             Session session,
             BrowseViewType browseView,
-            List<NodeId> nodesIds,
+            IList<NodeId> nodesIds,
             NodeClass nodeClassMask,
             ITelemetryContext telemetry,
             CancellationToken ct = default)

--- a/Samples/Controls.Net4/Sessions/BrowseTreeCtrl.cs
+++ b/Samples/Controls.Net4/Sessions/BrowseTreeCtrl.cs
@@ -66,7 +66,7 @@ namespace Opc.Ua.Sample.Controls
         private bool m_showReferences;
         private TreeNode m_nodeToBrowse;
         private ReferenceDescription m_parent;
-        private List<ReferenceDescription> m_references;
+        private IList<ReferenceDescription> m_references;
         private event NodesSelectedEventHandler m_ItemsSelected;
         private event MethodCalledEventHandler m_MethodCalled;
         private BrowserEventHandler m_BrowserMoreReferences;
@@ -109,7 +109,7 @@ namespace Opc.Ua.Sample.Controls
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA2227:Collection properties should be read only", Justification = "Sample code preserves existing public API and behavior.")]
         [System.ComponentModel.DesignerSerializationVisibility(System.ComponentModel.DesignerSerializationVisibility.Hidden)]
-        public List<ReferenceDescription> SelectedReferences
+        public IList<ReferenceDescription> SelectedReferences
         {
             get
             {
@@ -1271,7 +1271,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Creates a new instance.
         /// </summary>
-        internal NodesSelectedEventArgs(ExpandedNodeId sourceId, List<ReferenceDescription> references)
+        internal NodesSelectedEventArgs(ExpandedNodeId sourceId, IList<ReferenceDescription> references)
         {
             m_sourceId = sourceId;
             m_references = references;
@@ -1298,7 +1298,7 @@ namespace Opc.Ua.Sample.Controls
 
         #region Private Fields
         private ExpandedNodeId m_sourceId;
-        private List<ReferenceDescription> m_references;
+        private IList<ReferenceDescription> m_references;
         #endregion
     }
 

--- a/Samples/Controls.Net4/Sessions/CreateSecureChannelDlg.cs
+++ b/Samples/Controls.Net4/Sessions/CreateSecureChannelDlg.cs
@@ -58,7 +58,7 @@ namespace Opc.Ua.Sample.Controls
 
         private ITransportChannel m_channel;
         private ApplicationConfiguration m_configuration;
-        private List<EndpointDescription> m_endpoints;
+        private IList<EndpointDescription> m_endpoints;
         private ServiceMessageContext m_messageContext;
         private ITelemetryContext m_telemetry;
 
@@ -67,7 +67,7 @@ namespace Opc.Ua.Sample.Controls
         /// </summary>
         public ITransportChannel ShowDialog(
             ApplicationConfiguration configuration,
-            List<EndpointDescription> endpoints)
+            IList<EndpointDescription> endpoints)
         {
             if (endpoints == null) throw new ArgumentNullException(nameof(endpoints));
             if (configuration == null) throw new ArgumentNullException(nameof(configuration));

--- a/Samples/Controls.Net4/Sessions/SessionTreeCtrl.cs
+++ b/Samples/Controls.Net4/Sessions/SessionTreeCtrl.cs
@@ -182,7 +182,7 @@ namespace Opc.Ua.Sample.Controls
 
             Telemetry = telemetry;
 
-            List<EndpointDescription> availableEndpoints = null;
+            IList<EndpointDescription> availableEndpoints = null;
 
             // check if the endpoint needs to be updated.
             if (endpoint.UpdateBeforeConnect)
@@ -244,7 +244,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Opens a new session.
         /// </summary>
-        public async Task<Session> ConnectAsync(ConfiguredEndpoint endpoint, ITransportChannel channel, List<EndpointDescription> availableEndpoints, ITelemetryContext telemetry, CancellationToken ct = default)
+        public async Task<Session> ConnectAsync(ConfiguredEndpoint endpoint, ITransportChannel channel, IList<EndpointDescription> availableEndpoints, ITelemetryContext telemetry, CancellationToken ct = default)
         {
             if (channel == null) throw new ArgumentNullException(nameof(channel));
 

--- a/Samples/Controls.Net4/Subscriptions/ContentFilterElementListCtrl.cs
+++ b/Samples/Controls.Net4/Subscriptions/ContentFilterElementListCtrl.cs
@@ -126,8 +126,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Returns the list of elements in the control.
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1002:Do not expose generic lists", Justification = "Sample code preserves existing public API and behavior.")]
-        public List<ContentFilterElement> GetElements()
+        public IList<ContentFilterElement> GetElements()
         {
             List<ContentFilterElement> elements = new List<ContentFilterElement>();
 

--- a/Samples/Controls.Net4/Subscriptions/EventFilterDlg.cs
+++ b/Samples/Controls.Net4/Subscriptions/EventFilterDlg.cs
@@ -114,7 +114,7 @@ namespace Opc.Ua.Sample.Controls
                 {
                     foreach (object item in e.Items)
                     {
-                        List<ContentFilterElement> elements = ContentFilterCTRL.GetElements();
+                        IList<ContentFilterElement> elements = ContentFilterCTRL.GetElements();
 
                         for (int ii = 0; ii < elements.Count; ii++)
                         {

--- a/Samples/Controls.Net4/Subscriptions/FilterOperandListCtrl.cs
+++ b/Samples/Controls.Net4/Subscriptions/FilterOperandListCtrl.cs
@@ -105,8 +105,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Returns the list of operands in the control.
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1002:Do not expose generic lists", Justification = "Sample code preserves existing public API and behavior.")]
-        public List<FilterOperand> GetOperands()
+        public IList<FilterOperand> GetOperands()
         {
             List<FilterOperand> operands = new List<FilterOperand>();
 

--- a/Samples/Controls.Net4/Subscriptions/HistoryReadDlg.cs
+++ b/Samples/Controls.Net4/Subscriptions/HistoryReadDlg.cs
@@ -62,7 +62,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Displays the dialog.
         /// </summary>
-        public void Show(Session session, List<ReadValueId> valueIds, ITelemetryContext telemetry)
+        public void Show(Session session, IList<ReadValueId> valueIds, ITelemetryContext telemetry)
         {
             if (session == null) throw new ArgumentNullException(nameof(session));
 
@@ -79,7 +79,7 @@ namespace Opc.Ua.Sample.Controls
 
         private async Task ReadAsync(CancellationToken ct = default)
         {
-            List<ReadValueId> nodesToRead = ReadValuesCTRL.GetValueIds();
+            List<ReadValueId> nodesToRead = ReadValuesCTRL.GetValueIds().ToList();
 
             if (nodesToRead == null || nodesToRead.Count == 0)
             {

--- a/Samples/Controls.Net4/Subscriptions/ReadDlg.cs
+++ b/Samples/Controls.Net4/Subscriptions/ReadDlg.cs
@@ -62,7 +62,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Displays the dialog.
         /// </summary>
-        public async Task ShowAsync(Session session, List<ReadValueId> valueIds, ITelemetryContext telemetry, CancellationToken ct = default)
+        public async Task ShowAsync(Session session, IList<ReadValueId> valueIds, ITelemetryContext telemetry, CancellationToken ct = default)
         {
             if (session == null) throw new ArgumentNullException(nameof(session));
 
@@ -79,7 +79,7 @@ namespace Opc.Ua.Sample.Controls
 
         private async Task ReadAsync(CancellationToken ct = default)
         {
-            List<ReadValueId> nodesToRead = ReadValuesCTRL.GetValueIds();
+            List<ReadValueId> nodesToRead = ReadValuesCTRL.GetValueIds().ToList();
 
             if (nodesToRead == null || nodesToRead.Count == 0)
             {

--- a/Samples/Controls.Net4/Subscriptions/ReadValueListCtrl.cs
+++ b/Samples/Controls.Net4/Subscriptions/ReadValueListCtrl.cs
@@ -79,7 +79,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Sets the nodes in the control.
         /// </summary>
-        public void Initialize(Session session, List<ReadValueId> valueIds, ITelemetryContext telemetry)
+        public void Initialize(Session session, IList<ReadValueId> valueIds, ITelemetryContext telemetry)
         {
             if (session == null) throw new ArgumentNullException(nameof(session));
 
@@ -128,7 +128,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Returns the items in the control.
         /// </summary>
-        public List<ReadValueId> GetValueIds()
+        public IList<ReadValueId> GetValueIds()
         {
             List<ReadValueId> valueIds = new List<ReadValueId>();
 

--- a/Samples/Controls.Net4/Subscriptions/SelectClauseListCtrl.cs
+++ b/Samples/Controls.Net4/Subscriptions/SelectClauseListCtrl.cs
@@ -52,7 +52,7 @@ namespace Opc.Ua.Sample.Controls
 
         #region Private Fields
         private Session m_session;
-        private List<SimpleAttributeOperand> m_selectClauses;
+        private IList<SimpleAttributeOperand> m_selectClauses;
 
         /// <summary>
 		/// The columns to display in the control.
@@ -78,7 +78,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Sets the nodes in the control.
         /// </summary>
-        public void Initialize(Session session, List<SimpleAttributeOperand> selectClauses)
+        public void Initialize(Session session, IList<SimpleAttributeOperand> selectClauses)
         {
             if (session == null) throw new ArgumentNullException(nameof(session));
 
@@ -137,7 +137,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Returns the SelectClauses in the control.
         /// </summary>
-        public List<SimpleAttributeOperand> GetSelectClauses()
+        public IList<SimpleAttributeOperand> GetSelectClauses()
         {
             List<SimpleAttributeOperand> clauses = new List<SimpleAttributeOperand>();
 

--- a/Samples/Controls.Net4/Subscriptions/WriteDlg.cs
+++ b/Samples/Controls.Net4/Subscriptions/WriteDlg.cs
@@ -62,7 +62,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Displays the dialog.
         /// </summary>
-        public async Task ShowAsync(Session session, List<WriteValue> values, ITelemetryContext telemetry, CancellationToken ct = default)
+        public async Task ShowAsync(Session session, IList<WriteValue> values, ITelemetryContext telemetry, CancellationToken ct = default)
         {
             if (session == null) throw new ArgumentNullException(nameof(session));
 

--- a/Samples/Controls.Net4/Subscriptions/WriteValueListCtrl.cs
+++ b/Samples/Controls.Net4/Subscriptions/WriteValueListCtrl.cs
@@ -82,7 +82,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Sets the nodes in the control.
         /// </summary>
-        public void Initialize(Session session, List<WriteValue> values, ITelemetryContext telemetry)
+        public void Initialize(Session session, IList<WriteValue> values, ITelemetryContext telemetry)
         {
             if (session == null) throw new ArgumentNullException(nameof(session));
 
@@ -136,7 +136,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Returns the items in the control.
         /// </summary>
-        public List<WriteValue> GetValues()
+        public IList<WriteValue> GetValues()
         {
             List<WriteValue> values = new List<WriteValue>();
 

--- a/Samples/Controls.Net4/UA Sample Controls.csproj
+++ b/Samples/Controls.Net4/UA Sample Controls.csproj
@@ -101,7 +101,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client.ComplexTypes">
       <Version>2.0.0-preview.2</Version>

--- a/Samples/GDS/Client/Controls/ApplicationCertificateControl.cs
+++ b/Samples/GDS/Client/Controls/ApplicationCertificateControl.cs
@@ -399,7 +399,7 @@ certificateRequest);
                     }
 
                     if (!String.IsNullOrEmpty(id.SubjectName) &&
-                        x509.Subject.IndexOf(id.SubjectName, StringComparison.OrdinalIgnoreCase) >= 0)
+                        x509.Subject.Contains(id.SubjectName, StringComparison.OrdinalIgnoreCase))
                     {
                         return x509;
                     }

--- a/Samples/GDS/Client/GlobalDiscoveryClient.csproj
+++ b/Samples/GDS/Client/GlobalDiscoveryClient.csproj
@@ -47,7 +47,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration">
       <Version>2.0.0-preview.2</Version>

--- a/Samples/GDS/Client/MainForm.Designer.cs
+++ b/Samples/GDS/Client/MainForm.Designer.cs
@@ -29,9 +29,11 @@ namespace Opc.Ua.Gds.Client
         /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
         protected override void Dispose(bool disposing)
         {
-            if (disposing && (components != null))
+            if (disposing)
             {
-                components.Dispose();
+                components?.Dispose();
+                // LocalDiscoveryServerClient is only IAsyncDisposable, and Dispose is synchronous
+                m_lds?.DisposeAsync().AsTask().GetAwaiter().GetResult();
             }
             base.Dispose(disposing);
         }

--- a/Samples/GDS/Client/MainForm.cs
+++ b/Samples/GDS/Client/MainForm.cs
@@ -52,17 +52,11 @@ namespace Opc.Ua.Gds.Client
             m_application = application;
             m_telemetry = telemetry;
 
-            // get the configuration.
-            m_configuration = null;
-
-            // use suitable defaults if no configuration exists.
-            if (m_configuration == null)
-            {
-                m_configuration = new GlobalDiscoveryClientConfiguration() {
-                    GlobalDiscoveryServerUrl = "opc.tcp://localhost:58810/GlobalDiscoveryServer",
-                    ExternalEditor = "notepad.exe"
-                };
-            }
+            // the sample keeps no persisted configuration, so start from suitable defaults.
+            m_configuration = new GlobalDiscoveryClientConfiguration() {
+                GlobalDiscoveryServerUrl = "opc.tcp://localhost:58810/GlobalDiscoveryServer",
+                ExternalEditor = "notepad.exe"
+            };
 
             m_filters = new QueryServersFilter();
             m_identity = new UserIdentity();
@@ -459,7 +453,7 @@ namespace Opc.Ua.Gds.Client
             {
                 if (m_server.IsConnected)
                 {
-                    m_server.DisconnectAsync().GetAwaiter().GetResult();
+                    m_server.DisconnectAsync().AsTask().GetAwaiter().GetResult();
                     UpdateStatus(true, DateTime.UtcNow, "Disconnected {0}", m_server.Endpoint);
                     await ServerStatusPanel.InitializeAsync(null, m_telemetry);
                 }
@@ -477,7 +471,7 @@ namespace Opc.Ua.Gds.Client
                 if (!m_gdsConfigured)
                 {
                     #pragma warning disable CA2000 // Justification: WinForms/sample ownership or lifetime is managed outside the local scope.
-                    string uri = new SelectGdsDialog().ShowDialog(null, m_gds, m_gds.GetDefaultGdsUrlsAsync(m_lds).GetAwaiter().GetResult(), m_telemetry);
+                    string uri = new SelectGdsDialog().ShowDialog(null, m_gds, m_gds.GetDefaultGdsUrlsAsync(m_lds).AsTask().GetAwaiter().GetResult(), m_telemetry);
                     #pragma warning restore CA2000
                     if (uri != null)
                     {
@@ -634,12 +628,12 @@ namespace Opc.Ua.Gds.Client
         private void SelectGdsButton_Click(object sender, EventArgs e)
         {
             m_gds.AdminCredentials = null;
-            m_gds.DisconnectAsync().GetAwaiter().GetResult();
+            m_gds.DisconnectAsync().AsTask().GetAwaiter().GetResult();
             m_gdsConfigured = false;
             UpdateGdsStatus(true, DateTime.UtcNow, "Disconnected");
 
             #pragma warning disable CA2000 // Justification: WinForms/sample ownership or lifetime is managed outside the local scope.
-            string uri = new SelectGdsDialog().ShowDialog(null, m_gds, m_gds.GetDefaultGdsUrlsAsync(m_lds).GetAwaiter().GetResult(), m_telemetry);
+            string uri = new SelectGdsDialog().ShowDialog(null, m_gds, m_gds.GetDefaultGdsUrlsAsync(m_lds).AsTask().GetAwaiter().GetResult(), m_telemetry);
             #pragma warning restore CA2000
             if (uri != null)
             {

--- a/Samples/GDS/Client/Program.cs
+++ b/Samples/GDS/Client/Program.cs
@@ -88,6 +88,11 @@ namespace Opc.Ua.Gds.Client
             {
                 ExceptionDlg.Show(m_telemetry, application.ApplicationName, e);
             }
+            finally
+            {
+                // ApplicationInstance is only IAsyncDisposable, and Main is synchronous
+                application.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
         }
     }
 }

--- a/Samples/GDS/ClientControls/Controls/DiscoveryUrlsDialog.cs
+++ b/Samples/GDS/ClientControls/Controls/DiscoveryUrlsDialog.cs
@@ -46,9 +46,7 @@ namespace Opc.Ua.Gds.Client.Controls
         private List<string> m_discoveryUrls;
         private ILogger m_logger = LoggerUtils.Null.Logger;
 
-        #pragma warning disable CA1002 // Justification: Public sample API compatibility is preserved.
-        public List<string> ShowDialog(ILogger logger, IWin32Window owner, IList<string> discoveryUrls)
-        #pragma warning restore CA1002
+        public IList<string> ShowDialog(ILogger logger, IWin32Window owner, IList<string> discoveryUrls)
         {
             m_logger = logger;
             StringBuilder builder = new StringBuilder();

--- a/Samples/GDS/ClientControls/Controls/EditValueCtrl.cs
+++ b/Samples/GDS/ClientControls/Controls/EditValueCtrl.cs
@@ -1544,7 +1544,7 @@ namespace Opc.Ua.Gds.Client.Controls
                 LocalizedText v => Variant.From(v),
                 ExtensionObject v => Variant.From(v),
                 DataValue v => Variant.From(v),
-                Variant v => Variant.From(ref v),
+                Variant v => Variant.From(in v),
                 IEncodeable v => Variant.From(new ExtensionObject(v)),
                 _ => Variant.Null
             };

--- a/Samples/GDS/ClientControls/Controls/ServerCapabilitiesDialog.cs
+++ b/Samples/GDS/ClientControls/Controls/ServerCapabilitiesDialog.cs
@@ -47,9 +47,7 @@ namespace Opc.Ua.Gds.Client.Controls
 
         private List<GdsServerCapability> m_capabilities;
 
-        #pragma warning disable CA1002 // Justification: Public sample API compatibility is preserved.
-        public List<string> ShowDialog(IWin32Window owner, IList<string> serverCapabilities)
-        #pragma warning restore CA1002
+        public IList<string> ShowDialog(IWin32Window owner, IList<string> serverCapabilities)
         {
             CapabilitiesListBox.Items.Clear();
 

--- a/Samples/GDS/ClientControls/Controls/ViewServersOnNetworkDialog.cs
+++ b/Samples/GDS/ClientControls/Controls/ViewServersOnNetworkDialog.cs
@@ -70,9 +70,7 @@ namespace Opc.Ua.Gds.Client.Controls
         private GlobalDiscoveryServerClient m_gds;
         private ITelemetryContext m_telemetry;
 
-        #pragma warning disable CA1002 // Justification: Public sample API compatibility is preserved.
-        public List<ServerOnNetwork> ShowDialog(IWin32Window owner, ref QueryServersFilter filters)
-        #pragma warning restore CA1002
+        public IList<ServerOnNetwork> ShowDialog(IWin32Window owner, ref QueryServersFilter filters)
         {
             ServersTable.Rows.Clear();
 

--- a/Samples/GDS/ClientControls/GlobalDiscoveryClientControls.csproj
+++ b/Samples/GDS/ClientControls/GlobalDiscoveryClientControls.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client">
       <Version>2.0.0-preview.2</Version>

--- a/Samples/GDS/Common/GlobalDiscoveryServerAliasMerger.cs
+++ b/Samples/GDS/Common/GlobalDiscoveryServerAliasMerger.cs
@@ -192,6 +192,7 @@ namespace Opc.Ua.Gds.Server
         /// registration hook so a newly registered server's aliases are
         /// merged without waiting for the next periodic sweep.
         /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1054:URI-like parameters should not be strings", Justification = "The application URI is a string in ApplicationRecordDataType and is used here as a key.")]
         public void QueueMerge(string applicationUri, IList<string> discoveryUrls)
         {
             if (m_configuration == null)
@@ -286,6 +287,7 @@ namespace Opc.Ua.Gds.Server
         /// aliases and as the replace key.</param>
         /// <param name="discoveryUrls">The server's discovery URLs.</param>
         /// <param name="ct">A cancellation token.</param>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1054:URI-like parameters should not be strings", Justification = "The application URI is a string in ApplicationRecordDataType and is used here as a key.")]
         public async Task MergeServerAsync(
             string applicationUri,
             IList<string> discoveryUrls,

--- a/Samples/GDS/ConsoleServer/NetCoreGlobalDiscoveryServer.csproj
+++ b/Samples/GDS/ConsoleServer/NetCoreGlobalDiscoveryServer.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.11" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="Mono.Options" Version="6.12.0.148" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client" Version="2.0.0-preview.2" />

--- a/Samples/GDS/ConsoleServer/Program.cs
+++ b/Samples/GDS/ConsoleServer/Program.cs
@@ -167,6 +167,7 @@ namespace Opc.Ua.Gds.Server
         private IApplicationsDatabase m_database;
         private LdsScannerConfiguration m_ldsScannerConfiguration;
         private GlobalDiscoveryServerAliasMerger m_aliasMerger;
+        private ApplicationInstance m_application;
         #pragma warning disable CA2211 // Justification: Public sample API compatibility is preserved.
         public static ExitCode exitCode;
         #pragma warning restore CA2211
@@ -258,6 +259,12 @@ namespace Opc.Ua.Gds.Server
                     await status.ConfigureAwait(false);
                     // Stop server and dispose
                     await _server.StopAsync();
+                }
+
+                if (m_application != null)
+                {
+                    await m_application.DisposeAsync().ConfigureAwait(false);
+                    m_application = null;
                 }
             }
 
@@ -368,7 +375,7 @@ namespace Opc.Ua.Gds.Server
         private async Task ConsoleGlobalDiscoveryServerAsync(ITelemetryContext telemetry)
         {
             ApplicationInstance.MessageDlg = new ApplicationMessageDlg();
-            var application = new ApplicationInstance(telemetry)
+            m_application = new ApplicationInstance(telemetry)
             {
                 ApplicationName = "Global Discovery Server",
                 ApplicationType = ApplicationType.Server,
@@ -376,10 +383,10 @@ namespace Opc.Ua.Gds.Server
             };
 
             // load the application configuration.
-            ApplicationConfiguration config = await application.LoadApplicationConfigurationAsync(false).ConfigureAwait(false);
+            ApplicationConfiguration config = await m_application.LoadApplicationConfigurationAsync(false).ConfigureAwait(false);
 
             // check the application certificate.
-            bool haveAppCertificate = await application.CheckApplicationInstanceCertificatesAsync(false).ConfigureAwait(false);
+            bool haveAppCertificate = await m_application.CheckApplicationInstanceCertificatesAsync(false).ConfigureAwait(false);
             if (!haveAppCertificate)
             {
                 #pragma warning disable CA2201 // Justification: Public sample API compatibility is preserved.
@@ -418,12 +425,14 @@ namespace Opc.Ua.Gds.Server
             server = new AliasMergingGlobalDiscoverySampleServer(
                 database,
                 database,
+                #pragma warning disable CA2000 // Justification: Certificate group ownership is transferred to the server.
                 new CertificateGroup(telemetry),
+                #pragma warning restore CA2000
                 userDatabase,
                 telemetry,
                 m_aliasMerger,
                 true);
-            await application.StartAsync(server).ConfigureAwait(false);
+            await m_application.StartAsync(server).ConfigureAwait(false);
 
             // keep the configuration and database so the interactive LDS scan
             // can register approved servers after start-up.
@@ -436,7 +445,7 @@ namespace Opc.Ua.Gds.Server
             m_aliasMerger.Start(config, database);
 
             // print endpoint info
-            IEnumerable<string> endpoints = application.Server.GetEndpoints().ToArray().Select(e => e.EndpointUrl).Distinct();
+            IEnumerable<string> endpoints = m_application.Server.GetEndpoints().ToArray().Select(e => e.EndpointUrl).Distinct();
             foreach (string endpoint in endpoints)
             {
                 Console.WriteLine(endpoint);

--- a/Samples/GDS/Server/GlobalDiscoveryServer.csproj
+++ b/Samples/GDS/Server/GlobalDiscoveryServer.csproj
@@ -31,13 +31,13 @@
     <Compile Include="..\Common\AliasMergingGlobalDiscoverySampleServer.cs" Link="Common\AliasMergingGlobalDiscoverySampleServer.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.11">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration">
       <Version>2.0.0-preview.2</Version>

--- a/Samples/GDS/Server/Program.cs
+++ b/Samples/GDS/Server/Program.cs
@@ -106,14 +106,16 @@ namespace Opc.Ua.Gds.Server
                 // GDS master AliasNames list (issue #274): merge each
                 // registered server's AliasNames into a master list served by
                 // this GDS.
-                var aliasMerger = new GlobalDiscoveryServerAliasMerger(m_telemetry);
+                using var aliasMerger = new GlobalDiscoveryServerAliasMerger(m_telemetry);
 
                 #pragma warning disable CA2000 // Justification: WinForms/sample ownership or lifetime is managed outside the local scope.
                 var server = new AliasMergingGlobalDiscoverySampleServer(
                 #pragma warning restore CA2000
                     database,
                     database,
+                    #pragma warning disable CA2000 // Justification: Certificate group ownership is transferred to the server.
                     new CertificateGroup(m_telemetry),
+                    #pragma warning restore CA2000
                     userDatabase,
                     m_telemetry,
                     aliasMerger,
@@ -123,23 +125,26 @@ namespace Opc.Ua.Gds.Server
                 // start refreshing the master AliasNames list and merge each
                 // server as soon as it registers.
                 aliasMerger.Start(application.ApplicationConfiguration, database);
-                database.ApplicationRegistered += (sender, app) =>
+                database.ApplicationRegistered += (sender, e) =>
                     aliasMerger.QueueMerge(
-                        app.ApplicationUri,
-                        app.DiscoveryUrls.IsNull
+                        e.Application.ApplicationUri,
+                        e.Application.DiscoveryUrls.IsNull
                             ? new List<string>()
-                            : app.DiscoveryUrls.ToArray());
+                            : e.Application.DiscoveryUrls.ToArray());
 
                 // run the application interactively.
                 #pragma warning disable CA2000 // Justification: WinForms/sample ownership or lifetime is managed outside the local scope.
                 System.Windows.Forms.Application.Run(new ServerForm(server, application.ApplicationConfiguration, m_telemetry));
                 #pragma warning restore CA2000
-
-                aliasMerger.Dispose();
             }
             catch (Exception e)
             {
                 ExceptionDlg.Show(m_telemetry, application.ApplicationName, e);
+            }
+            finally
+            {
+                // ApplicationInstance is only IAsyncDisposable, and Main is synchronous
+                application.DisposeAsync().AsTask().GetAwaiter().GetResult();
             }
         }
 

--- a/Samples/GDS/Server/SqlApplicationsDatabase.cs
+++ b/Samples/GDS/Server/SqlApplicationsDatabase.cs
@@ -38,6 +38,22 @@ using Opc.Ua.Gds.Server.DB;
 
 namespace Opc.Ua.Gds.Server.Database.Sql
 {
+    /// <summary>
+    /// Carries the application record of a server which has just (re-)registered.
+    /// </summary>
+    public class ApplicationRegisteredEventArgs : EventArgs
+    {
+        public ApplicationRegisteredEventArgs(ApplicationRecordDataType application)
+        {
+            Application = application;
+        }
+
+        /// <summary>
+        /// The record the server registered with.
+        /// </summary>
+        public ApplicationRecordDataType Application { get; }
+    }
+
     public class SqlApplicationsDatabase : ApplicationsDatabaseBase, ICertificateRequest
     {
         /// <summary>
@@ -45,7 +61,7 @@ namespace Opc.Ua.Gds.Server.Database.Sql
         /// The GDS host uses this to merge the newly registered server's
         /// AliasNames into the master AliasNames list (issue #274).
         /// </summary>
-        public event EventHandler<ApplicationRecordDataType> ApplicationRegistered;
+        public event EventHandler<ApplicationRegisteredEventArgs> ApplicationRegistered;
 
         #region IApplicationsDatabase Members
         public override void Initialize()
@@ -156,7 +172,7 @@ namespace Opc.Ua.Gds.Server.Database.Sql
                 entities.SaveChanges();
                 m_lastCounterResetTime = DateTime.UtcNow;
 
-                ApplicationRegistered?.Invoke(this, application);
+                ApplicationRegistered?.Invoke(this, new ApplicationRegisteredEventArgs(application));
 
                 return new NodeId(applicationId, NamespaceIndex); ;
             }

--- a/Samples/LDS/ConsoleServer/ConsoleLds.csproj
+++ b/Samples/LDS/ConsoleServer/ConsoleLds.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.11" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Lds.Server" Version="2.0.0-preview.2" />
   </ItemGroup>
 

--- a/Samples/Opc.Ua.Sample/Base/CustomNodeManager.cs
+++ b/Samples/Opc.Ua.Sample/Base/CustomNodeManager.cs
@@ -297,7 +297,7 @@ namespace Opc.Ua.Sample
             // must release the lock before removing cross references to other node managers.
             if (referencesToRemove.Count > 0)
             {
-                Server.NodeManager.RemoveReferencesAsync(referencesToRemove).GetAwaiter().GetResult();
+                Server.NodeManager.RemoveReferencesAsync(referencesToRemove).AsTask().GetAwaiter().GetResult();
             }
 
             return found;

--- a/Samples/Opc.Ua.Sample/Base/DataChangeMonitoredItem.cs
+++ b/Samples/Opc.Ua.Sample/Base/DataChangeMonitoredItem.cs
@@ -27,6 +27,10 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
+// the IDataChangeMonitoredItem members this class implements are annotated,
+// so the annotations need a nullable context to live in
+#nullable enable annotations
+
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/Samples/Opc.Ua.Sample/Base/SampleNodeManager.cs
+++ b/Samples/Opc.Ua.Sample/Base/SampleNodeManager.cs
@@ -286,7 +286,7 @@ namespace Opc.Ua.Sample
             // must release the lock before removing cross references to other node managers.
             if (referencesToRemove.Count > 0)
             {
-                Server.NodeManager.RemoveReferencesAsync(referencesToRemove).GetAwaiter().GetResult();
+                Server.NodeManager.RemoveReferencesAsync(referencesToRemove).AsTask().GetAwaiter().GetResult();
             }
 
             return found;

--- a/Samples/Opc.Ua.Sample/Boiler/BoilerState.cs
+++ b/Samples/Opc.Ua.Sample/Boiler/BoilerState.cs
@@ -36,6 +36,7 @@ using Opc.Ua;
 
 namespace Boiler
 {
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1001:Types that own disposable fields should be disposable", Justification = "Sample code preserves existing public API and behavior; the simulation timer is disposed on every state transition.")]
     public partial class BoilerState
     {
         #region Initialization
@@ -55,7 +56,7 @@ namespace Boiler
         /// <summary>
         /// Cleans up when the object is disposed.
         /// </summary>
-        protected new void Dispose(bool disposing)
+        protected void Dispose(bool disposing)
         {
             try
             {

--- a/Samples/Opc.Ua.Sample/MemoryBuffer/MemoryBufferState.cs
+++ b/Samples/Opc.Ua.Sample/MemoryBuffer/MemoryBufferState.cs
@@ -40,6 +40,7 @@ using Microsoft.Extensions.Logging;
 
 namespace MemoryBuffer
 {
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1001:Types that own disposable fields should be disposable", Justification = "Sample code preserves existing public API and behavior.")]
     public partial class MemoryBufferState
     {
         #region Constructors

--- a/Samples/Opc.Ua.Sample/Opc.Ua.Sample.csproj
+++ b/Samples/Opc.Ua.Sample/Opc.Ua.Sample.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.11" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Core" Version="2.0.0-preview.2" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server" Version="2.0.0-preview.2" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.SourceGeneration" Version="2.0.0-preview.2" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />

--- a/Samples/Opc.Ua.Sample/SampleServer.UserAuthentication.cs
+++ b/Samples/Opc.Ua.Sample/SampleServer.UserAuthentication.cs
@@ -163,9 +163,11 @@ namespace Opc.Ua.Sample
                     throw new ServiceResultException(StatusCodes.BadIdentityTokenRejected);
                 }
 
+#pragma warning disable CA2025 // Justification: the validation completes here, before the certificate leaves scope.
                 CertificateValidationResult validationResult = m_certificateValidator
                     .ValidateAsync(certificate, TrustListIdentifier.Users, System.Threading.CancellationToken.None)
                     .GetAwaiter().GetResult();
+#pragma warning restore CA2025
 
                 if (!validationResult.IsValid)
                 {

--- a/Samples/Opc.Ua.Sample/TestData/HistoryDataReader.cs
+++ b/Samples/Opc.Ua.Sample/TestData/HistoryDataReader.cs
@@ -109,7 +109,7 @@ namespace TestData
             TimestampsToReturn timestampsToReturn,
             NumericRange indexRange,
             QualifiedName dataEncoding,
-            List<DataValue> values)
+            IList<DataValue> values)
         {
             m_request = request;
 
@@ -154,7 +154,7 @@ namespace TestData
             TimestampsToReturn timestampsToReturn,
             NumericRange indexRange,
             QualifiedName dataEncoding,
-            List<DataValue> values)
+            IList<DataValue> values)
         {
             DataValue value = DataValue.Null;
 
@@ -203,7 +203,7 @@ namespace TestData
             TimestampsToReturn timestampsToReturn,
             NumericRange indexRange,
             QualifiedName dataEncoding,
-            List<DataValue> values,
+            IList<DataValue> values,
             DataValue value)
         {
             // ignore invalid case.

--- a/Samples/ReferenceClient/Program.cs
+++ b/Samples/ReferenceClient/Program.cs
@@ -95,6 +95,11 @@ namespace Quickstarts.ReferenceClient
             {
                 ExceptionDlg.Show(m_telemetry, application.ApplicationName, e);
             }
+            finally
+            {
+                // ApplicationInstance is only IAsyncDisposable, and Main is synchronous
+                application.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
         }
     }
 

--- a/Samples/ReferenceClient/Reference Client.csproj
+++ b/Samples/ReferenceClient/Reference Client.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Bindings.Https">
       <Version>2.0.0-preview.2</Version>

--- a/Samples/ReferenceServer/Program.cs
+++ b/Samples/ReferenceServer/Program.cs
@@ -141,6 +141,11 @@ namespace Quickstarts.ReferenceServer
             {
                 ExceptionDlg.Show(m_telemetry, application.ApplicationName, e);
             }
+            finally
+            {
+                // ApplicationInstance is only IAsyncDisposable, and Main is synchronous
+                application.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
         }
     }
 

--- a/Samples/ReferenceServer/Reference Server.csproj
+++ b/Samples/ReferenceServer/Reference Server.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Bindings.Https">
       <Version>2.0.0-preview.2</Version>

--- a/Samples/ReferenceServer/ReferenceServerUtils.cs
+++ b/Samples/ReferenceServer/ReferenceServerUtils.cs
@@ -362,7 +362,7 @@ namespace Quickstarts.ReferenceServer
         public static uint CreateError(
             uint code,
             OperationContext context,
-            List<DiagnosticInfo> diagnosticInfos,
+            IList<DiagnosticInfo> diagnosticInfos,
             int index,
             ILogger logger)
         {
@@ -381,8 +381,8 @@ namespace Quickstarts.ReferenceServer
         /// </summary>
         public static bool CreateError(
             uint code,
-            List<StatusCode> results,
-            List<DiagnosticInfo> diagnosticInfos,
+            IList<StatusCode> results,
+            IList<DiagnosticInfo> diagnosticInfos,
             OperationContext context,
             ILogger logger)
         {
@@ -403,8 +403,8 @@ namespace Quickstarts.ReferenceServer
         /// </summary>
         public static bool CreateError(
             uint code,
-            List<StatusCode> results,
-            List<DiagnosticInfo> diagnosticInfos,
+            IList<StatusCode> results,
+            IList<DiagnosticInfo> diagnosticInfos,
             int index,
             OperationContext context,
             ILogger logger)
@@ -425,8 +425,8 @@ namespace Quickstarts.ReferenceServer
         /// Creates a place holder in the lists for the results.
         /// </summary>
         public static void CreateSuccess(
-            List<StatusCode> results,
-            List<DiagnosticInfo> diagnosticInfos,
+            IList<StatusCode> results,
+            IList<DiagnosticInfo> diagnosticInfos,
             OperationContext context)
         {
             results.Add(StatusCodes.Good);
@@ -440,7 +440,7 @@ namespace Quickstarts.ReferenceServer
         /// <summary>
         /// Creates a collection of diagnostics from a set of errors.
         /// </summary>
-        public static List<DiagnosticInfo> CreateDiagnosticInfoCollection(
+        public static IList<DiagnosticInfo> CreateDiagnosticInfoCollection(
             OperationContext context,
             IList<ServiceResult> errors,
             ILogger logger)
@@ -472,11 +472,11 @@ namespace Quickstarts.ReferenceServer
         /// <summary>
         /// Creates a collection of status codes and diagnostics from a set of errors.
         /// </summary>
-        public static List<StatusCode> CreateStatusCodeCollection(
+        public static IList<StatusCode> CreateStatusCodeCollection(
             OperationContext context,
             IList<ServiceResult> errors,
             ILogger logger,
-            out List<DiagnosticInfo> diagnosticInfos)
+            out IList<DiagnosticInfo> diagnosticInfos)
         {
             diagnosticInfos = null;
 

--- a/Samples/Server.Net4/Program.cs
+++ b/Samples/Server.Net4/Program.cs
@@ -97,6 +97,11 @@ namespace Opc.Ua.Sample
             {
                 ExceptionDlg.Show(m_telemetry, application.ApplicationName, e);
             }
+            finally
+            {
+                // ApplicationInstance is only IAsyncDisposable, and Main is synchronous
+                application.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
         }
     }
 }

--- a/Samples/Server.Net4/UA Sample Server.csproj
+++ b/Samples/Server.Net4/UA Sample Server.csproj
@@ -33,10 +33,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Bindings.Https">
       <Version>2.0.0-preview.2</Version>

--- a/Samples/ServerControls.Net4/UA Server Controls.csproj
+++ b/Samples/ServerControls.Net4/UA Server Controls.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Core">
       <Version>2.0.0-preview.2</Version>

--- a/Tests/SampleClients.Tests/SampleClientTests.cs
+++ b/Tests/SampleClients.Tests/SampleClientTests.cs
@@ -141,7 +141,9 @@ namespace Opc.Ua.Samples.Tests
 
                         // blocks the message loop until the watchdog closes it, which is
                         // exactly what a sample error dialog does in a test run
+#pragma warning disable CA1849 // Justification: blocking the message loop is what this test exercises.
                         DialogResult ignored = dialog.ShowDialog();
+#pragma warning restore CA1849
 
                         return Task.CompletedTask;
                     },

--- a/Tests/SampleClients.Tests/SampleClients.Tests.csproj
+++ b/Tests/SampleClients.Tests/SampleClients.Tests.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.3.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/Tests/SampleConfiguration.Tests/SampleConfiguration.Tests.csproj
+++ b/Tests/SampleConfiguration.Tests/SampleConfiguration.Tests.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.3.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/Tests/SampleServers.Tests/ConsoleSampleTests.cs
+++ b/Tests/SampleServers.Tests/ConsoleSampleTests.cs
@@ -122,7 +122,7 @@ namespace Opc.Ua.Samples.Tests
                 Is.True,
                 $"Reading the server state failed: {state.StatusCode}");
 
-            var serverState = (ServerState)Convert.ToInt32(state.WrappedValue.Value, CultureInfo.InvariantCulture);
+            var serverState = (ServerState)Convert.ToInt32(state.WrappedValue.AsBoxedObject(), CultureInfo.InvariantCulture);
 
             Assert.That(serverState, Is.EqualTo(ServerState.Running), "The server does not report itself as running.");
         }

--- a/Tests/SampleServers.Tests/SampleServerTests.cs
+++ b/Tests/SampleServers.Tests/SampleServerTests.cs
@@ -157,7 +157,7 @@ namespace Opc.Ua.Samples.Tests
                 Is.True,
                 $"Reading the server state failed: {state.StatusCode}");
 
-            var serverState = (ServerState)Convert.ToInt32(state.WrappedValue.Value, CultureInfo.InvariantCulture);
+            var serverState = (ServerState)Convert.ToInt32(state.WrappedValue.AsBoxedObject(), CultureInfo.InvariantCulture);
 
             Assert.That(serverState, Is.EqualTo(ServerState.Running), "The server does not report itself as running.");
 

--- a/Tests/SampleServers.Tests/SampleServers.Tests.csproj
+++ b/Tests/SampleServers.Tests/SampleServers.Tests.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.3.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/Tests/Samples.Tests.Common/TestClient.cs
+++ b/Tests/Samples.Tests.Common/TestClient.cs
@@ -87,15 +87,18 @@ namespace Opc.Ua.Samples.Tests
             string sessionName,
             CancellationToken ct = default)
         {
-            var pki = new TemporaryPki($"client-{sessionName}");
-
-            var application = new ApplicationInstance(NullTelemetry.Instance) {
-                ApplicationName = "Sample Test Client",
-                ApplicationType = ApplicationType.Client,
-            };
+            TemporaryPki pki = null;
+            ApplicationInstance application = null;
 
             try
             {
+                pki = new TemporaryPki($"client-{sessionName}");
+
+                application = new ApplicationInstance(NullTelemetry.Instance) {
+                    ApplicationName = "Sample Test Client",
+                    ApplicationType = ApplicationType.Client,
+                };
+
                 ApplicationConfiguration configuration =
                     await CreateConfigurationAsync(application, pki, ct).ConfigureAwait(false);
 
@@ -125,7 +128,12 @@ namespace Opc.Ua.Samples.Tests
                             default,
                             ct).ConfigureAwait(false);
 
-                        return new TestClient(session, application, pki) { Endpoint = description };
+                        // the client owns the application and the pki from here on, so the
+                        // locals are cleared to keep the finally below from disposing them
+                        var client = new TestClient(session, application, pki) { Endpoint = description };
+                        application = null;
+                        pki = null;
+                        return client;
                     }
                     catch (ServiceResultException refused)
                     {
@@ -141,11 +149,15 @@ namespace Opc.Ua.Samples.Tests
                     $"None of the {candidates.Length} endpoints of {endpointUrl} accepted a session." +
                     $"{Environment.NewLine}{string.Join(Environment.NewLine, refusals)}");
             }
-            catch
+            finally
             {
-                await application.DisposeAsync().ConfigureAwait(false);
-                pki.Dispose();
-                throw;
+                // both locals are cleared once the client takes ownership, so this only
+                // runs for the paths which never produced a client
+                if (application != null)
+                {
+                    await application.DisposeAsync().ConfigureAwait(false);
+                }
+                pki?.Dispose();
             }
         }
 
@@ -233,6 +245,9 @@ namespace Opc.Ua.Samples.Tests
             TemporaryPki pki,
             CancellationToken ct)
         {
+// the diagnostic for the obsolete overload below lands on the start of the chain,
+// so the suppression has to cover the whole statement
+#pragma warning disable CS0618
             ApplicationConfiguration configuration = await application
                 .Build(
                     "urn:localhost:OPCFoundation:SampleTestClient",
@@ -242,15 +257,14 @@ namespace Opc.Ua.Samples.Tests
                 // leaves SecurityConfiguration.ApplicationCertificate unset in 2.0.158-preview,
                 // and the configuration then fails validation with "ApplicationCertificate must
                 // be specified", so the subject name overload is used here on purpose
-#pragma warning disable CS0618
                 .AddSecurityConfiguration(
                     "CN=Sample Test Client, C=US, S=Arizona, O=OPC Foundation, DC=localhost",
                     pki.RootPath)
-#pragma warning restore CS0618
                 .SetAutoAcceptUntrustedCertificates(true)
                 .SetAddAppCertToTrustedStore(true)
                 .CreateAsync(ct)
                 .ConfigureAwait(false);
+#pragma warning restore CS0618
 
             bool certificateOk = await application
                 .CheckApplicationInstanceCertificatesAsync(true, null, ct)

--- a/Workshop/Aggregation/Client/Aggregation Client.csproj
+++ b/Workshop/Aggregation/Client/Aggregation Client.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client">
       <Version>2.0.0-preview.2</Version>

--- a/Workshop/Aggregation/Client/Program.cs
+++ b/Workshop/Aggregation/Client/Program.cs
@@ -87,6 +87,11 @@ namespace AggregationClient
             {
                 ExceptionDlg.Show(m_telemetry, application.ApplicationName, e);
             }
+            finally
+            {
+                // ApplicationInstance is only IAsyncDisposable, and Main is synchronous
+                application.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
         }
     }
 }

--- a/Workshop/Aggregation/ConsoleAggregationServer/ConsoleAggregationServer.csproj
+++ b/Workshop/Aggregation/ConsoleAggregationServer/ConsoleAggregationServer.csproj
@@ -63,7 +63,7 @@
   </Choose>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.11" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
   </ItemGroup>
 

--- a/Workshop/Aggregation/ConsoleAggregationServer/Program.cs
+++ b/Workshop/Aggregation/ConsoleAggregationServer/Program.cs
@@ -107,6 +107,7 @@ namespace AggregationServer
     public class MyServer
     {
         AggregationServer server;
+        ApplicationInstance application;
         Task status;
         DateTime lastEventTime;
         private readonly ITelemetryContext m_telemetry = new ConsoleTelemetry();
@@ -144,6 +145,12 @@ namespace AggregationServer
                 server.Dispose();
                 server = null;
 
+                if (application != null)
+                {
+                    application.DisposeAsync().AsTask().GetAwaiter().GetResult();
+                    application = null;
+                }
+
                 status.Wait();
             }
         }
@@ -161,7 +168,7 @@ namespace AggregationServer
         private async Task ConsoleAggregationServerAsync()
         {
             ApplicationInstance.MessageDlg = new ApplicationMessageDlg();
-            ApplicationInstance application = new ApplicationInstance(m_telemetry);
+            application = new ApplicationInstance(m_telemetry);
 
             application.ApplicationName = "Quickstart Aggregation Server";
             application.ApplicationType = ApplicationType.Server;

--- a/Workshop/Aggregation/Server/Aggregation Server.csproj
+++ b/Workshop/Aggregation/Server/Aggregation Server.csproj
@@ -38,7 +38,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client">
       <Version>2.0.0-preview.2</Version>

--- a/Workshop/Aggregation/Server/AggregationNodeManager.cs
+++ b/Workshop/Aggregation/Server/AggregationNodeManager.cs
@@ -368,7 +368,7 @@ namespace AggregationServer
                     0,
                     TimestampsToReturn.Both,
                     requests,
-                    default).Result;
+                    default).AsTask().Result;
 
                 ResponseHeader responseHeader = response.ResponseHeader;
                 ArrayOf<DataValue> results = response.Results;
@@ -475,7 +475,7 @@ namespace AggregationServer
                 WriteResponse response = client.WriteAsync(
                     null,
                     requests,
-                    default).Result;
+                    default).AsTask().Result;
 
                 ResponseHeader responseHeader = response.ResponseHeader;
                 ArrayOf<StatusCode> results = response.Results;
@@ -618,7 +618,7 @@ namespace AggregationServer
                 CallResponse response = client.CallAsync(
                     null,
                     requests,
-                    default).Result;
+                    default).AsTask().Result;
 
                 ResponseHeader responseHeader = response.ResponseHeader;
                 ArrayOf<CallMethodResult> results2 = response.Results;
@@ -1828,7 +1828,10 @@ namespace AggregationServer
                     }
                 }
 
-                m_logger.LogInformation("Closed downstream session for client {SessionId}.", clientSessionId);
+                if (m_logger.IsEnabled(LogLevel.Information))
+                {
+                    m_logger.LogInformation("Closed downstream session for client {SessionId}.", clientSessionId);
+                }
             }
             catch (Exception e)
             {

--- a/Workshop/Aggregation/Server/Program.cs
+++ b/Workshop/Aggregation/Server/Program.cs
@@ -71,7 +71,7 @@ namespace AggregationServer
             Application.SetCompatibleTextRenderingDefault(false);
 
             ApplicationInstance.MessageDlg = new ApplicationMessageDlg();
-            ApplicationInstance application = new ApplicationInstance(m_telemetry);
+            await using ApplicationInstance application = new ApplicationInstance(m_telemetry);
             application.ApplicationType = ApplicationType.Server;
             application.ConfigSectionName = "Quickstarts.AggregationServer";
 

--- a/Workshop/AlarmCondition/Client/AlarmCondition Client.csproj
+++ b/Workshop/AlarmCondition/Client/AlarmCondition Client.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
       <Version>2.0.0-preview.2</Version>

--- a/Workshop/AlarmCondition/Client/FilterDefinition.cs
+++ b/Workshop/AlarmCondition/Client/FilterDefinition.cs
@@ -74,7 +74,7 @@ namespace Quickstarts.AlarmConditionClient
         /// The select clauses to use with the filter.
         /// </summary>
 #pragma warning disable CA1051 // Justification: Sample code exposes fields by design.
-        public List<SimpleAttributeOperand> SelectClauses;
+        public IList<SimpleAttributeOperand> SelectClauses;
 #pragma warning restore CA1051
 
         /// <summary>
@@ -171,7 +171,7 @@ namespace Quickstarts.AlarmConditionClient
             EventFilter filter = new EventFilter();
 
             // the select clauses specify the values returned with each event notification.
-            filter.SelectClauses = SelectClauses;
+            filter.SelectClauses = SelectClauses.ToArrayOf();
 
             // the where clause restricts the events returned by the server.
             // it works a lot like the WHERE clause in a SQL statement and supports

--- a/Workshop/AlarmCondition/Client/Program.cs
+++ b/Workshop/AlarmCondition/Client/Program.cs
@@ -90,6 +90,11 @@ namespace Quickstarts.AlarmConditionClient
                 ExceptionDlg.Show(m_telemetry, application.ApplicationName, e);
                 return;
             }
+            finally
+            {
+                // ApplicationInstance is only IAsyncDisposable, and Main is synchronous
+                application.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
         }
     }
 

--- a/Workshop/AlarmCondition/Server/AlarmCondition Server.csproj
+++ b/Workshop/AlarmCondition/Server/AlarmCondition Server.csproj
@@ -30,7 +30,7 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Logging.Console">
-            <Version>10.0.10</Version>
+            <Version>10.0.11</Version>
         </PackageReference>
         <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
             <Version>2.0.0-preview.2</Version>

--- a/Workshop/AlarmCondition/Server/Program.cs
+++ b/Workshop/AlarmCondition/Server/Program.cs
@@ -95,6 +95,11 @@ namespace Quickstarts.AlarmConditionServer
                 ExceptionDlg.Show(m_telemetry, application.ApplicationName, e);
                 return;
             }
+            finally
+            {
+                // ApplicationInstance is only IAsyncDisposable, and Main is synchronous
+                application.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
         }
     }
 

--- a/Workshop/Boiler/Client/Boiler Client.csproj
+++ b/Workshop/Boiler/Client/Boiler Client.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client">
       <Version>2.0.0-preview.2</Version>

--- a/Workshop/Boiler/Client/Program.cs
+++ b/Workshop/Boiler/Client/Program.cs
@@ -92,6 +92,11 @@ namespace Quickstarts.Boiler.Client
                 ExceptionDlg.Show(m_telemetry, application.ApplicationName, e);
                 return;
             }
+            finally
+            {
+                // ApplicationInstance is only IAsyncDisposable, and Main is synchronous
+                application.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
         }
     }
 

--- a/Workshop/Boiler/Server/Boiler Server.csproj
+++ b/Workshop/Boiler/Server/Boiler Server.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
       <Version>2.0.0-preview.2</Version>

--- a/Workshop/Boiler/Server/Program.cs
+++ b/Workshop/Boiler/Server/Program.cs
@@ -100,6 +100,11 @@ namespace Quickstarts.Boiler.Server
                 ExceptionDlg.Show(m_telemetry, application.ApplicationName, e);
                 return;
             }
+            finally
+            {
+                // ApplicationInstance is only IAsyncDisposable, and Main is synchronous
+                application.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
         }
     }
 

--- a/Workshop/Common/FilterDefinition.cs
+++ b/Workshop/Common/FilterDefinition.cs
@@ -61,7 +61,7 @@ namespace Quickstarts
         /// <summary>
         /// The select clauses to use with the filter.
         /// </summary>
-        public List<SimpleAttributeOperand> SelectClauses;
+        public IList<SimpleAttributeOperand> SelectClauses;
         #pragma warning restore CA1051
 
         /// <summary>
@@ -158,7 +158,7 @@ namespace Quickstarts
             EventFilter filter = new EventFilter();
 
             // the select clauses specify the values returned with each event notification.
-            filter.SelectClauses = SelectClauses;
+            filter.SelectClauses = SelectClauses.ToArrayOf();
 
             // the where clause restricts the events returned by the server.
             // it works a lot like the WHERE clause in a SQL statement and supports

--- a/Workshop/Common/FormUtils.cs
+++ b/Workshop/Common/FormUtils.cs
@@ -420,7 +420,7 @@ namespace Quickstarts
         /// <returns>
         /// The references found. Null if an error occurred.
         /// </returns>
-        public static async Task<List<ReferenceDescription>> BrowseAsync(ISession session, List<BrowseDescription> nodesToBrowse, bool throwOnError, CancellationToken ct = default)
+        public static async Task<List<ReferenceDescription>> BrowseAsync(ISession session, IReadOnlyList<BrowseDescription> nodesToBrowse, bool throwOnError, CancellationToken ct = default)
         {
             try
             {
@@ -434,7 +434,7 @@ namespace Quickstarts
                         null,
                         null,
                         0,
-                        nodesToBrowse,
+                        nodesToBrowse.ToArrayOf(),
                         ct);
                     List<BrowseResult> results = response.Results.ToList();
                     List<DiagnosticInfo> diagnosticInfos = response.DiagnosticInfos.ToList();
@@ -911,8 +911,7 @@ namespace Quickstarts
         /// <param name="fields">The fields.</param>
         /// <param name="fieldNodeIds">The node id for the declaration of the field.</param>
         /// <param name="ct">The cancellation token to cancel the operation with</param>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1002:Do not expose generic lists", Justification = "Public sample API preserves existing List<T> parameter.")]
-        public static async Task CollectFieldsForTypeAsync(Session session, NodeId typeId, List<SimpleAttributeOperand> fields, List<NodeId> fieldNodeIds, CancellationToken ct = default)
+        public static async Task CollectFieldsForTypeAsync(Session session, NodeId typeId, IList<SimpleAttributeOperand> fields, IList<NodeId> fieldNodeIds, CancellationToken ct = default)
         {
             // get the supertypes.
             List<ReferenceDescription> supertypes = await FormUtils.BrowseSuperTypesAsync(session, typeId, false, ct);
@@ -943,8 +942,7 @@ namespace Quickstarts
         /// <param name="fields">The fields.</param>
         /// <param name="fieldNodeIds">The node id for the declaration of the field.</param>
         /// <param name="ct">The cancellation token to cancel the operation with</param>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1002:Do not expose generic lists", Justification = "Public sample API preserves existing List<T> parameter.")]
-        public static async Task CollectFieldsForInstanceAsync(Session session, NodeId instanceId, List<SimpleAttributeOperand> fields, List<NodeId> fieldNodeIds, CancellationToken ct = default)
+        public static async Task CollectFieldsForInstanceAsync(Session session, NodeId instanceId, IList<SimpleAttributeOperand> fields, IList<NodeId> fieldNodeIds, CancellationToken ct = default)
         {
             Dictionary<NodeId, List<QualifiedName>> foundNodes = new Dictionary<NodeId, List<QualifiedName>>();
             List<QualifiedName> parentPath = new List<QualifiedName>();
@@ -965,8 +963,8 @@ namespace Quickstarts
             Session session,
             NodeId nodeId,
             List<QualifiedName> parentPath,
-            List<SimpleAttributeOperand> fields,
-            List<NodeId> fieldNodeIds,
+            IList<SimpleAttributeOperand> fields,
+            IList<NodeId> fieldNodeIds,
             Dictionary<NodeId, List<QualifiedName>> foundNodes,
             CancellationToken ct = default)
         {
@@ -1035,7 +1033,7 @@ namespace Quickstarts
         /// <returns>
         /// 	<c>true</c> if the specified select clause contains path; otherwise, <c>false</c>.
         /// </returns>
-        private static int ContainsPath(List<SimpleAttributeOperand> selectClause, List<QualifiedName> browsePath)
+        private static int ContainsPath(IList<SimpleAttributeOperand> selectClause, List<QualifiedName> browsePath)
         {
             for (int ii = 0; ii < selectClause.Count; ii++)
             {

--- a/Workshop/Common/ModelUtils.cs
+++ b/Workshop/Common/ModelUtils.cs
@@ -353,7 +353,7 @@ namespace Quickstarts
 
                     if (!(instance.DataType).IsNull)
                     {
-                        instance.BuiltInType = TypeInfo.GetBuiltInType(instance.DataType, session.TypeTree);
+                        instance.BuiltInType = await TypeInfo.GetBuiltInTypeAsync(instance.DataType, session.TypeTree, ct);
                         instance.DataTypeDisplayText = await session.NodeCache.GetDisplayTextAsync(instance.DataType, ct);
 
                         if (instance.ValueRank >= 0)
@@ -378,7 +378,7 @@ namespace Quickstarts
     /// </summary>
     public class TypeDeclaration
     {
-#pragma warning disable CA1051, CA1002 // Justification: sample data transfer types intentionally expose mutable fields.
+#pragma warning disable CA1051 // Justification: sample data transfer types intentionally expose mutable fields.
         /// <summary>
         /// The node if for the type.
         /// </summary>
@@ -387,8 +387,8 @@ namespace Quickstarts
         /// <summary>
         /// The fully inhierited list of instance declarations for the type.
         /// </summary>
-        public List<InstanceDeclaration> Declarations;
-#pragma warning restore CA1051, CA1002
+        public IList<InstanceDeclaration> Declarations;
+#pragma warning restore CA1051
     }
 
     /// <summary>
@@ -405,7 +405,7 @@ namespace Quickstarts
         /// <summary>
         /// The browse path to the instance declaration.
         /// </summary>
-        public List<QualifiedName> BrowsePath;
+        public IList<QualifiedName> BrowsePath;
 
         /// <summary>
         /// The browse path to the instance declaration.
@@ -627,7 +627,7 @@ namespace Quickstarts
         public EventFilter GetFilter()
         {
             EventFilter filter = new EventFilter();
-            filter.SelectClauses = GetSelectClause();
+            filter.SelectClauses = GetSelectClause().ToArrayOf();
             filter.WhereClause = GetWhereClause();
             return filter;
         }
@@ -673,7 +673,7 @@ namespace Quickstarts
         /// <summary>
         /// Returns the select clause defined by the filter declaration.
         /// </summary>
-        public List<SimpleAttributeOperand> GetSelectClause()
+        public IList<SimpleAttributeOperand> GetSelectClause()
         {
             List<SimpleAttributeOperand> selectClause = new List<SimpleAttributeOperand>();
 
@@ -687,7 +687,7 @@ namespace Quickstarts
                 operand = new SimpleAttributeOperand();
                 operand.TypeDefinitionId = field.InstanceDeclaration.RootTypeId;
                 operand.AttributeId = (field.InstanceDeclaration.NodeClass == NodeClass.Object) ? Attributes.NodeId : Attributes.Value;
-                operand.BrowsePath = field.InstanceDeclaration.BrowsePath;
+                operand.BrowsePath = field.InstanceDeclaration.BrowsePath.ToArrayOf();
                 selectClause.Add(operand);
             }
 
@@ -711,7 +711,7 @@ namespace Quickstarts
                     SimpleAttributeOperand operand1 = new SimpleAttributeOperand();
                     operand1.TypeDefinitionId = field.InstanceDeclaration.RootTypeId;
                     operand1.AttributeId = (field.InstanceDeclaration.NodeClass == NodeClass.Object) ? Attributes.NodeId : Attributes.Value;
-                    operand1.BrowsePath = field.InstanceDeclaration.BrowsePath;
+                    operand1.BrowsePath = field.InstanceDeclaration.BrowsePath.ToArrayOf();
 
                     LiteralOperand operand2 = new LiteralOperand();
                     operand2.Value = field.FilterValue;
@@ -727,7 +727,7 @@ namespace Quickstarts
         /// <summary>
         /// Returns the value for the specified browse name.
         /// </summary>
-        public T GetValue<T>(QualifiedName browseName, List<Variant> fields, T defaultValue)
+        public T GetValue<T>(QualifiedName browseName, IList<Variant> fields, T defaultValue)
         {
             if (fields == null || fields.Count == 0)
             {
@@ -757,9 +757,9 @@ namespace Quickstarts
             return defaultValue;
         }
 
-        #pragma warning disable CA1051, CA1002 // Justification: sample data transfer type intentionally exposes mutable fields.
+        #pragma warning disable CA1051 // Justification: sample data transfer type intentionally exposes mutable fields.
         public NodeId EventTypeId;
-        public List<FilterDeclarationField> Fields;
-        #pragma warning restore CA1051, CA1002
+        public IList<FilterDeclarationField> Fields;
+        #pragma warning restore CA1051
     }
 }

--- a/Workshop/Common/MonitoredNode.cs
+++ b/Workshop/Common/MonitoredNode.cs
@@ -77,8 +77,7 @@ namespace Quickstarts
         /// <summary>
         /// Gets the current list of data change MonitoredItems.
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1002:Do not expose generic lists", Justification = "Sample API exposes mutable monitored item lists by design.")]
-        public List<MonitoredItem> DataChangeMonitoredItems
+        public IList<MonitoredItem> DataChangeMonitoredItems
         {
             get { return m_dataChangeMonitoredItems; }
             private set { m_dataChangeMonitoredItems = value; }
@@ -87,8 +86,7 @@ namespace Quickstarts
         /// <summary>
         /// Gets the current list of event MonitoredItems.
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1002:Do not expose generic lists", Justification = "Sample API exposes mutable monitored item lists by design.")]
-        public List<IEventMonitoredItem> EventMonitoredItems
+        public IList<IEventMonitoredItem> EventMonitoredItems
         {
             get { return m_eventMonitoredItems; }
             private set { m_eventMonitoredItems = value; }
@@ -274,8 +272,8 @@ namespace Quickstarts
         #region Private Fields
         private QuickstartNodeManager m_nodeManager;
         private NodeState m_node;
-        private List<MonitoredItem> m_dataChangeMonitoredItems;
-        private List<IEventMonitoredItem> m_eventMonitoredItems;
+        private IList<MonitoredItem> m_dataChangeMonitoredItems;
+        private IList<IEventMonitoredItem> m_eventMonitoredItems;
         #endregion
     }
 }

--- a/Workshop/Common/Quickstart Library.csproj
+++ b/Workshop/Common/Quickstart Library.csproj
@@ -43,7 +43,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Core">
       <Version>2.0.0-preview.2</Version>

--- a/Workshop/DataAccess/Client/DataAccess Client.csproj
+++ b/Workshop/DataAccess/Client/DataAccess Client.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client">
       <Version>2.0.0-preview.2</Version>

--- a/Workshop/DataAccess/Client/Program.cs
+++ b/Workshop/DataAccess/Client/Program.cs
@@ -89,6 +89,11 @@ namespace Quickstarts.DataAccessClient
                 ExceptionDlg.Show(m_telemetry, application.ApplicationName, e);
                 return;
             }
+            finally
+            {
+                // ApplicationInstance is only IAsyncDisposable, and Main is synchronous
+                application.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
         }
     }
 

--- a/Workshop/DataAccess/Server/DataAccess Server.csproj
+++ b/Workshop/DataAccess/Server/DataAccess Server.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
       <Version>2.0.0-preview.2</Version>

--- a/Workshop/DataAccess/Server/Program.cs
+++ b/Workshop/DataAccess/Server/Program.cs
@@ -96,6 +96,11 @@ namespace Quickstarts.DataAccessServer
                 ExceptionDlg.Show(m_telemetry, application.ApplicationName, e);
                 return;
             }
+            finally
+            {
+                // ApplicationInstance is only IAsyncDisposable, and Main is synchronous
+                application.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
         }
     }
 

--- a/Workshop/DataTypes/Client/DataTypes Client.csproj
+++ b/Workshop/DataTypes/Client/DataTypes Client.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client">
       <Version>2.0.0-preview.2</Version>

--- a/Workshop/DataTypes/Client/Program.cs
+++ b/Workshop/DataTypes/Client/Program.cs
@@ -96,6 +96,11 @@ namespace Quickstarts.DataTypes
                 ExceptionDlg.Show(m_telemetry, application.ApplicationName, e);
                 return;
             }
+            finally
+            {
+                // ApplicationInstance is only IAsyncDisposable, and Main is synchronous
+                application.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
         }
     }
 }

--- a/Workshop/DataTypes/Common/DataTypes Library.csproj
+++ b/Workshop/DataTypes/Common/DataTypes Library.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Core">
       <Version>2.0.0-preview.2</Version>

--- a/Workshop/DataTypes/Server/DataTypes Server.csproj
+++ b/Workshop/DataTypes/Server/DataTypes Server.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
       <Version>2.0.0-preview.2</Version>

--- a/Workshop/DataTypes/Server/Program.cs
+++ b/Workshop/DataTypes/Server/Program.cs
@@ -101,6 +101,11 @@ namespace Quickstarts.DataTypes
                 ExceptionDlg.Show(m_telemetry, application.ApplicationName, e);
                 return;
             }
+            finally
+            {
+                // ApplicationInstance is only IAsyncDisposable, and Main is synchronous
+                application.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
         }
     }
 }

--- a/Workshop/Empty/Client/Empty Client.csproj
+++ b/Workshop/Empty/Client/Empty Client.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client">
       <Version>2.0.0-preview.2</Version>

--- a/Workshop/Empty/Client/Program.cs
+++ b/Workshop/Empty/Client/Program.cs
@@ -92,6 +92,11 @@ namespace Quickstarts.EmptyClient
                 ExceptionDlg.Show(m_telemetry, application.ApplicationName, e);
                 return;
             }
+            finally
+            {
+                // ApplicationInstance is only IAsyncDisposable, and Main is synchronous
+                application.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
         }
     }
 

--- a/Workshop/Empty/Server/Empty Server.csproj
+++ b/Workshop/Empty/Server/Empty Server.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
       <Version>2.0.0-preview.2</Version>

--- a/Workshop/Empty/Server/Program.cs
+++ b/Workshop/Empty/Server/Program.cs
@@ -100,6 +100,11 @@ namespace Quickstarts.EmptyServer
                 ExceptionDlg.Show(m_telemetry, application.ApplicationName, e);
                 return;
             }
+            finally
+            {
+                // ApplicationInstance is only IAsyncDisposable, and Main is synchronous
+                application.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
         }
     }
 

--- a/Workshop/HistoricalAccess/Client/HistoricalAccess Client.csproj
+++ b/Workshop/HistoricalAccess/Client/HistoricalAccess Client.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client">
       <Version>2.0.0-preview.2</Version>

--- a/Workshop/HistoricalAccess/Client/Program.cs
+++ b/Workshop/HistoricalAccess/Client/Program.cs
@@ -88,6 +88,11 @@ namespace Quickstarts.HistoricalAccess.Client
                 ExceptionDlg.Show(m_telemetry, application.ApplicationName, e);
                 return;
             }
+            finally
+            {
+                // ApplicationInstance is only IAsyncDisposable, and Main is synchronous
+                application.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
         }
     }
 

--- a/Workshop/HistoricalAccess/Server/HistoricalAccess Server.csproj
+++ b/Workshop/HistoricalAccess/Server/HistoricalAccess Server.csproj
@@ -56,7 +56,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
       <Version>2.0.0-preview.2</Version>

--- a/Workshop/HistoricalAccess/Server/HistoricalAccessNodeManager.cs
+++ b/Workshop/HistoricalAccess/Server/HistoricalAccessNodeManager.cs
@@ -122,7 +122,7 @@ namespace Quickstarts.HistoricalAccessServer
         {
             // The server owns its diagnostics lock and no longer exposes it; this
             // section does not touch the diagnostics summary it guarded.
-            HistoryServerCapabilitiesState capabilities = Server.DiagnosticsNodeManager.GetDefaultHistoryCapabilitiesAsync(System.Threading.CancellationToken.None).GetAwaiter().GetResult();
+            HistoryServerCapabilitiesState capabilities = Server.DiagnosticsNodeManager.GetDefaultHistoryCapabilitiesAsync(System.Threading.CancellationToken.None).AsTask().GetAwaiter().GetResult();
             capabilities.AccessHistoryDataCapability.Value = true;
             capabilities.InsertDataCapability.Value = true;
             capabilities.ReplaceDataCapability.Value = true;
@@ -424,7 +424,7 @@ namespace Quickstarts.HistoricalAccessServer
 
             try
             {
-                HistoryReadRequest request = CreateHistoryReadRequest(
+                using HistoryReadRequest request = CreateHistoryReadRequest(
                     context,
                     details,
                     handle,
@@ -672,11 +672,13 @@ namespace Quickstarts.HistoricalAccessServer
                     // create a new request.
                     else
                     {
+#pragma warning disable CA2000 // Justification: ownership is transferred to the session continuation points.
                         request = CreateHistoryReadRequest(
                             context,
                             details,
                             handle,
                             nodeToRead);
+#pragma warning restore CA2000
                     }
 
                     // process values until the max is reached.
@@ -791,12 +793,14 @@ namespace Quickstarts.HistoricalAccessServer
                             continue;
                         }
 
+#pragma warning disable CA2000 // Justification: ownership is transferred to the session continuation points.
                         request = CreateHistoryReadRequest(
                             context,
                             details,
                             handle,
                             nodeToRead,
                             details.AggregateType[ii]);
+#pragma warning restore CA2000
                     }
 
                     // process values until the max is reached.
@@ -886,11 +890,13 @@ namespace Quickstarts.HistoricalAccessServer
                     // create a new request.
                     else
                     {
+#pragma warning disable CA2000 // Justification: ownership is transferred to the session continuation points.
                         request = CreateHistoryReadRequest(
                             context,
                             details,
                             handle,
                             nodeToRead);
+#pragma warning restore CA2000
                     }
 
                     // process values until the max is reached.

--- a/Workshop/HistoricalAccess/Server/Program.cs
+++ b/Workshop/HistoricalAccess/Server/Program.cs
@@ -107,6 +107,11 @@ namespace Quickstarts.HistoricalAccessServer
                 ExceptionDlg.Show(m_telemetry, application.ApplicationName, e);
                 return;
             }
+            finally
+            {
+                // ApplicationInstance is only IAsyncDisposable, and Main is synchronous
+                application.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
         }
 
         internal sealed class TestCase

--- a/Workshop/HistoricalAccess/Server/UnderlyingSystem/ArchiveItemState.cs
+++ b/Workshop/HistoricalAccess/Server/UnderlyingSystem/ArchiveItemState.cs
@@ -172,8 +172,7 @@ namespace Quickstarts.HistoricalAccessServer
         /// <summary>
         /// Creates a new sample.
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1002:Do not expose generic lists", Justification = "Public sample API preserves existing return type.")]
-        public List<DataValue> NewSamples(ISystemContext context)
+        public IList<DataValue> NewSamples(ISystemContext context)
         {
             List<DataValue> newSamples = new List<DataValue>();
 

--- a/Workshop/HistoricalAccess/Tester/Aggregate Tester.csproj
+++ b/Workshop/HistoricalAccess/Tester/Aggregate Tester.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client">
       <Version>2.0.0-preview.2</Version>

--- a/Workshop/HistoricalEvents/Client/HistoricalEvents Client.csproj
+++ b/Workshop/HistoricalEvents/Client/HistoricalEvents Client.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client">
       <Version>2.0.0-preview.2</Version>

--- a/Workshop/HistoricalEvents/Client/Program.cs
+++ b/Workshop/HistoricalEvents/Client/Program.cs
@@ -89,6 +89,11 @@ namespace Quickstarts.HistoricalEvents.Client
                 ExceptionDlg.Show(m_telemetry, application.ApplicationName, e);
                 return;
             }
+            finally
+            {
+                // ApplicationInstance is only IAsyncDisposable, and Main is synchronous
+                application.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
         }
     }
 

--- a/Workshop/HistoricalEvents/Client/ViewEventDetailsDlg.cs
+++ b/Workshop/HistoricalEvents/Client/ViewEventDetailsDlg.cs
@@ -59,7 +59,7 @@ namespace Quickstarts.HistoricalEvents.Client
         /// <summary>
         /// Shows all fields for the current condition.
         /// </summary>
-        public bool ShowDialog(FilterDeclaration filter, List<Variant> fields)
+        public bool ShowDialog(FilterDeclaration filter, IList<Variant> fields)
         {
             // fill in dialog.
             for (int ii = 0; ii < filter.Fields.Count; ii++)

--- a/Workshop/HistoricalEvents/Server/HistoricalEvents Server.csproj
+++ b/Workshop/HistoricalEvents/Server/HistoricalEvents Server.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
       <Version>2.0.0-preview.2</Version>

--- a/Workshop/HistoricalEvents/Server/HistoricalEventsNodeManager.cs
+++ b/Workshop/HistoricalEvents/Server/HistoricalEventsNodeManager.cs
@@ -314,11 +314,13 @@ namespace Quickstarts.HistoricalEvents.Server
                 // create a new request.
                 else
                 {
+#pragma warning disable CA2000 // Justification: ownership is transferred to the session continuation points.
                     request = CreateHistoryReadRequest(
                         context,
                         details,
                         handle,
                         nodeToRead);
+#pragma warning restore CA2000
                 }
 
                 // process events until the max is reached.

--- a/Workshop/HistoricalEvents/Server/Program.cs
+++ b/Workshop/HistoricalEvents/Server/Program.cs
@@ -101,6 +101,11 @@ namespace Quickstarts.HistoricalEvents.Server
                 ExceptionDlg.Show(m_telemetry, application.ApplicationName, e);
                 return;
             }
+            finally
+            {
+                // ApplicationInstance is only IAsyncDisposable, and Main is synchronous
+                application.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
         }
     }
 

--- a/Workshop/Methods/Client/Methods Client.csproj
+++ b/Workshop/Methods/Client/Methods Client.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client">
       <Version>2.0.0-preview.2</Version>

--- a/Workshop/Methods/Client/Program.cs
+++ b/Workshop/Methods/Client/Program.cs
@@ -92,6 +92,11 @@ namespace Quickstarts.MethodsClient
                 ExceptionDlg.Show(m_telemetry, application.ApplicationName, e);
                 return;
             }
+            finally
+            {
+                // ApplicationInstance is only IAsyncDisposable, and Main is synchronous
+                application.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
         }
     }
 

--- a/Workshop/Methods/Server/Methods Server.csproj
+++ b/Workshop/Methods/Server/Methods Server.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
       <Version>2.0.0-preview.2</Version>

--- a/Workshop/Methods/Server/MethodsNodeManager.cs
+++ b/Workshop/Methods/Server/MethodsNodeManager.cs
@@ -250,6 +250,7 @@ namespace Quickstarts.MethodsServer
         /// <param name="inputArguments">The input arguments.</param>
         /// <param name="outputArguments">The output arguments.</param>
         /// <returns></returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1002:Do not expose generic lists", Justification = "GenericMethodCalledEventHandler target: the SDK hands the handler a mutable List<Variant> to fill, because ArrayOf<Variant> is immutable.")]
         public ServiceResult OnStart(
             ISystemContext context,
             MethodState method,

--- a/Workshop/Methods/Server/Program.cs
+++ b/Workshop/Methods/Server/Program.cs
@@ -100,6 +100,11 @@ namespace Quickstarts.MethodsServer
                 ExceptionDlg.Show(m_telemetry, application.ApplicationName, e);
                 return;
             }
+            finally
+            {
+                // ApplicationInstance is only IAsyncDisposable, and Main is synchronous
+                application.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
         }
     }
 

--- a/Workshop/PerfTest/Client/PerfTest Client.csproj
+++ b/Workshop/PerfTest/Client/PerfTest Client.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client">
       <Version>2.0.0-preview.2</Version>

--- a/Workshop/PerfTest/Client/Program.cs
+++ b/Workshop/PerfTest/Client/Program.cs
@@ -92,6 +92,11 @@ namespace Quickstarts.PerfTestClient
                 ExceptionDlg.Show(m_telemetry, application.ApplicationName, e);
                 return;
             }
+            finally
+            {
+                // ApplicationInstance is only IAsyncDisposable, and Main is synchronous
+                application.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
         }
     }
 

--- a/Workshop/PerfTest/Server/PerfTest Server.csproj
+++ b/Workshop/PerfTest/Server/PerfTest Server.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
       <Version>2.0.0-preview.2</Version>

--- a/Workshop/PerfTest/Server/Program.cs
+++ b/Workshop/PerfTest/Server/Program.cs
@@ -96,6 +96,11 @@ namespace Quickstarts.PerfTestServer
                 ExceptionDlg.Show(m_telemetry, application.ApplicationName, e);
                 return;
             }
+            finally
+            {
+                // ApplicationInstance is only IAsyncDisposable, and Main is synchronous
+                application.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
         }
     }
 

--- a/Workshop/SimpleEvents/Client/Program.cs
+++ b/Workshop/SimpleEvents/Client/Program.cs
@@ -92,6 +92,11 @@ namespace Quickstarts.SimpleEvents.Client
                 ExceptionDlg.Show(m_telemetry, application.ApplicationName, e);
                 return;
             }
+            finally
+            {
+                // ApplicationInstance is only IAsyncDisposable, and Main is synchronous
+                application.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
         }
     }
 

--- a/Workshop/SimpleEvents/Client/SimpleEvents Client.csproj
+++ b/Workshop/SimpleEvents/Client/SimpleEvents Client.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client">
       <Version>2.0.0-preview.2</Version>

--- a/Workshop/SimpleEvents/Server/Program.cs
+++ b/Workshop/SimpleEvents/Server/Program.cs
@@ -100,6 +100,11 @@ namespace Quickstarts.SimpleEvents.Server
                 ExceptionDlg.Show(m_telemetry, application.ApplicationName, e);
                 return;
             }
+            finally
+            {
+                // ApplicationInstance is only IAsyncDisposable, and Main is synchronous
+                application.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
         }
     }
 

--- a/Workshop/SimpleEvents/Server/SimpleEvents Server.csproj
+++ b/Workshop/SimpleEvents/Server/SimpleEvents Server.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
       <Version>2.0.0-preview.2</Version>

--- a/Workshop/UserAuthentication/Client/Program.cs
+++ b/Workshop/UserAuthentication/Client/Program.cs
@@ -92,6 +92,11 @@ namespace Quickstarts.UserAuthenticationClient
                 ExceptionDlg.Show(m_telemetry, application.ApplicationName, e);
                 return;
             }
+            finally
+            {
+                // ApplicationInstance is only IAsyncDisposable, and Main is synchronous
+                application.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
         }
     }
 

--- a/Workshop/UserAuthentication/Client/UserAuthentication Client.csproj
+++ b/Workshop/UserAuthentication/Client/UserAuthentication Client.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client">
       <Version>2.0.0-preview.2</Version>

--- a/Workshop/UserAuthentication/Server/Program.cs
+++ b/Workshop/UserAuthentication/Server/Program.cs
@@ -100,6 +100,11 @@ namespace Quickstarts.UserAuthenticationServer
                 ExceptionDlg.Show(m_telemetry, application.ApplicationName, e);
                 return;
             }
+            finally
+            {
+                // ApplicationInstance is only IAsyncDisposable, and Main is synchronous
+                application.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
         }
     }
 

--- a/Workshop/UserAuthentication/Server/UserAuthentication Server.csproj
+++ b/Workshop/UserAuthentication/Server/UserAuthentication Server.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
       <Version>2.0.0-preview.2</Version>

--- a/Workshop/UserAuthentication/Server/UserAuthenticationServer.cs
+++ b/Workshop/UserAuthentication/Server/UserAuthenticationServer.cs
@@ -206,7 +206,9 @@ namespace Quickstarts.UserAuthenticationServer
         private ValueTask<IUserIdentity> AuthenticateX509Async(X509IdentityTokenHandler handler, System.Threading.CancellationToken ct)
         {
             X509IdentityToken x509Token = handler.Token as X509IdentityToken;
-            VerifyCertificate(new X509Certificate2(x509Token.CertificateData.ToArray()));
+            using X509Certificate2 userCertificate =
+                X509CertificateLoader.LoadCertificate(x509Token.CertificateData.ToArray());
+            VerifyCertificate(userCertificate);
             IUserIdentity identity = new UserIdentity(x509Token);
             if (m_logger.IsEnabled(LogLevel.Information))
             {

--- a/Workshop/Views/Client/Program.cs
+++ b/Workshop/Views/Client/Program.cs
@@ -91,6 +91,11 @@ namespace Quickstarts.ViewsClient
                 ExceptionDlg.Show(m_telemetry, application.ApplicationName, e);
                 return;
             }
+            finally
+            {
+                // ApplicationInstance is only IAsyncDisposable, and Main is synchronous
+                application.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
         }
     }
 

--- a/Workshop/Views/Client/Views Client.csproj
+++ b/Workshop/Views/Client/Views Client.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client">
       <Version>2.0.0-preview.2</Version>

--- a/Workshop/Views/Server/Program.cs
+++ b/Workshop/Views/Server/Program.cs
@@ -100,6 +100,11 @@ namespace Quickstarts.ViewsServer
                 ExceptionDlg.Show(m_telemetry, application.ApplicationName, e);
                 return;
             }
+            finally
+            {
+                // ApplicationInstance is only IAsyncDisposable, and Main is synchronous
+                application.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
         }
     }
 

--- a/Workshop/Views/Server/Views Server.csproj
+++ b/Workshop/Views/Server/Views Server.csproj
@@ -38,7 +38,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>10.0.10</Version>
+      <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
       <Version>2.0.0-preview.2</Version>

--- a/targets.props
+++ b/targets.props
@@ -38,11 +38,11 @@
   </PropertyGroup>
 
   <ItemGroup Condition="$(NO_RCS) == ''">
-    <PackageReference Include="Roslynator.Analyzers" Version="4.15.0" PrivateAssets="All" />
-    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.15.0" PrivateAssets="All" />
+    <PackageReference Include="Roslynator.Analyzers" Version="5.0.0" PrivateAssets="All" />
+    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="5.0.0" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.400" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Proposed changes

Two things: every NuGet package is bumped to its latest stable version, and the solution now builds with **zero warnings** in both Debug and Release across `net48`, `netstandard2.1`, `net8.0` and `net10.0`. It started at 128 distinct warnings.

### Package bumps

| Package | From | To |
|---|---|---|
| Microsoft.EntityFrameworkCore.Design / .SqlServer | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.Hosting / .Logging.Console / .Logging.Abstractions | 10.0.10 | 10.0.11 |
| Microsoft.NET.Test.Sdk | 18.8.1 | 18.9.0 |
| NUnit3TestAdapter | 6.2.0 | 6.3.0 |
| Roslynator.Analyzers / .Formatting.Analyzers | 4.15.0 | 5.0.0 |
| Microsoft.CodeAnalysis.NetAnalyzers | 10.0.302 | 10.0.400 |

Everything else was already current — the fourteen OPC UA packages are on the newest build the `opcua-preview` feed publishes (`2.0.0-preview.2`), and Mono.Options, NUnit, NUnit.Analyzers, Serilog and the container tooling targets were already at their latest stable release.

EF Core, the Extensions packages and NetAnalyzers all have 11.0.0 previews and NUnit has a 5.0.0 beta, but the repository targets .NET 10 GA, so this stays on stable. Neither the Roslynator 5.0 major bump nor the newer NetAnalyzers introduced any new diagnostics.

### Warning fixes

Most were real defects and are fixed in code:

- **CA2000 (45)** — `ApplicationInstance` is `IAsyncDisposable` only, so the sample entry points now dispose it in a `finally` (or with `await using` where `Main` is async). The two console hosts that outlive the method creating the instance keep it in a field and dispose it during shutdown. `TestClient.ConnectAsync` moved to try/finally and clears its locals once the client takes ownership.
- **CA2012 (10)** — `ValueTask` results were being read directly; they now go through `AsTask()`.
- **CA1849** — `TypeInfo.GetBuiltInType` → `GetBuiltInTypeAsync`.
- **SYSLIB0057** — `new X509Certificate2(byte[])` → `X509CertificateLoader`.
- **CS0618** — `Variant.Value` → `AsBoxedObject()`.
- **CA2213** — the GDS client form now disposes its `LocalDiscoveryServerClient`.
- **CA1508** — removed a null check that could never be true.
- **CA1003** — `ApplicationRegistered` now carries an `EventArgs`-derived type.
- **CS9191, CS0109, CA2249, CA1307, CS8632, CA1873** — fixed in place.

### The CA1002 decision (worth a reviewer's attention)

49 sites reported "do not expose generic lists", and they needed a judgement call rather than a mechanical fix.

The 2.0 SDK replaced the old `XxxCollection : List<T>` service types with the immutable `ArrayOf<T>` — but it did **not** deprecate `List<T>`. Because `ArrayOf<T>` cannot be appended to, the SDK still hands a mutable `List<T>` to anything a callee is meant to fill; `Opc.Ua.Server` alone has 77 public signatures that do this. So the rule can't just be applied everywhere.

Checking all 49 individually: exactly **one** — `MethodsNodeManager.OnStart` — is a `GenericMethodCalledEventHandler` target whose shape the SDK fixes. It carries a `SuppressMessage` saying exactly that. The other **48** were the samples' own controls and helpers, and are now `IList<T>` — or `IReadOnlyList<T>` in the two browse helpers, because `ClientBase.ValidateResponse` takes `IReadOnlyList<TRequest>` — with `.ToArrayOf()` at the service boundaries.

`IList<T>` was chosen over `Collection<T>` because it is what the samples already used elsewhere (`FilterDefinition.EventTypes` was `IList<NodeId>` sitting next to a `List<T>` sibling) and what the SDK itself uses for these roles, and because callers passing a `List<T>` need no change.

The same pass also converted twelve files that had been carrying pre-existing CA1002 suppressions rather than warnings, so the codebase is now consistent. **25 suppressions removed, 1 added.** The 22 that remain are all node manager members whose `List<T>` parameters were verified against `Opc.Ua.Server` by reflection and genuinely cannot be reshaped:

```
RootNotifiers                 : List<NodeState>
Read(nodesToValidate)         : List<NodeHandle>
Write(nodesToValidate)        : List<NodeHandle>
RemovePredefinedNode(refs)    : List<LocalReference>
```

**`.editorconfig` is unchanged** — no rule was silenced to reach zero warnings.

## Related Issues

- Fixes #

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

The public signatures of sample controls and helpers changed from `List<T>` to `IList<T>`. Nothing outside this repository consumes them, and callers passing a `List<T>` are unaffected, so this is not marked a breaking change — but it is the part most worth reviewing.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines.
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

All 247 tests pass: 143 configuration, 88 server smoke, 16 client smoke.

One note for anyone reproducing that locally: the tiers must be run **one project at a time**. `dotnet test` on the whole solution runs `SampleServers.Tests` and `SampleClients.Tests` concurrently, and because the samples bind fixed ports they collide — which shows up as a spurious `BadNoCommunication` / `AddressAlreadyInUse` failure. `.azurepipelines/test.yml` already warns that the job must not share an agent, but not that the projects race each other inside one run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
