### PR TITLE
Migrate the Workshop AlarmCondition and DataAccess servers to AsyncCustomNodeManager

### DIFF
--- a/Tests/SampleNodeManagers.Tests/AlarmConditionNodeManagerTests.cs
+++ b/Tests/SampleNodeManagers.Tests/AlarmConditionNodeManagerTests.cs
@@ -33,7 +33,9 @@ namespace Opc.Ua.Samples.Tests
     /// is a graph rather than a hierarchy. A migration which turns it back into a tree
     /// would be caught by SourceIsSharedBetweenAreas.
     ///
-    /// This is one of the three samples built on the local QuickstartNodeManager fork.
+    /// The node manager is built directly on the AsyncCustomNodeManager of the SDK; the
+    /// areas and sources exist only as entries in its dictionaries until a node id names
+    /// them.
     /// </remarks>
     [TestFixture]
     [Category("NodeManager")]
@@ -250,6 +252,69 @@ namespace Opc.Ua.Samples.Tests
                 alarm.EventType.IsNull,
                 Is.False,
                 "An event which reaches a client has to name its type.");
+        }
+
+        /// <summary>
+        /// A condition refresh replays the retained conditions between its markers.
+        /// </summary>
+        /// <remarks>
+        /// Every source creates a dialog condition which stays retained because nothing in
+        /// this fixture ever answers it, so a refresh must always replay one dialog per
+        /// configured source between the RefreshStart and RefreshEnd events. This is how an
+        /// alarm client synchronizes its condition list after connecting, and the half of
+        /// the event path which runs through ConditionRefreshAsync.
+        /// </remarks>
+        [Test]
+        [CancelAfter(kTimeout)]
+        public async Task ConditionRefreshReplaysRetainedConditions(CancellationToken ct)
+        {
+            await using EventCapture capture = await EventCapture
+                .CreateAsync(Session, ObjectIds.Server, ct)
+                .ConfigureAwait(false);
+
+            CallMethodResult result = await SessionOps.CallAsync(
+                Session,
+                ObjectTypeIds.ConditionType,
+                MethodIds.ConditionType_ConditionRefresh,
+                ct,
+                Variant.From(capture.SubscriptionId)).ConfigureAwait(false);
+
+            Assert.That(
+                StatusCode.IsGood(result.StatusCode),
+                Is.True,
+                $"The ConditionRefresh call failed: {result.StatusCode}");
+
+            await capture.WaitAsync(
+                candidate => candidate.EventType == ObjectTypeIds.RefreshStartEventType,
+                TimeSpan.FromSeconds(30),
+                "the refresh start marker",
+                ct).ConfigureAwait(false);
+
+            // everything between the markers is the refresh; live alarms may interleave,
+            // so only the dialogs are counted, and they identify their source by name
+            var betweenMarkers = new List<CapturedEvent>();
+            CapturedEvent next;
+
+            while ((next = await capture.NextAsync(TimeSpan.FromSeconds(30), ct).ConfigureAwait(false)).EventType
+                != ObjectTypeIds.RefreshEndEventType)
+            {
+                betweenMarkers.Add(next);
+            }
+
+            await ReportAsync(
+                "Events replayed by the refresh",
+                betweenMarkers.Select(replayed => replayed.ToString())).ConfigureAwait(false);
+
+            var dialogs = betweenMarkers
+                .Where(replayed => replayed.EventType == ObjectTypeIds.DialogConditionType
+                    && replayed.SourceName != null)
+                .Select(replayed => replayed.SourceName)
+                .ToHashSet(StringComparer.Ordinal);
+
+            Assert.That(
+                dialogs,
+                Is.SupersetOf(new[] { "EastTank", "NorthMotor", "WestTank", "SouthMotor" }),
+                "The refresh has to replay the retained dialog condition of every configured source.");
         }
 
         /// <summary>

--- a/Tests/SampleNodeManagers.Tests/DataAccessNodeManagerTests.cs
+++ b/Tests/SampleNodeManagers.Tests/DataAccessNodeManagerTests.cs
@@ -27,8 +27,9 @@ namespace Opc.Ua.Samples.Tests
     /// the duration of the operation. The same block appears under several paths, which is
     /// the part of the design a rewrite is most likely to lose, so it is checked here.
     ///
-    /// This is one of the three samples built on the local QuickstartNodeManager fork, so
-    /// these tests are also the coverage for that base class.
+    /// The node manager is built directly on the AsyncCustomNodeManager of the SDK, and
+    /// the tag variables route their writes to the underlying system through the
+    /// asynchronous write handler.
     /// </remarks>
     [TestFixture]
     [Category("NodeManager")]
@@ -299,6 +300,65 @@ namespace Opc.Ua.Samples.Tests
                 values.Select(value => value.StatusCode),
                 Is.All.Matches<StatusCode>(StatusCode.IsGood),
                 "The block simulation has to report good values.");
+        }
+
+        /// <summary>
+        /// Writing the set point of a controller reaches the underlying system.
+        /// </summary>
+        /// <remarks>
+        /// The write goes through the asynchronous write handler of the tag variable into
+        /// the underlying system, and the simulation never touches writable tags, so a
+        /// fresh read - which builds a new block from the system - has to return the
+        /// written value. The original value is restored so the fixture stays order
+        /// independent.
+        /// </remarks>
+        [Test]
+        [CancelAfter(kTimeout)]
+        public async Task ControllerSetPointIsWritable(CancellationToken ct)
+        {
+            NodeId setPointId = Tag("FC1001", "SetPoint");
+
+            DataValue original = await SessionOps
+                .ReadValueAsync(Session, setPointId, ct)
+                .ConfigureAwait(false);
+
+            Assert.That(
+                StatusCode.IsGood(original.StatusCode),
+                Is.True,
+                $"Reading the set point failed: {original.StatusCode}");
+
+            float written = (original.WrappedValue.AsBoxedObject() as float? ?? 0f) + 10f;
+
+            try
+            {
+                StatusCode result = await SessionOps
+                    .WriteValueAsync(Session, setPointId, Variant.From(written), ct)
+                    .ConfigureAwait(false);
+
+                Assert.That(
+                    StatusCode.IsGood(result),
+                    Is.True,
+                    $"Writing the set point failed: {result}");
+
+                DataValue readBack = await SessionOps
+                    .ReadValueAsync(Session, setPointId, ct)
+                    .ConfigureAwait(false);
+
+                await TestContext.Out
+                    .WriteLineAsync($"Set point: was {original.WrappedValue}, wrote {written}, read {readBack.WrappedValue}")
+                    .ConfigureAwait(false);
+
+                Assert.That(
+                    readBack.WrappedValue.AsBoxedObject(),
+                    Is.EqualTo(written),
+                    "The set point has to come back from the underlying system with the written value.");
+            }
+            finally
+            {
+                await SessionOps
+                    .WriteValueAsync(Session, setPointId, original.WrappedValue, ct)
+                    .ConfigureAwait(false);
+            }
         }
 
         private QualifiedName Segment(string name)

--- a/Tests/Samples.Tests.Common/EventCapture.cs
+++ b/Tests/Samples.Tests.Common/EventCapture.cs
@@ -100,6 +100,11 @@ namespace Opc.Ua.Samples.Tests
         }
 
         /// <summary>
+        /// The id the server gave the subscription, as needed by a ConditionRefresh call.
+        /// </summary>
+        public uint SubscriptionId => m_subscription.Id;
+
+        /// <summary>
         /// Subscribes to the events of a notifier.
         /// </summary>
         /// <param name="session">The session to subscribe on.</param>

--- a/Workshop/AlarmCondition/Server/AlarmCondition Server.csproj
+++ b/Workshop/AlarmCondition/Server/AlarmCondition Server.csproj
@@ -27,7 +27,6 @@
     <ItemGroup>
         <ProjectReference Include="..\..\..\Samples\ServerControls.Net4\UA Server Controls.csproj" />
         <ProjectReference Include="..\..\..\Samples\Hosting\Opc.Ua.Samples.Hosting.csproj" />
-        <ProjectReference Include="..\..\Common\Quickstart Library.csproj" />
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">

--- a/Workshop/AlarmCondition/Server/AlarmConditionNodeManager.cs
+++ b/Workshop/AlarmCondition/Server/AlarmConditionNodeManager.cs
@@ -2,7 +2,7 @@
  * Copyright (c) 2005-2019 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
- * 
+ *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
  * files (the "Software"), to deal in the Software without
@@ -11,7 +11,7 @@
  * copies of the Software, and to permit persons to whom the
  * Software is furnished to do so, subject to the following
  * conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
@@ -29,8 +29,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Opc.Ua;
 using Opc.Ua.Server;
@@ -38,15 +38,36 @@ using Opc.Ua.Server;
 namespace Quickstarts.AlarmConditionServer
 {
     /// <summary>
+    /// The factory the server registers to create the node manager.
+    /// </summary>
+    public class AlarmConditionServerNodeManagerFactory : IAsyncNodeManagerFactory
+    {
+        /// <inheritdoc/>
+        public ValueTask<IAsyncNodeManager> CreateAsync(
+            IServerInternal server,
+            ApplicationConfiguration configuration,
+            CancellationToken cancellationToken = default)
+        {
+#pragma warning disable CA2000 // Justification: ownership of the node manager transfers to the caller.
+            return new ValueTask<IAsyncNodeManager>(
+                new AlarmConditionServerNodeManager(server, configuration));
+#pragma warning restore CA2000
+        }
+
+        /// <inheritdoc/>
+        public ArrayOf<string> NamespacesUris => [Namespaces.AlarmCondition];
+    }
+
+    /// <summary>
     /// A node manager for a simple server that exposes several Areas, Sources and Conditions.
     /// </summary>
     /// <remarks>
     /// This node manager presumes that the information model consists of a hierachy of predefined
-    /// Areas with a number of Sources contained within them. Each individual Source is 
+    /// Areas with a number of Sources contained within them. Each individual Source is
     /// identified by a fully qualified path. The underlying system knows how to access the source
     /// configuration when it is provided the fully qualified path.
     /// </remarks>
-    public class AlarmConditionServerNodeManager : QuickstartNodeManager
+    public class AlarmConditionServerNodeManager : AsyncCustomNodeManager
     {
         #region Constructors
         /// <summary>
@@ -54,15 +75,16 @@ namespace Quickstarts.AlarmConditionServer
         /// </summary>
         public AlarmConditionServerNodeManager(IServerInternal server, ApplicationConfiguration configuration)
         :
-            base(server, configuration, Namespaces.AlarmCondition)
+            base(
+                server,
+                configuration,
+                server.Telemetry.CreateLogger<AlarmConditionServerNodeManager>(),
+                Namespaces.AlarmCondition)
         {
             SystemContext.SystemHandle = m_system = new UnderlyingSystem(server.Telemetry);
-            SystemContext.NodeIdFactory = this;
 
             // get the configuration for the node manager.
             m_configuration = configuration.ParseExtension<AlarmConditionServerConfiguration>();
-
-            m_logger = server.Telemetry.CreateLogger<AlarmConditionServerNodeManager>();
 
             // use suitable defaults if no configuration exists.
             if (m_configuration == null)
@@ -108,7 +130,7 @@ namespace Quickstarts.AlarmConditionServer
         /// <returns>The new NodeId.</returns>
         /// <remarks>
         /// This method is called by the NodeState.Create() method which initializes a Node from
-        /// the type model. During initialization a number of child nodes are created and need to 
+        /// the type model. During initialization a number of child nodes are created and need to
         /// have NodeIds assigned to them. This implementation constructs NodeIds by constructing
         /// strings. Other implementations could assign unique integers or Guids and save the new
         /// Node in a dictionary for later lookup.
@@ -119,53 +141,54 @@ namespace Quickstarts.AlarmConditionServer
         }
         #endregion
 
-        #region INodeManager Members
+        #region IAsyncNodeManager Members
         /// <summary>
         /// Does any initialization required before the address space can be used.
         /// </summary>
         /// <remarks>
         /// The externalReferences is an out parameter that allows the node manager to link to nodes
         /// in other node managers. For example, the 'Objects' node is managed by the CoreNodeManager and
-        /// should have a reference to the root folder node(s) exposed by this node manager.  
+        /// should have a reference to the root folder node(s) exposed by this node manager.
         /// </remarks>
-        public override void CreateAddressSpace(IDictionary<NodeId, IList<IReference>> externalReferences)
+        public override async ValueTask CreateAddressSpaceAsync(
+            IDictionary<NodeId, IList<IReference>> externalReferences,
+            CancellationToken cancellationToken = default)
         {
-            lock (Lock)
+            await base.CreateAddressSpaceAsync(externalReferences, cancellationToken).ConfigureAwait(false);
+
+            if (m_configuration.Areas != null)
             {
-                if (m_configuration.Areas != null)
+                // Top level areas need a reference from the Server object.
+                // These references are added to a list that is returned to the caller.
+                // The caller will update the Objects folder node.
+                IList<IReference> references = null;
+
+                if (!externalReferences.TryGetValue(ObjectIds.Server, out references))
                 {
-                    // Top level areas need a reference from the Server object. 
-                    // These references are added to a list that is returned to the caller.
-                    // The caller will update the Objects folder node.
-                    IList<IReference> references = null;
-
-                    if (!externalReferences.TryGetValue(ObjectIds.Server, out references))
-                    {
-                        externalReferences[ObjectIds.Server] = references = new List<IReference>();
-                    }
-
-                    for (int ii = 0; ii < m_configuration.Areas.Count; ii++)
-                    {
-                        // recursively process each area.
-                        AreaState area = CreateAndIndexAreas(null, m_configuration.Areas[ii]);
-                        AddRootNotifier(area);
-
-                        // add an organizes reference from the ObjectsFolder to the area.
-                        references.Add(new NodeStateReference(ReferenceTypeIds.HasNotifier, false, area.NodeId));
-                    }
+                    externalReferences[ObjectIds.Server] = references = new List<IReference>();
                 }
 
-                // start the simulation.
-                m_system.StartSimulation();
-                m_simulationTimer = new Timer(OnRaiseSystemEvents, null, 1000, 1000);
+                for (int ii = 0; ii < m_configuration.Areas.Count; ii++)
+                {
+                    // recursively process each area.
+                    AreaState area = CreateAndIndexAreas(null, m_configuration.Areas[ii]);
+                    await AddRootNotifierAsync(area, cancellationToken).ConfigureAwait(false);
+
+                    // add an organizes reference from the ObjectsFolder to the area.
+                    references.Add(new NodeStateReference(ReferenceTypeIds.HasNotifier, false, area.NodeId));
+                }
             }
+
+            // start the simulation.
+            m_system.StartSimulation();
+            m_simulationTimer = new Timer(OnRaiseSystemEvents, null, 1000, 1000);
         }
 
-        private void OnRaiseSystemEvents(object state)
+        private async void OnRaiseSystemEvents(object state)
         {
             try
             {
-#pragma warning disable CA2000 // Justification: Event state ownership is transferred to Server.ReportEvent.
+#pragma warning disable CA2000 // Justification: Event state ownership is transferred to Server.ReportEventAsync.
                 SystemEventState e = new SystemEventState(null);
 #pragma warning restore CA2000
 
@@ -178,9 +201,9 @@ namespace Quickstarts.AlarmConditionServer
                 e.SetChildValue(SystemContext, BrowseNames.SourceNode, ObjectIds.Server, false);
                 e.SetChildValue(SystemContext, BrowseNames.SourceName, "Internal", false);
 
-                Server.ReportEvent(e);
+                await Server.ReportEventAsync(SystemContext, e).ConfigureAwait(false);
 
-#pragma warning disable CA2000 // Justification: Event state ownership is transferred to Server.ReportEvent.
+#pragma warning disable CA2000 // Justification: Event state ownership is transferred to Server.ReportEventAsync.
                 AuditEventState ae = new AuditEventState(null);
 #pragma warning restore CA2000
 
@@ -195,7 +218,7 @@ namespace Quickstarts.AlarmConditionServer
                 ae.SetChildValue(SystemContext, BrowseNames.SourceNode, ObjectIds.Server, false);
                 ae.SetChildValue(SystemContext, BrowseNames.SourceName, "Internal", false);
 
-                Server.ReportEvent(ae);
+                await Server.ReportEventAsync(SystemContext, ae).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -249,7 +272,7 @@ namespace Quickstarts.AlarmConditionServer
 
                     // HasEventSource and HasNotifier control the propagation of event notifications so
                     // they are not like other references. These calls set up a link between the source
-                    // and area that will cause events produced by the source to be automatically 
+                    // and area that will cause events produced by the source to be automatically
                     // propagated to the area.
                     source.AddNotifier(SystemContext, ReferenceTypeIds.HasEventSource, true, area);
                     area.AddNotifier(SystemContext, ReferenceTypeIds.HasEventSource, false, source);
@@ -263,66 +286,78 @@ namespace Quickstarts.AlarmConditionServer
         /// <summary>
         /// Frees any resources allocated for the address space.
         /// </summary>
-        public override void DeleteAddressSpace()
+        public override async ValueTask DeleteAddressSpaceAsync(CancellationToken cancellationToken = default)
         {
-            lock (Lock)
-            {
-                m_system.StopSimulation();
-                m_areas.Clear();
-                m_sources.Clear();
-            }
+            m_system.StopSimulation();
+            m_areas.Clear();
+            m_sources.Clear();
+
+            await base.DeleteAddressSpaceAsync(cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
         /// Returns a unique handle for the node.
         /// </summary>
-        protected override NodeHandle GetManagerHandle(ServerSystemContext context, NodeId nodeId, IDictionary<NodeId, NodeState> cache)
+        protected override ValueTask<NodeHandle> GetManagerHandleAsync(
+            ServerSystemContext context,
+            NodeId nodeId,
+            IDictionary<NodeId, NodeState> cache,
+            CancellationToken cancellationToken = default)
         {
-            lock (Lock)
+            // quickly exclude nodes that are not in the namespace.
+            if (!IsNodeIdInNamespace(nodeId))
             {
-                // quickly exclude nodes that are not in the namespace.
-                if (!IsNodeIdInNamespace(nodeId))
-                {
-                    return null;
-                }
-
-                // check for check for nodes that are being currently monitored.
-                MonitoredNode monitoredNode = null;
-
-                if (MonitoredNodes.TryGetValue(nodeId, out monitoredNode))
-                {
-                    NodeHandle handle = new NodeHandle();
-
-                    handle.NodeId = nodeId;
-                    handle.Validated = true;
-                    handle.Node = monitoredNode.Node;
-
-                    return handle;
-                }
-
-                // parse the identifier.
-                ParsedNodeId parsedNodeId = ParsedNodeId.Parse(nodeId);
-
-                if (parsedNodeId != null)
-                {
-                    NodeHandle handle = new NodeHandle();
-
-                    handle.NodeId = nodeId;
-                    handle.Validated = false;
-                    handle.Node = null;
-                    handle.ParsedNodeId = parsedNodeId;
-
-                    return handle;
-                }
-
-                return null;
+                return new ValueTask<NodeHandle>();
             }
+
+            // check for nodes that are being currently monitored.
+            MonitoredNode2 monitoredNode = null;
+
+            if (MonitoredNodes.TryGetValue(nodeId, out monitoredNode))
+            {
+                NodeHandle handle = new NodeHandle();
+
+                handle.NodeId = nodeId;
+                handle.Validated = true;
+                handle.Node = monitoredNode.Node;
+
+                return new ValueTask<NodeHandle>(handle);
+            }
+
+            // parse the identifier.
+            ParsedNodeId parsedNodeId = ParsedNodeId.Parse(nodeId);
+
+            if (parsedNodeId != null)
+            {
+                NodeHandle handle = new NodeHandle();
+
+                handle.NodeId = nodeId;
+                handle.Validated = false;
+                handle.Node = null;
+                handle.ParsedNodeId = parsedNodeId;
+
+                return new ValueTask<NodeHandle>(handle);
+            }
+
+            return new ValueTask<NodeHandle>();
         }
 
         /// <summary>
         /// Verifies that the specified node exists.
         /// </summary>
-        protected override NodeState ValidateNode(
+        protected override ValueTask<NodeState> ValidateNodeAsync(
+            ServerSystemContext context,
+            NodeHandle handle,
+            IDictionary<NodeId, NodeState> cache,
+            CancellationToken cancellationToken = default)
+        {
+            return new ValueTask<NodeState>(ValidateNode(context, handle, cache));
+        }
+
+        /// <summary>
+        /// Verifies that the specified node exists.
+        /// </summary>
+        private NodeState ValidateNode(
             ServerSystemContext context,
             NodeHandle handle,
             IDictionary<NodeId, NodeState> cache)
@@ -363,7 +398,9 @@ namespace Quickstarts.AlarmConditionServer
             try
             {
                 // check if the node id has been parsed.
-                if (handle.ParsedNodeId == null)
+                ParsedNodeId parsedNodeId = handle.ParsedNodeId as ParsedNodeId;
+
+                if (parsedNodeId == null)
                 {
                     return null;
                 }
@@ -371,11 +408,11 @@ namespace Quickstarts.AlarmConditionServer
                 NodeState root = null;
 
                 // validate area.
-                if (handle.ParsedNodeId.RootType == ModelUtils.Area)
+                if (parsedNodeId.RootType == ModelUtils.Area)
                 {
                     AreaState area = null;
 
-                    if (!m_areas.TryGetValue(handle.ParsedNodeId.RootId, out area))
+                    if (!m_areas.TryGetValue(parsedNodeId.RootId, out area))
                     {
                         return null;
                     }
@@ -384,11 +421,11 @@ namespace Quickstarts.AlarmConditionServer
                 }
 
                 // validate soucre.
-                else if (handle.ParsedNodeId.RootType == ModelUtils.Source)
+                else if (parsedNodeId.RootType == ModelUtils.Source)
                 {
                     SourceState source = null;
 
-                    if (!m_sources.TryGetValue(handle.ParsedNodeId.RootId, out source))
+                    if (!m_sources.TryGetValue(parsedNodeId.RootId, out source))
                     {
                         return null;
                     }
@@ -403,7 +440,7 @@ namespace Quickstarts.AlarmConditionServer
                 }
 
                 // all done if no components to validate.
-                if (String.IsNullOrEmpty(handle.ParsedNodeId.ComponentPath))
+                if (String.IsNullOrEmpty(parsedNodeId.ComponentPath))
                 {
                     handle.Validated = true;
                     handle.Node = target = root;
@@ -411,7 +448,7 @@ namespace Quickstarts.AlarmConditionServer
                 }
 
                 // validate component.
-                NodeState component = root.FindChildBySymbolicName(context, handle.ParsedNodeId.ComponentPath);
+                NodeState component = root.FindChildBySymbolicName(context, parsedNodeId.ComponentPath);
 
                 // component does not exist.
                 if (component == null)
@@ -438,7 +475,6 @@ namespace Quickstarts.AlarmConditionServer
         #region Private Fields
         private UnderlyingSystem m_system;
         private AlarmConditionServerConfiguration m_configuration;
-        private ILogger m_logger;
         private Dictionary<string, AreaState> m_areas;
         private Dictionary<string, SourceState> m_sources;
         private Timer m_simulationTimer;

--- a/Workshop/AlarmCondition/Server/AlarmConditionServer.cs
+++ b/Workshop/AlarmCondition/Server/AlarmConditionServer.cs
@@ -28,8 +28,6 @@
  * ======================================================================*/
 
 using System;
-using System.Collections.Generic;
-using Microsoft.Extensions.Logging;
 using Opc.Ua;
 using Opc.Ua.Server;
 
@@ -43,7 +41,7 @@ namespace Quickstarts.AlarmConditionServer
     /// responsible for reading the configuration file, creating the endpoints and dispatching
     /// incoming requests to the appropriate handler.
     /// 
-    /// This sub-class specifies non-configurable metadata such as Product Name and initializes
+    /// This sub-class specifies non-configurable metadata such as Product Name and registers
     /// the AlarmConditionServerNodeManager which provides access to the data exposed by the Server.
     /// </remarks>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1724:Type names should not match namespaces", Justification = "Sample public API name matches the workshop namespace.")]
@@ -51,6 +49,9 @@ namespace Quickstarts.AlarmConditionServer
     {
         public AlarmConditionServer(ITelemetryContext telemetry) : base(telemetry)
         {
+            // register the node manager factory. the server creates the node manager
+            // from it while it builds the master node manager on startup.
+            AddNodeManager(new AlarmConditionServerNodeManagerFactory());
         }
 
         #region Public Interface
@@ -64,28 +65,6 @@ namespace Quickstarts.AlarmConditionServer
         #endregion
 
         #region Overridden Methods
-        /// <summary>
-        /// Creates the node managers for the server.
-        /// </summary>
-        /// <remarks>
-        /// This method allows the sub-class create any additional node managers which it uses. The SDK
-        /// always creates a CoreNodeManager which handles the built-in nodes defined by the specification.
-        /// Any additional NodeManagers are expected to handle application specific nodes.
-        /// </remarks>
-        protected override MasterNodeManager CreateMasterNodeManager(IServerInternal server, ApplicationConfiguration configuration)
-        {
-            ILogger logger = server.Telemetry.CreateLogger<AlarmConditionServer>();
-            logger.LogInformation("Creating the Node Managers.");
-
-            List<INodeManager> nodeManagers = new List<INodeManager>();
-
-            // create the custom node managers.
-            nodeManagers.Add(new AlarmConditionServerNodeManager(server, configuration));
-
-            // create master node manager.
-            return new MasterNodeManager(server, configuration, null, nodeManagers.ToArray());
-        }
-
         /// <summary>
         /// Loads the non-configurable properties for the application.
         /// </summary>

--- a/Workshop/AlarmCondition/Server/Model/SourceState.cs
+++ b/Workshop/AlarmCondition/Server/Model/SourceState.cs
@@ -29,6 +29,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Opc.Ua;
 
 namespace Quickstarts.AlarmConditionServer
@@ -43,7 +46,7 @@ namespace Quickstarts.AlarmConditionServer
         /// Initializes the area.
         /// </summary>
         public SourceState(
-            QuickstartNodeManager nodeManager,
+            AlarmConditionServerNodeManager nodeManager,
             NodeId nodeId,
             string sourcePath)
         :
@@ -53,6 +56,7 @@ namespace Quickstarts.AlarmConditionServer
 
             // save the node manager that owns the source.
             m_nodeManager = nodeManager;
+            m_logger = nodeManager.Server.Telemetry.CreateLogger<SourceState>();
 
             // create the source with the underlying system.
             m_source = ((UnderlyingSystem)nodeManager.SystemContext.SystemHandle).CreateSource(sourcePath, OnAlarmChanged);
@@ -100,53 +104,57 @@ namespace Quickstarts.AlarmConditionServer
                 }
             }
 
-            // report the dialog.
-            if (m_dialog != null)
+            // the refresh can run concurrently with alarm changes reported by the underlying system.
+            lock (m_lock)
             {
-                // do not refresh dialogs that are not active.
-                if (m_dialog.Retain.Value)
+                // report the dialog.
+                if (m_dialog != null)
                 {
+                    // do not refresh dialogs that are not active.
+                    if (m_dialog.Retain.Value)
+                    {
+                        // create a snapshot.
+                        InstanceStateSnapshot e = new InstanceStateSnapshot();
+                        e.Initialize(context, m_dialog);
+
+                        // set the handle of the snapshot to check for duplicates.
+                        e.Handle = this;
+
+                        events.Add(e);
+                    }
+                }
+
+                // the alarm objects act as a cache for the last known state and are used to generate refresh events.
+                foreach (AlarmConditionState alarm in m_alarms.Values)
+                {
+                    // do not refresh alarms that are not in an interesting state.
+                    if (!alarm.Retain.Value)
+                    {
+                        continue;
+                    }
+
                     // create a snapshot.
                     InstanceStateSnapshot e = new InstanceStateSnapshot();
-                    e.Initialize(context, m_dialog);
+                    e.Initialize(context, alarm);
 
                     // set the handle of the snapshot to check for duplicates.
                     e.Handle = this;
 
                     events.Add(e);
                 }
-            }
 
-            // the alarm objects act as a cache for the last known state and are used to generate refresh events.
-            foreach (AlarmConditionState alarm in m_alarms.Values)
-            {
-                // do not refresh alarms that are not in an interesting state.
-                if (!alarm.Retain.Value)
+                // report any active branches.
+                foreach (AlarmConditionState alarm in m_branches.Values)
                 {
-                    continue;
+                    // create a snapshot.
+                    InstanceStateSnapshot e = new InstanceStateSnapshot();
+                    e.Initialize(context, alarm);
+
+                    // set the handle of the snapshot to check for duplicates.
+                    e.Handle = this;
+
+                    events.Add(e);
                 }
-
-                // create a snapshot.
-                InstanceStateSnapshot e = new InstanceStateSnapshot();
-                e.Initialize(context, alarm);
-
-                // set the handle of the snapshot to check for duplicates.
-                e.Handle = this;
-
-                events.Add(e);
-            }
-
-            // report any active branches.
-            foreach (AlarmConditionState alarm in m_branches.Values)
-            {
-                // create a snapshot.
-                InstanceStateSnapshot e = new InstanceStateSnapshot();
-                e.Initialize(context, alarm);
-
-                // set the handle of the snapshot to check for duplicates.
-                e.Handle = this;
-
-                events.Add(e);
             }
         }
         #endregion
@@ -155,47 +163,61 @@ namespace Quickstarts.AlarmConditionServer
         /// <summary>
         /// Called when the state of an alarm for the source has changed.
         /// </summary>
-        private void OnAlarmChanged(UnderlyingSystemAlarm alarm)
+        /// <remarks>
+        /// The underlying system reports the change on its own thread. The alarm state is
+        /// updated under the source lock and the resulting event is reported through the
+        /// asynchronous event path of the node state.
+        /// </remarks>
+        private async void OnAlarmChanged(UnderlyingSystemAlarm alarm)
         {
-            lock (m_nodeManager.Lock)
+            try
             {
-                // ignore archived alarms for now.
-                if (alarm.RecordNumber != 0)
-                {
-                    NodeId branchId = new NodeId(alarm.RecordNumber, this.NodeId.NamespaceIndex);
-
-                    // find the alarm branch.
-                    AlarmConditionState branch = null;
-
-                    if (!m_branches.TryGetValue(branchId, out branch))
-                    {
-                        m_branches[branchId] = branch = CreateAlarm(alarm, branchId);
-                    }
-
-                    // map the system information to the UA defined alarm.
-                    UpdateAlarm(branch, alarm);
-                    ReportChanges(branch);
-
-                    // delete the branch.
-                    if ((alarm.State & UnderlyingSystemAlarmStates.Deleted) != 0)
-                    {
-                        m_branches.Remove(branchId);
-                    }
-
-                    return;
-                }
-
-                // find the alarm node.
                 AlarmConditionState node = null;
 
-                if (!m_alarms.TryGetValue(alarm.Name, out node))
+                lock (m_lock)
                 {
-                    m_alarms[alarm.Name] = node = CreateAlarm(alarm, NodeId.Null);
+                    // ignore archived alarms for now.
+                    if (alarm.RecordNumber != 0)
+                    {
+                        NodeId branchId = new NodeId(alarm.RecordNumber, this.NodeId.NamespaceIndex);
+
+                        // find the alarm branch.
+                        AlarmConditionState branch = null;
+
+                        if (!m_branches.TryGetValue(branchId, out branch))
+                        {
+                            m_branches[branchId] = branch = CreateAlarm(alarm, branchId);
+                        }
+
+                        // map the system information to the UA defined alarm.
+                        UpdateAlarm(branch, alarm);
+
+                        // delete the branch.
+                        if ((alarm.State & UnderlyingSystemAlarmStates.Deleted) != 0)
+                        {
+                            m_branches.Remove(branchId);
+                        }
+
+                        node = branch;
+                    }
+                    else
+                    {
+                        // find the alarm node.
+                        if (!m_alarms.TryGetValue(alarm.Name, out node))
+                        {
+                            m_alarms[alarm.Name] = node = CreateAlarm(alarm, NodeId.Null);
+                        }
+
+                        // map the system information to the UA defined alarm.
+                        UpdateAlarm(node, alarm);
+                    }
                 }
 
-                // map the system information to the UA defined alarm.
-                UpdateAlarm(node, alarm);
-                ReportChanges(node);
+                await ReportChangesAsync(node).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                m_logger.LogError(e, "Unexpected error reporting a change to an alarm for source {SourceName}.", SymbolicName);
             }
         }
 
@@ -240,10 +262,15 @@ namespace Quickstarts.AlarmConditionServer
             node.Time.Value = DateTime.UtcNow;
             node.ReceiveTime.Value = node.Time.Value;
             node.Message.Value = new LocalizedText("The dialog was activated");
-            node.Retain.Value = true;
 
             node.SetEnableState(context, true);
             node.SetSeverity(context, EventSeverity.Low);
+
+            // enabling re-evaluates the retain state, and the dialog condition of the SDK
+            // does not consider an active dialog interesting on its own. the dialog has to
+            // stay retained until it is answered, so that a condition refresh replays it,
+            // which is how a client which connects later learns that a response is wanted.
+            node.Retain.Value = true;
 
             // initialize the dialog information.
             node.Prompt.Value = new LocalizedText("Please specify a new state for the source.");
@@ -405,7 +432,7 @@ namespace Quickstarts.AlarmConditionServer
         }
 
         /// <summary>
-        /// Updates the alarm with a new state.
+        /// Updates the alarm with a new state. The caller must hold the source lock.
         /// </summary>
         /// <param name="node">The node.</param>
         /// <param name="alarm">The alarm.</param>
@@ -596,10 +623,14 @@ namespace Quickstarts.AlarmConditionServer
             bool oneShot,
             double shelvingTime)
         {
-            alarm.SetShelvingState(context, shelving, oneShot, shelvingTime);
-            alarm.Message.Value = new LocalizedText("The alarm shelved.");
+            lock (m_lock)
+            {
+                alarm.SetShelvingState(context, shelving, oneShot, shelvingTime);
+                alarm.Message.Value = new LocalizedText("The alarm shelved.");
 
-            UpdateAlarm(alarm, null);
+                UpdateAlarm(alarm, null);
+            }
+
             ReportChanges(alarm);
 
             return ServiceResult.Good;
@@ -612,11 +643,15 @@ namespace Quickstarts.AlarmConditionServer
             ISystemContext context,
             AlarmConditionState alarm)
         {
-            // update the alarm state and produce and event.
-            alarm.SetShelvingState(context, false, false, 0);
-            alarm.Message.Value = new LocalizedText("The timed shelving period expired.");
+            lock (m_lock)
+            {
+                // update the alarm state and produce and event.
+                alarm.SetShelvingState(context, false, false, 0);
+                alarm.Message.Value = new LocalizedText("The timed shelving period expired.");
 
-            UpdateAlarm(alarm, null);
+                UpdateAlarm(alarm, null);
+            }
+
             ReportChanges(alarm);
 
             return ServiceResult.Good;
@@ -642,19 +677,46 @@ namespace Quickstarts.AlarmConditionServer
                 m_source.SetOfflineState(true);
             }
 
-            // other responses mean do nothing.
-            dialog.SetResponse(context, selectedResponse);
+            lock (m_lock)
+            {
+                // other responses mean do nothing.
+                dialog.SetResponse(context, selectedResponse);
 
-            // dialog no longer interesting once it is deactivated.
-            dialog.Message.Value = new LocalizedText("The dialog was deactivated");
-            dialog.Retain.Value = false;
+                // dialog no longer interesting once it is deactivated.
+                dialog.Message.Value = new LocalizedText("The dialog was deactivated");
+                dialog.Retain.Value = false;
+            }
 
             return ServiceResult.Good;
         }
 
         /// <summary>
+        /// Reports the changes to the alarm through the asynchronous event path.
+        /// </summary>
+        private async Task ReportChangesAsync(AlarmConditionState alarm, CancellationToken cancellationToken = default)
+        {
+            // report changes to node attributes.
+            await alarm.ClearChangeMasksAsync(m_nodeManager.SystemContext, true, cancellationToken).ConfigureAwait(false);
+
+            // check if events are being monitored for the source.
+            if (this.AreEventsMonitored)
+            {
+                // create a snapshot.
+                InstanceStateSnapshot e = new InstanceStateSnapshot();
+                e.Initialize(m_nodeManager.SystemContext, alarm);
+
+                // report the event.
+                await alarm.ReportEventAsync(m_nodeManager.SystemContext, e, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
         /// Reports the changes to the alarm.
         /// </summary>
+        /// <remarks>
+        /// The shelving handlers are synchronous delegates, so they use this synchronous
+        /// bridge; it still drives the asynchronous notification sinks of the node state.
+        /// </remarks>
         private void ReportChanges(AlarmConditionState alarm)
         {
             // report changes to node attributes.
@@ -686,9 +748,12 @@ namespace Quickstarts.AlarmConditionServer
 
             AlarmConditionState alarm = null;
 
-            if (!m_events.TryGetValue(Utils.ToHexString(eventId.ToArray()), out alarm))
+            lock (m_lock)
             {
-                return null;
+                if (!m_events.TryGetValue(Utils.ToHexString(eventId.ToArray()), out alarm))
+                {
+                    return null;
+                }
             }
 
             return alarm;
@@ -731,7 +796,9 @@ namespace Quickstarts.AlarmConditionServer
         #endregion    
 
         #region Private Fields
-        private QuickstartNodeManager m_nodeManager;
+        private readonly Lock m_lock = new();
+        private AlarmConditionServerNodeManager m_nodeManager;
+        private ILogger m_logger;
         private UnderlyingSystemSource m_source;
         private Dictionary<string, AlarmConditionState> m_alarms;
         private Dictionary<string, AlarmConditionState> m_events;

--- a/Workshop/DataAccess/Server/DataAccess Server.csproj
+++ b/Workshop/DataAccess/Server/DataAccess Server.csproj
@@ -28,7 +28,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\Samples\ServerControls.Net4\UA Server Controls.csproj" />
     <ProjectReference Include="..\..\..\Samples\Hosting\Opc.Ua.Samples.Hosting.csproj" />
-    <ProjectReference Include="..\..\Common\Quickstart Library.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">

--- a/Workshop/DataAccess/Server/DataAccessNodeManager.cs
+++ b/Workshop/DataAccess/Server/DataAccessNodeManager.cs
@@ -1,8 +1,8 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2019 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
- * 
+ *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
  * files (the "Software"), to deal in the Software without
@@ -11,7 +11,7 @@
  * copies of the Software, and to permit persons to whom the
  * Software is furnished to do so, subject to the following
  * conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
@@ -29,21 +29,38 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
-using System.Diagnostics;
-using System.Xml;
-using System.IO;
 using System.Threading;
-using System.Reflection;
+using System.Threading.Tasks;
 using Opc.Ua;
 using Opc.Ua.Server;
 
 namespace Quickstarts.DataAccessServer
 {
     /// <summary>
+    /// The factory the server registers to create the node manager.
+    /// </summary>
+    public class DataAccessServerNodeManagerFactory : IAsyncNodeManagerFactory
+    {
+        /// <inheritdoc/>
+        public ValueTask<IAsyncNodeManager> CreateAsync(
+            IServerInternal server,
+            ApplicationConfiguration configuration,
+            CancellationToken cancellationToken = default)
+        {
+#pragma warning disable CA2000 // Justification: ownership of the node manager transfers to the caller.
+            return new ValueTask<IAsyncNodeManager>(
+                new DataAccessServerNodeManager(server, configuration));
+#pragma warning restore CA2000
+        }
+
+        /// <inheritdoc/>
+        public ArrayOf<string> NamespacesUris => [Namespaces.DataAccess];
+    }
+
+    /// <summary>
     /// A node manager for a server that exposes several variables.
     /// </summary>
-    public class DataAccessServerNodeManager : QuickstartNodeManager
+    public class DataAccessServerNodeManager : AsyncCustomNodeManager
     {
         #region Constructors
         /// <summary>
@@ -51,24 +68,18 @@ namespace Quickstarts.DataAccessServer
         /// </summary>
         public DataAccessServerNodeManager(IServerInternal server, ApplicationConfiguration configuration)
         :
-            base(server, configuration, Namespaces.DataAccess)
+            base(
+                server,
+                configuration,
+                server.Telemetry.CreateLogger<DataAccessServerNodeManager>(),
+                Namespaces.DataAccess)
         {
             this.AliasRoot = "DA";
 
             SystemContext.SystemHandle = m_system = new UnderlyingSystem(server.Telemetry);
-            SystemContext.NodeIdFactory = this;
-
-            // get the configuration for the node manager.
-            m_configuration = configuration.ParseExtension<DataAccessServerConfiguration>();
-
-            // use suitable defaults if no configuration exists.
-            if (m_configuration == null)
-            {
-                m_configuration = new DataAccessServerConfiguration();
-            }
 
             // create the table to store the cached blocks.
-            m_blocks = new Dictionary<NodeId, BlockState>();
+            m_blocks = new NodeIdDictionary<BlockState>();
         }
         #endregion
 
@@ -96,7 +107,7 @@ namespace Quickstarts.DataAccessServer
         /// <returns>The new NodeId.</returns>
         /// <remarks>
         /// This method is called by the NodeState.Create() method which initializes a Node from
-        /// the type model. During initialization a number of child nodes are created and need to 
+        /// the type model. During initialization a number of child nodes are created and need to
         /// have NodeIds assigned to them. This implementation constructs NodeIds by constructing
         /// strings. Other implementations could assign unique integers or Guids and save the new
         /// Node in a dictionary for later lookup.
@@ -107,124 +118,137 @@ namespace Quickstarts.DataAccessServer
         }
         #endregion
 
-        #region INodeManager Members
+        #region IAsyncNodeManager Members
         /// <summary>
         /// Does any initialization required before the address space can be used.
         /// </summary>
         /// <remarks>
         /// The externalReferences is an out parameter that allows the node manager to link to nodes
         /// in other node managers. For example, the 'Objects' node is managed by the CoreNodeManager and
-        /// should have a reference to the root folder node(s) exposed by this node manager.  
+        /// should have a reference to the root folder node(s) exposed by this node manager.
         /// </remarks>
-        public override void CreateAddressSpace(IDictionary<NodeId, IList<IReference>> externalReferences)
+        public override async ValueTask CreateAddressSpaceAsync(
+            IDictionary<NodeId, IList<IReference>> externalReferences,
+            CancellationToken cancellationToken = default)
         {
-            lock (Lock)
+            await base.CreateAddressSpaceAsync(externalReferences, cancellationToken).ConfigureAwait(false);
+
+            // find the top level segments and link them to the ObjectsFolder.
+            IList<UnderlyingSystemSegment> segments = m_system.FindSegments(null);
+
+            for (int ii = 0; ii < segments.Count; ii++)
             {
-                // find the top level segments and link them to the ObjectsFolder.
-                IList<UnderlyingSystemSegment> segments = m_system.FindSegments(null);
+                // Top level areas need a reference from the Server object.
+                // These references are added to a list that is returned to the caller.
+                // The caller will update the Objects folder node.
+                IList<IReference> references = null;
 
-                for (int ii = 0; ii < segments.Count; ii++)
+                if (!externalReferences.TryGetValue(ObjectIds.ObjectsFolder, out references))
                 {
-                    // Top level areas need a reference from the Server object. 
-                    // These references are added to a list that is returned to the caller.
-                    // The caller will update the Objects folder node.
-                    IList<IReference> references = null;
-
-                    if (!externalReferences.TryGetValue(ObjectIds.ObjectsFolder, out references))
-                    {
-                        externalReferences[ObjectIds.ObjectsFolder] = references = new List<IReference>();
-                    }
-
-                    // construct the NodeId of a segment.
-                    NodeId segmentId = ModelUtils.ConstructIdForSegment(segments[ii].Id, NamespaceIndex);
-
-                    // add an organizes reference from the ObjectsFolder to the area.
-                    references.Add(new NodeStateReference(ReferenceTypeIds.Organizes, false, segmentId));
+                    externalReferences[ObjectIds.ObjectsFolder] = references = new List<IReference>();
                 }
 
-                // start the simulation.
-                m_system.StartSimulation(Server.Telemetry);
+                // construct the NodeId of a segment.
+                NodeId segmentId = ModelUtils.ConstructIdForSegment(segments[ii].Id, NamespaceIndex);
+
+                // add an organizes reference from the ObjectsFolder to the area.
+                references.Add(new NodeStateReference(ReferenceTypeIds.Organizes, false, segmentId));
             }
+
+            // start the simulation.
+            m_system.StartSimulation(Server.Telemetry);
         }
 
         /// <summary>
         /// Frees any resources allocated for the address space.
         /// </summary>
-        public override void DeleteAddressSpace()
+        public override async ValueTask DeleteAddressSpaceAsync(CancellationToken cancellationToken = default)
         {
-            lock (Lock)
-            {
-                m_system.StopSimulation();
-                m_blocks.Clear();
-            }
+            m_system.StopSimulation();
+            m_blocks.Clear();
+
+            await base.DeleteAddressSpaceAsync(cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
         /// Returns a unique handle for the node.
         /// </summary>
-        protected override NodeHandle GetManagerHandle(ServerSystemContext context, NodeId nodeId, IDictionary<NodeId, NodeState> cache)
+        protected override ValueTask<NodeHandle> GetManagerHandleAsync(
+            ServerSystemContext context,
+            NodeId nodeId,
+            IDictionary<NodeId, NodeState> cache,
+            CancellationToken cancellationToken = default)
         {
-            lock (Lock)
+            // quickly exclude nodes that are not in the namespace.
+            if (!IsNodeIdInNamespace(nodeId))
             {
-                // quickly exclude nodes that are not in the namespace.
-                if (!IsNodeIdInNamespace(nodeId))
-                {
-                    return null;
-                }
-
-                // check for check for nodes that are being currently monitored.
-                MonitoredNode monitoredNode = null;
-
-                if (MonitoredNodes.TryGetValue(nodeId, out monitoredNode))
-                {
-                    NodeHandle handle = new NodeHandle();
-
-                    handle.NodeId = nodeId;
-                    handle.Validated = true;
-                    handle.Node = monitoredNode.Node;
-
-                    return handle;
-                }
-
-                if (nodeId.IdType != IdType.String)
-                {
-                    NodeState node = null;
-
-                    if (PredefinedNodes.TryGetValue(nodeId, out node))
-                    {
-                        NodeHandle handle = new NodeHandle();
-
-                        handle.NodeId = nodeId;
-                        handle.Node = node;
-                        handle.Validated = true;
-
-                        return handle;
-                    }
-                }
-
-                // parse the identifier.
-                ParsedNodeId parsedNodeId = ParsedNodeId.Parse(nodeId);
-
-                if (parsedNodeId != null)
-                {
-                    NodeHandle handle = new NodeHandle();
-
-                    handle.NodeId = nodeId;
-                    handle.Validated = false;
-                    handle.Node = null;
-                    handle.ParsedNodeId = parsedNodeId;
-
-                    return handle;
-                }
-
-                return null;
+                return new ValueTask<NodeHandle>();
             }
+
+            // check for nodes that are being currently monitored.
+            MonitoredNode2 monitoredNode = null;
+
+            if (MonitoredNodes.TryGetValue(nodeId, out monitoredNode))
+            {
+                NodeHandle handle = new NodeHandle();
+
+                handle.NodeId = nodeId;
+                handle.Validated = true;
+                handle.Node = monitoredNode.Node;
+
+                return new ValueTask<NodeHandle>(handle);
+            }
+
+            if (nodeId.IdType != IdType.String)
+            {
+                NodeState node = null;
+
+                if (PredefinedNodes.TryGetValue(nodeId, out node))
+                {
+                    NodeHandle handle = new NodeHandle();
+
+                    handle.NodeId = nodeId;
+                    handle.Node = node;
+                    handle.Validated = true;
+
+                    return new ValueTask<NodeHandle>(handle);
+                }
+            }
+
+            // parse the identifier.
+            ParsedNodeId parsedNodeId = ParsedNodeId.Parse(nodeId);
+
+            if (parsedNodeId != null)
+            {
+                NodeHandle handle = new NodeHandle();
+
+                handle.NodeId = nodeId;
+                handle.Validated = false;
+                handle.Node = null;
+                handle.ParsedNodeId = parsedNodeId;
+
+                return new ValueTask<NodeHandle>(handle);
+            }
+
+            return new ValueTask<NodeHandle>();
         }
 
         /// <summary>
         /// Verifies that the specified node exists.
         /// </summary>
-        protected override NodeState ValidateNode(
+        protected override ValueTask<NodeState> ValidateNodeAsync(
+            ServerSystemContext context,
+            NodeHandle handle,
+            IDictionary<NodeId, NodeState> cache,
+            CancellationToken cancellationToken = default)
+        {
+            return new ValueTask<NodeState>(ValidateNode(context, handle, cache));
+        }
+
+        /// <summary>
+        /// Verifies that the specified node exists.
+        /// </summary>
+        private NodeState ValidateNode(
             ServerSystemContext context,
             NodeHandle handle,
             IDictionary<NodeId, NodeState> cache)
@@ -265,7 +289,9 @@ namespace Quickstarts.DataAccessServer
             try
             {
                 // check if the node id has been parsed.
-                if (handle.ParsedNodeId == null)
+                ParsedNodeId parsedNodeId = handle.ParsedNodeId as ParsedNodeId;
+
+                if (parsedNodeId == null)
                 {
                     return null;
                 }
@@ -273,9 +299,9 @@ namespace Quickstarts.DataAccessServer
                 NodeState root = null;
 
                 // validate a segment.
-                if (handle.ParsedNodeId.RootType == ModelUtils.Segment)
+                if (parsedNodeId.RootType == ModelUtils.Segment)
                 {
-                    UnderlyingSystemSegment segment = m_system.FindSegment(handle.ParsedNodeId.RootId);
+                    UnderlyingSystemSegment segment = m_system.FindSegment(parsedNodeId.RootId);
 
                     // segment does not exist.
                     if (segment == null)
@@ -292,10 +318,10 @@ namespace Quickstarts.DataAccessServer
                 }
 
                 // validate segment.
-                else if (handle.ParsedNodeId.RootType == ModelUtils.Block)
+                else if (parsedNodeId.RootType == ModelUtils.Block)
                 {
                     // validate the block.
-                    UnderlyingSystemBlock block = m_system.FindBlock(handle.ParsedNodeId.RootId);
+                    UnderlyingSystemBlock block = m_system.FindBlock(parsedNodeId.RootId);
 
                     // block does not exist.
                     if (block == null)
@@ -305,7 +331,7 @@ namespace Quickstarts.DataAccessServer
 
                     NodeId rootId = ModelUtils.ConstructIdForBlock(block.Id, NamespaceIndex);
 
-                    // check for check for blocks that are being currently monitored.
+                    // check for blocks that are being currently monitored.
                     BlockState node = null;
 
                     if (m_blocks.TryGetValue(rootId, out node))
@@ -329,7 +355,7 @@ namespace Quickstarts.DataAccessServer
                 }
 
                 // all done if no components to validate.
-                if (String.IsNullOrEmpty(handle.ParsedNodeId.ComponentPath))
+                if (String.IsNullOrEmpty(parsedNodeId.ComponentPath))
                 {
                     handle.Validated = true;
                     handle.Node = target = root;
@@ -337,7 +363,7 @@ namespace Quickstarts.DataAccessServer
                 }
 
                 // validate component.
-                NodeState component = root.FindChildBySymbolicName(context, handle.ParsedNodeId.ComponentPath);
+                NodeState component = root.FindChildBySymbolicName(context, parsedNodeId.ComponentPath);
 
                 // component does not exist.
                 if (component == null)
@@ -368,7 +394,7 @@ namespace Quickstarts.DataAccessServer
         /// <param name="context">The context.</param>
         /// <param name="handle">The handle for the node.</param>
         /// <param name="monitoredItem">The monitored item.</param>
-        protected override void OnMonitoredItemCreated(ServerSystemContext context, NodeHandle handle, MonitoredItem monitoredItem)
+        protected override void OnMonitoredItemCreated(ServerSystemContext context, NodeHandle handle, ISampledDataChangeMonitoredItem monitoredItem)
         {
             BlockState block = handle.Node.GetHierarchyRoot() as BlockState;
 
@@ -387,7 +413,12 @@ namespace Quickstarts.DataAccessServer
         /// <param name="context">The context.</param>
         /// <param name="handle">The handle for the node.</param>
         /// <param name="monitoredItem">The monitored item.</param>
-        protected override void OnMonitoredItemDeleted(ServerSystemContext context, NodeHandle handle, MonitoredItem monitoredItem)
+        /// <param name="cancellationToken">The cancellation token.</param>
+        protected override ValueTask OnMonitoredItemDeletedAsync(
+            ServerSystemContext context,
+            NodeHandle handle,
+            ISampledDataChangeMonitoredItem monitoredItem,
+            CancellationToken cancellationToken = default)
         {
             BlockState block = handle.Node.GetHierarchyRoot() as BlockState;
 
@@ -396,16 +427,17 @@ namespace Quickstarts.DataAccessServer
                 if (!block.StopMonitoring(context))
                 {
                     // can remove the block since all monitored items for the block are gone.
-                    m_blocks.Remove(block.NodeId);
+                    m_blocks.TryRemove(block.NodeId, out _);
                 }
             }
+
+            return default;
         }
         #endregion
 
         #region Private Fields
         private UnderlyingSystem m_system;
-        private DataAccessServerConfiguration m_configuration;
-        private Dictionary<NodeId, BlockState> m_blocks;
+        private NodeIdDictionary<BlockState> m_blocks;
         #endregion
     }
 }

--- a/Workshop/DataAccess/Server/DataAccessServer.cs
+++ b/Workshop/DataAccess/Server/DataAccessServer.cs
@@ -28,9 +28,6 @@
  * ======================================================================*/
 
 using System;
-using System.Collections.Generic;
-using System.Text;
-using Microsoft.Extensions.Logging;
 using Opc.Ua;
 using Opc.Ua.Server;
 
@@ -44,7 +41,7 @@ namespace Quickstarts.DataAccessServer
     /// responsible for reading the configuration file, creating the endpoints and dispatching
     /// incoming requests to the appropriate handler.
     /// 
-    /// This sub-class specifies non-configurable metadata such as Product Name and initializes
+    /// This sub-class specifies non-configurable metadata such as Product Name and registers
     /// the DataAccessServerNodeManager which provides access to the data exposed by the Server.
     /// </remarks>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1724:Type names should not match namespaces", Justification = "Sample public API name matches the workshop namespace.")]
@@ -52,6 +49,9 @@ namespace Quickstarts.DataAccessServer
     {
         public DataAccessServer(ITelemetryContext telemetry) : base(telemetry)
         {
+            // register the node manager factory. the server creates the node manager
+            // from it while it builds the master node manager on startup.
+            AddNodeManager(new DataAccessServerNodeManagerFactory());
         }
 
         #region Public Interface
@@ -65,28 +65,6 @@ namespace Quickstarts.DataAccessServer
         #endregion
 
         #region Overridden Methods
-        /// <summary>
-        /// Creates the node managers for the server.
-        /// </summary>
-        /// <remarks>
-        /// This method allows the sub-class create any additional node managers which it uses. The SDK
-        /// always creates a CoreNodeManager which handles the built-in nodes defined by the specification.
-        /// Any additional NodeManagers are expected to handle application specific nodes.
-        /// </remarks>
-        protected override MasterNodeManager CreateMasterNodeManager(IServerInternal server, ApplicationConfiguration configuration)
-        {
-            ILogger logger = server.Telemetry.CreateLogger<DataAccessServer>();
-            logger.LogInformation("Creating the Node Managers.");
-
-            List<INodeManager> nodeManagers = new List<INodeManager>();
-
-            // create the custom node managers.
-            nodeManagers.Add(new DataAccessServerNodeManager(server, configuration));
-
-            // create master node manager.
-            return new MasterNodeManager(server, configuration, null, nodeManagers.ToArray());
-        }
-
         /// <summary>
         /// Loads the non-configurable properties for the application.
         /// </summary>

--- a/Workshop/DataAccess/Server/Model/BlockState.cs
+++ b/Workshop/DataAccess/Server/Model/BlockState.cs
@@ -33,6 +33,7 @@ using System.Xml;
 using System.IO;
 using System.Reflection;
 using System.Threading;
+using System.Threading.Tasks;
 using Opc.Ua;
 using Opc.Ua.Server;
 
@@ -80,7 +81,7 @@ namespace Quickstarts.DataAccessServer
                     BaseVariableState variable = CreateVariable(nodeManager.SystemContext, tags[ii]);
 #pragma warning restore CA2000
                     AddChild(variable);
-                    variable.OnSimpleWriteValue = OnWriteTagValue;
+                    variable.OnSimpleWriteValueAsync = OnWriteTagValueAsync;
                 }
             }
         }
@@ -138,25 +139,28 @@ namespace Quickstarts.DataAccessServer
         }
 
         /// <summary>
-        /// Used to receive notifications when the value attribute is read or written.
+        /// Used to receive notifications when the value attribute is written.
         /// </summary>
-        public ServiceResult OnWriteTagValue(
+        public ValueTask<AttributeWriteResult> OnWriteTagValueAsync(
             ISystemContext context,
             NodeState node,
-            ref Variant value)
+            Variant value,
+            CancellationToken cancellationToken)
         {
             UnderlyingSystem system = context.SystemHandle as UnderlyingSystem;
 
             if (system == null)
             {
-                return StatusCodes.BadCommunicationError;
+                return new ValueTask<AttributeWriteResult>(
+                    new AttributeWriteResult(StatusCodes.BadCommunicationError));
             }
 
             UnderlyingSystemBlock block = system.FindBlock(m_blockId);
 
             if (block == null)
             {
-                return StatusCodes.BadNodeIdUnknown;
+                return new ValueTask<AttributeWriteResult>(
+                    new AttributeWriteResult(StatusCodes.BadNodeIdUnknown));
             }
 
             StatusCode error = block.WriteTagValue(node.SymbolicName, value.AsBoxedObject());
@@ -164,10 +168,10 @@ namespace Quickstarts.DataAccessServer
             if (error != 0)
             {
                 // the simulator uses UA status codes so there is no need for a mapping table.
-                return error;
+                return new ValueTask<AttributeWriteResult>(new AttributeWriteResult(error));
             }
 
-            return ServiceResult.Good;
+            return new ValueTask<AttributeWriteResult>(new AttributeWriteResult(ServiceResult.Good));
         }
 
         /// <summary>
@@ -176,7 +180,7 @@ namespace Quickstarts.DataAccessServer
         /// <param name="tags">The tags.</param>
         private void OnTagsChanged(IList<UnderlyingSystemTag> tags)
         {
-            lock (m_nodeManager.Lock)
+            lock (m_lock)
             {
                 for (int ii = 0; ii < tags.Count; ii++)
                 {
@@ -431,8 +435,9 @@ namespace Quickstarts.DataAccessServer
         #endregion
 
         #region Private Fields
+        private readonly Lock m_lock = new();
         private string m_blockId;
-        private QuickstartNodeManager m_nodeManager;
+        private DataAccessServerNodeManager m_nodeManager;
         private int m_monitoringCount;
         #endregion
     }

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -266,7 +266,7 @@ not parking. Both lists are currently empty.
 
 ## What Tier 1.5 checks today
 
-86 test cases across 16 fixtures, about 1.5 minutes. One fixture per node manager, each
+88 test cases across 16 fixtures, about 1.5 minutes. One fixture per node manager, each
 starting its sample server once and driving it through an ordinary OPC UA session.
 
 **Everything is observed through the services a client would use.** No test reaches into a
@@ -288,14 +288,22 @@ What each fixture pins down, in one line:
 | Methods | Argument metadata, the two argument-validation refusals, the ramp, and replacing a running process |
 | UserAuthentication | UserAccessLevel computed per session, the write refused for anonymous, an unknown user refused a session |
 | PerfTest | The register/offset arithmetic in the node id, nodes synthesized on demand, bounds refused |
-| DataAccess | The segment tree, blocks browsable down to their tags, one block reachable through two paths |
-| AlarmCondition | The configured area tree, areas as notifiers of the server, alarms travelling from source to area |
+| DataAccess | The segment tree, blocks browsable down to their tags, one block reachable through two paths, a set point written through to the underlying system |
+| AlarmCondition | The configured area tree, areas as notifiers of the server, alarms travelling from source to area, a condition refresh replaying the retained dialogs |
 | HistoricalAccess | Raw reads, continuation points, read-at-time, aggregates, inserting into the history, and which items are still being collected |
 | HistoricalEvents | The well tree, event history with continuation points, and the two refusals the sample declares |
 | Aggregation | The proxy root for the configured downstream server, and the pass through behind it: browsing the other server's address space, reading a static value, and a subscription forwarded downstream with its notifications coming back |
 | TestData | Static write round trip, simulated values while monitored, and which single variable is archived |
 | MemoryBuffer | Tags synthesized from node ids, and the three creation refusals the custom monitored item makes |
 | Boiler (sample server) | Display names renamed after the unit, and the state machine started by the node manager itself |
+
+The condition refresh test earned its keep on arrival: the dialog condition every alarm
+source creates was never replayed by a refresh. `SetEnableState` in the 2.0 stack
+re-evaluates `Retain` when a condition is enabled, a dialog is not considered interesting on
+its own, and the sample had set `Retain` to true just *before* enabling - so the flag was
+silently cleared and a client connecting after startup could never learn that a response was
+wanted. `Workshop/AlarmCondition/Server/Model/SourceState.cs` now sets the retain state after
+enabling, and the refresh replays one dialog per source until somebody answers it.
 
 ### Recorded issues
 


### PR DESCRIPTION
Part of #753; fixes #761. Both samples build their address space by hand (no generated model), so this is the whole migration for each - step 2 (Fluent/source generation) does not apply.

## What changed

- `AlarmConditionServerNodeManager` and `DataAccessServerNodeManager` derive from `AsyncCustomNodeManager`, passing their namespace and a properly categorized logger to the base. The servers register hand-written `IAsyncNodeManagerFactory` implementations through `AddNodeManager` instead of overriding `CreateMasterNodeManager`, following the `TestDataNodeManager` shape in UA-.NETStandard.
- The virtual address space moved onto the async overrides: `CreateAddressSpaceAsync` (awaits the base, registers the top-level areas through `AddRootNotifierAsync`, wires the external references as before), `DeleteAddressSpaceAsync`, and `GetManagerHandleAsync`/`ValidateNodeAsync` working on the SDK's `NodeHandle` and `ParsedNodeId`. Those SDK types are drop-in replacements for the Quickstart Library copies - the tests already construct tag ids with `Opc.Ua.Server.ParsedNodeId` against the samples' own ids - so **both server projects drop their Quickstart Library reference entirely**; only HistoricalAccess still builds on that fork. The parsed-but-never-read DataAccess configuration field is gone too.
- The event paths are asynchronous wherever the caller can await: the AlarmCondition simulation timer reports its system events through `Server.ReportEventAsync`, and an alarm change reported by the underlying system updates the condition under a per-source lock and reports it through `ReportEventAsync`/`ClearChangeMasksAsync` outside of it. The condition method handlers (acknowledge, confirm, shelve, respond) keep a synchronous bridge because the SDK's condition delegates have no async variants. `ConditionRefresh` needs no sample code any more - the base class's `IConditionRefreshAsyncNodeManager` implementation walks the root notifiers into `SourceState.ConditionRefresh`.
- DataAccess routes tag writes through `OnSimpleWriteValueAsync`, and the block bookkeeping moved into `OnMonitoredItemCreated`/`OnMonitoredItemDeletedAsync` over a concurrent `NodeIdDictionary`.
- No `QuickstartNodeManager` and no coarse `lock (Lock)` remains. The model objects guard their own state with a private lock, which is the shape the SDK's own TestData and Alarm samples use.

## A defect the new tests found

`ConditionRefreshReplaysRetainedConditions` calls `ConditionRefresh` the way the sample client does and expects the retained dialog of every source between the refresh markers. It failed on arrival: `SetEnableState` in the 2.0 stack re-evaluates `Retain` (`EvaluateRetainStateOnEnable` → `GetRetainState`), `DialogConditionState` does not consider an active dialog interesting on its own, and `CreateDialog` set `Retain = true` just *before* enabling - so the flag was silently cleared and a client which connected after startup could never learn that a response was wanted. The dialog now sets its retain state after enabling, and the refresh replays one dialog per source until somebody answers it.

## Tests

- `ConditionRefreshReplaysRetainedConditions` - the refresh markers arrive and the retained dialog of all four configured sources is replayed between them (the other half of the #761 acceptance criteria next to the existing live-alarm tests).
- `ControllerSetPointIsWritable` - writes FC1001's set point through the async handler into the underlying system and reads it back through a freshly built block, restoring the original value so the fixture stays order-independent.
- `EventCapture` exposes the id the server gave its subscription, which is what a `ConditionRefresh` call takes as its argument.
- `docs/TESTING.md` records the new coverage and the retain find.

## Test plan

- `dotnet test Tests/SampleNodeManagers.Tests` - 83 passed, 3 pre-existing skips (both migrated fixtures 15/15 including the two new tests)
- `dotnet test Tests/SampleServers.Tests` - 88/88
- `dotnet test Tests/SampleClients.Tests --filter AlarmCondition|DataAccess` - 2/2 (the WinForms clients against the migrated servers)
- `dotnet build "UA Samples.slnx"` - no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
