### PR TITLE
Migrate Workshop Methods, Empty and UserAuthentication to AsyncCustomNodeManager

### DIFF
--- a/Workshop/Empty/Server/EmptyNodeManager.cs
+++ b/Workshop/Empty/Server/EmptyNodeManager.cs
@@ -2,7 +2,7 @@
  * Copyright (c) 2005-2019 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
- * 
+ *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
  * files (the "Software"), to deal in the Software without
@@ -11,7 +11,7 @@
  * copies of the Software, and to permit persons to whom the
  * Software is furnished to do so, subject to the following
  * conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
@@ -27,23 +27,39 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
-using System;
 using System.Collections.Generic;
-using System.Text;
-using System.Diagnostics;
-using System.Xml;
-using System.IO;
 using System.Threading;
-using System.Reflection;
+using System.Threading.Tasks;
 using Opc.Ua;
 using Opc.Ua.Server;
 
 namespace Quickstarts.EmptyServer
 {
     /// <summary>
+    /// The factory the server registers to create the node manager.
+    /// </summary>
+    public class EmptyNodeManagerFactory : IAsyncNodeManagerFactory
+    {
+        /// <inheritdoc/>
+        public ValueTask<IAsyncNodeManager> CreateAsync(
+            IServerInternal server,
+            ApplicationConfiguration configuration,
+            CancellationToken cancellationToken = default)
+        {
+#pragma warning disable CA2000 // Justification: ownership of the node manager transfers to the caller.
+            return new ValueTask<IAsyncNodeManager>(
+                new EmptyNodeManager(server, configuration));
+#pragma warning restore CA2000
+        }
+
+        /// <inheritdoc/>
+        public ArrayOf<string> NamespacesUris => [Namespaces.Empty];
+    }
+
+    /// <summary>
     /// A node manager for a server that exposes several variables.
     /// </summary>
-    public class EmptyNodeManager : CustomNodeManager2
+    public class EmptyNodeManager : AsyncCustomNodeManager
     {
         #region Constructors
         /// <summary>
@@ -53,190 +69,83 @@ namespace Quickstarts.EmptyServer
         :
             base(server, configuration, Namespaces.Empty)
         {
-            SystemContext.NodeIdFactory = this;
-
-            // get the configuration for the node manager.
-            m_configuration = configuration.ParseExtension<EmptyServerConfiguration>();
-
-            // use suitable defaults if no configuration exists.
-            if (m_configuration == null)
-            {
-                m_configuration = new EmptyServerConfiguration();
-            }
         }
         #endregion
 
-        #region IDisposable Members
-        /// <summary>
-        /// An overrideable version of the Dispose.
-        /// </summary>
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                // TBD
-            }
-
-            base.Dispose(disposing);
-        }
-        #endregion
-
-        #region INodeIdFactory Members
-        /// <summary>
-        /// Creates the NodeId for the specified node.
-        /// </summary>
-        public override NodeId New(ISystemContext context, NodeState node)
-        {
-            return node.NodeId;
-        }
-        #endregion
-
-        #region INodeManager Members
+        #region IAsyncNodeManager Members
         /// <summary>
         /// Does any initialization required before the address space can be used.
         /// </summary>
         /// <remarks>
         /// The externalReferences is an out parameter that allows the node manager to link to nodes
         /// in other node managers. For example, the 'Objects' node is managed by the CoreNodeManager and
-        /// should have a reference to the root folder node(s) exposed by this node manager.  
+        /// should have a reference to the root folder node(s) exposed by this node manager.
         /// </remarks>
-        public override void CreateAddressSpace(IDictionary<NodeId, IList<IReference>> externalReferences)
+        public override async ValueTask CreateAddressSpaceAsync(
+            IDictionary<NodeId, IList<IReference>> externalReferences,
+            CancellationToken cancellationToken = default)
         {
-            lock (Lock)
-            {
-#pragma warning disable CA2000 // Justification: Node ownership is transferred to the server address space.
-                BaseObjectState trigger = new BaseObjectState(null);
-#pragma warning restore CA2000
-
-                trigger.NodeId = new NodeId(1, NamespaceIndex);
-                trigger.BrowseName = new QualifiedName("Trigger", NamespaceIndex);
-                trigger.DisplayName = new LocalizedText(trigger.BrowseName.Name);
-                trigger.TypeDefinitionId = ObjectTypeIds.BaseObjectType;
-
-                // ensure trigger can be found via the server object. 
-                IList<IReference> references = null;
-
-                if (!externalReferences.TryGetValue(ObjectIds.ObjectsFolder, out references))
-                {
-                    externalReferences[ObjectIds.ObjectsFolder] = references = new List<IReference>();
-                }
-
-                trigger.AddReference(ReferenceTypeIds.Organizes, true, ObjectIds.ObjectsFolder);
-                references.Add(new NodeStateReference(ReferenceTypeIds.Organizes, false, trigger.NodeId));
+            await base.CreateAddressSpaceAsync(externalReferences, cancellationToken).ConfigureAwait(false);
 
 #pragma warning disable CA2000 // Justification: Node ownership is transferred to the server address space.
-                PropertyState property = new PropertyState(trigger);
+            BaseObjectState trigger = new BaseObjectState(null);
 #pragma warning restore CA2000
 
-                property.NodeId = new NodeId(2, NamespaceIndex);
-                property.BrowseName = new QualifiedName("Matrix", NamespaceIndex);
-                property.DisplayName = new LocalizedText(property.BrowseName.Name);
-                property.TypeDefinitionId = VariableTypeIds.PropertyType;
-                property.ReferenceTypeId = ReferenceTypeIds.HasProperty;
-                property.DataType = DataTypeIds.Int32;
-                property.ValueRank = ValueRanks.TwoDimensions;
-                property.ArrayDimensions = new uint[] { 2, 2 }.ToArrayOf();
+            trigger.NodeId = new NodeId(1, NamespaceIndex);
+            trigger.BrowseName = new QualifiedName("Trigger", NamespaceIndex);
+            trigger.DisplayName = new LocalizedText(trigger.BrowseName.Name);
+            trigger.TypeDefinitionId = ObjectTypeIds.BaseObjectType;
 
-                trigger.AddChild(property);
+            // ensure trigger can be found via the server object.
+            IList<IReference> references = null;
 
-                // save in dictionary. 
-                AddPredefinedNode(SystemContext, trigger);
+            if (!externalReferences.TryGetValue(ObjectIds.ObjectsFolder, out references))
+            {
+                externalReferences[ObjectIds.ObjectsFolder] = references = new List<IReference>();
+            }
+
+            trigger.AddReference(ReferenceTypeIds.Organizes, true, ObjectIds.ObjectsFolder);
+            references.Add(new NodeStateReference(ReferenceTypeIds.Organizes, false, trigger.NodeId));
 
 #pragma warning disable CA2000 // Justification: Node ownership is transferred to the server address space.
-                ReferenceTypeState referenceType = new ReferenceTypeState();
+            PropertyState property = new PropertyState(trigger);
 #pragma warning restore CA2000
 
-                referenceType.NodeId = new NodeId(3, NamespaceIndex);
-                referenceType.BrowseName = new QualifiedName("IsTriggerSource", NamespaceIndex);
-                referenceType.DisplayName = new LocalizedText(referenceType.BrowseName.Name);
-                referenceType.InverseName = new LocalizedText("IsSourceOfTrigger");
-                referenceType.SuperTypeId = ReferenceTypeIds.NonHierarchicalReferences;
+            property.NodeId = new NodeId(2, NamespaceIndex);
+            property.BrowseName = new QualifiedName("Matrix", NamespaceIndex);
+            property.DisplayName = new LocalizedText(property.BrowseName.Name);
+            property.TypeDefinitionId = VariableTypeIds.PropertyType;
+            property.ReferenceTypeId = ReferenceTypeIds.HasProperty;
+            property.DataType = DataTypeIds.Int32;
+            property.ValueRank = ValueRanks.TwoDimensions;
+            property.ArrayDimensions = new uint[] { 2, 2 }.ToArrayOf();
 
-                if (!externalReferences.TryGetValue(ObjectIds.Server, out references))
-                {
-                    externalReferences[ObjectIds.Server] = references = new List<IReference>();
-                }
+            trigger.AddChild(property);
 
-                trigger.AddReference(referenceType.NodeId, false, ObjectIds.Server);
-                references.Add(new NodeStateReference(referenceType.NodeId, true, trigger.NodeId));
+            // save in dictionary.
+            await AddPredefinedNodeAsync(SystemContext, trigger, cancellationToken).ConfigureAwait(false);
 
-                // save in dictionary. 
-                AddPredefinedNode(SystemContext, referenceType);
-            }
-        }
+#pragma warning disable CA2000 // Justification: Node ownership is transferred to the server address space.
+            ReferenceTypeState referenceType = new ReferenceTypeState();
+#pragma warning restore CA2000
 
-        /// <summary>
-        /// Frees any resources allocated for the address space.
-        /// </summary>
-        public override void DeleteAddressSpace()
-        {
-            lock (Lock)
+            referenceType.NodeId = new NodeId(3, NamespaceIndex);
+            referenceType.BrowseName = new QualifiedName("IsTriggerSource", NamespaceIndex);
+            referenceType.DisplayName = new LocalizedText(referenceType.BrowseName.Name);
+            referenceType.InverseName = new LocalizedText("IsSourceOfTrigger");
+            referenceType.SuperTypeId = ReferenceTypeIds.NonHierarchicalReferences;
+
+            if (!externalReferences.TryGetValue(ObjectIds.Server, out references))
             {
-                // TBD
+                externalReferences[ObjectIds.Server] = references = new List<IReference>();
             }
+
+            trigger.AddReference(referenceType.NodeId, false, ObjectIds.Server);
+            references.Add(new NodeStateReference(referenceType.NodeId, true, trigger.NodeId));
+
+            // save in dictionary.
+            await AddPredefinedNodeAsync(SystemContext, referenceType, cancellationToken).ConfigureAwait(false);
         }
-
-        /// <summary>
-        /// Returns a unique handle for the node.
-        /// </summary>
-        protected override NodeHandle GetManagerHandle(ServerSystemContext context, NodeId nodeId, IDictionary<NodeId, NodeState> cache)
-        {
-            lock (Lock)
-            {
-                // quickly exclude nodes that are not in the namespace. 
-                if (!IsNodeIdInNamespace(nodeId))
-                {
-                    return null;
-                }
-
-                NodeState node = null;
-
-                if (!PredefinedNodes.TryGetValue(nodeId, out node))
-                {
-                    return null;
-                }
-
-                NodeHandle handle = new NodeHandle();
-
-                handle.NodeId = nodeId;
-                handle.Node = node;
-                handle.Validated = true;
-
-                return handle;
-            }
-        }
-
-        /// <summary>
-        /// Verifies that the specified node exists.
-        /// </summary>
-        protected override NodeState ValidateNode(
-            ServerSystemContext context,
-            NodeHandle handle,
-            IDictionary<NodeId, NodeState> cache)
-        {
-            // not valid if no root.
-            if (handle == null)
-            {
-                return null;
-            }
-
-            // check if previously validated.
-            if (handle.Validated)
-            {
-                return handle.Node;
-            }
-
-            // TBD
-
-            return null;
-        }
-        #endregion
-
-        #region Overridden Methods
-        #endregion
-
-        #region Private Fields
-        private EmptyServerConfiguration m_configuration;
         #endregion
     }
 }

--- a/Workshop/Empty/Server/EmptyServer.cs
+++ b/Workshop/Empty/Server/EmptyServer.cs
@@ -27,10 +27,6 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-using Microsoft.Extensions.Logging;
 using Opc.Ua;
 using Opc.Ua.Server;
 
@@ -43,8 +39,8 @@ namespace Quickstarts.EmptyServer
     /// Each server instance must have one instance of a StandardServer object which is
     /// responsible for reading the configuration file, creating the endpoints and dispatching
     /// incoming requests to the appropriate handler.
-    /// 
-    /// This sub-class specifies non-configurable metadata such as Product Name and initializes
+    ///
+    /// This sub-class specifies non-configurable metadata such as Product Name and registers
     /// the EmptyNodeManager which provides access to the data exposed by the Server.
     /// </remarks>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1724:Type names should not match namespaces", Justification = "Sample server type name intentionally mirrors the namespace.")]
@@ -52,31 +48,12 @@ namespace Quickstarts.EmptyServer
     {
         public EmptyServer(ITelemetryContext telemetry) : base(telemetry)
         {
+            // register the node manager factory. the server creates the node manager
+            // from it while it builds the master node manager on startup.
+            AddNodeManager(new EmptyNodeManagerFactory());
         }
 
         #region Overridden Methods
-        /// <summary>
-        /// Creates the node managers for the server.
-        /// </summary>
-        /// <remarks>
-        /// This method allows the sub-class create any additional node managers which it uses. The SDK
-        /// always creates a CoreNodeManager which handles the built-in nodes defined by the specification.
-        /// Any additional NodeManagers are expected to handle application specific nodes.
-        /// </remarks>
-        protected override MasterNodeManager CreateMasterNodeManager(IServerInternal server, ApplicationConfiguration configuration)
-        {
-            ILogger logger = server.Telemetry.CreateLogger<EmptyServer>();
-            logger.LogInformation("Creating the Node Managers.");
-
-            List<INodeManager> nodeManagers = new List<INodeManager>();
-
-            // create the custom node managers.
-            nodeManagers.Add(new EmptyNodeManager(server, configuration));
-
-            // create master node manager.
-            return new MasterNodeManager(server, configuration, null, nodeManagers.ToArray());
-        }
-
         /// <summary>
         /// Loads the non-configurable properties for the application.
         /// </summary>

--- a/Workshop/Methods/Server/MethodsNodeManager.cs
+++ b/Workshop/Methods/Server/MethodsNodeManager.cs
@@ -2,7 +2,7 @@
  * Copyright (c) 2005-2019 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
- * 
+ *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
  * files (the "Software"), to deal in the Software without
@@ -11,7 +11,7 @@
  * copies of the Software, and to permit persons to whom the
  * Software is furnished to do so, subject to the following
  * conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
@@ -29,22 +29,39 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
-using System.Diagnostics;
-using System.Xml;
-using System.IO;
 using System.Threading;
-using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Opc.Ua;
 using Opc.Ua.Server;
-using Microsoft.Extensions.Logging;
 
 namespace Quickstarts.MethodsServer
 {
     /// <summary>
+    /// The factory the server registers to create the node manager.
+    /// </summary>
+    public class MethodsNodeManagerFactory : IAsyncNodeManagerFactory
+    {
+        /// <inheritdoc/>
+        public ValueTask<IAsyncNodeManager> CreateAsync(
+            IServerInternal server,
+            ApplicationConfiguration configuration,
+            CancellationToken cancellationToken = default)
+        {
+#pragma warning disable CA2000 // Justification: ownership of the node manager transfers to the caller.
+            return new ValueTask<IAsyncNodeManager>(
+                new MethodsNodeManager(server, configuration));
+#pragma warning restore CA2000
+        }
+
+        /// <inheritdoc/>
+        public ArrayOf<string> NamespacesUris => [Namespaces.Methods];
+    }
+
+    /// <summary>
     /// A node manager for a server that exposes several variables.
     /// </summary>
-    public class MethodsNodeManager : CustomNodeManager2
+    public class MethodsNodeManager : AsyncCustomNodeManager
     {
         #region Constructors
         /// <summary>
@@ -54,16 +71,6 @@ namespace Quickstarts.MethodsServer
         :
             base(server, configuration, Namespaces.Methods)
         {
-            SystemContext.NodeIdFactory = this;
-
-            // get the configuration for the node manager.
-            m_configuration = configuration.ParseExtension<MethodsServerConfiguration>();
-
-            // use suitable defaults if no configuration exists.
-            if (m_configuration == null)
-            {
-                m_configuration = new MethodsServerConfiguration();
-            }
         }
         #endregion
 
@@ -84,133 +91,124 @@ namespace Quickstarts.MethodsServer
         }
         #endregion
 
-        #region INodeIdFactory Members
-        /// <summary>
-        /// Creates the NodeId for the specified node.
-        /// </summary>
-        public override NodeId New(ISystemContext context, NodeState node)
-        {
-            return node.NodeId;
-        }
-        #endregion
-
-        #region INodeManager Members
+        #region IAsyncNodeManager Members
         /// <summary>
         /// Does any initialization required before the address space can be used.
         /// </summary>
         /// <remarks>
         /// The externalReferences is an out parameter that allows the node manager to link to nodes
         /// in other node managers. For example, the 'Objects' node is managed by the CoreNodeManager and
-        /// should have a reference to the root folder node(s) exposed by this node manager.  
+        /// should have a reference to the root folder node(s) exposed by this node manager.
         /// </remarks>
-        public override void CreateAddressSpace(IDictionary<NodeId, IList<IReference>> externalReferences)
+        public override async ValueTask CreateAddressSpaceAsync(
+            IDictionary<NodeId, IList<IReference>> externalReferences,
+            CancellationToken cancellationToken = default)
         {
-            lock (Lock)
+            await base.CreateAddressSpaceAsync(externalReferences, cancellationToken).ConfigureAwait(false);
+
+            // create a object to represent the process being controlled.
+#pragma warning disable CA2000 // Justification: Node ownership is transferred to the server address space.
+            BaseObjectState process = new BaseObjectState(null);
+#pragma warning restore CA2000
+
+            process.NodeId = new NodeId(1, NamespaceIndex);
+            process.BrowseName = new QualifiedName("My Process", NamespaceIndex);
+            process.DisplayName = new LocalizedText(process.BrowseName.Name);
+            process.TypeDefinitionId = ObjectTypeIds.BaseObjectType;
+
+            // ensure the process object can be found via the server object.
+            IList<IReference> references = null;
+
+            if (!externalReferences.TryGetValue(ObjectIds.ObjectsFolder, out references))
             {
-                // create a object to represent the process being controlled.
-#pragma warning disable CA2000 // Justification: Node ownership is transferred to the server address space.
-                BaseObjectState process = new BaseObjectState(null);
-#pragma warning restore CA2000
-
-                process.NodeId = new NodeId(1, NamespaceIndex);
-                process.BrowseName = new QualifiedName("My Process", NamespaceIndex);
-                process.DisplayName = new LocalizedText(process.BrowseName.Name);
-                process.TypeDefinitionId = ObjectTypeIds.BaseObjectType;
-
-                // ensure the process object can be found via the server object. 
-                IList<IReference> references = null;
-
-                if (!externalReferences.TryGetValue(ObjectIds.ObjectsFolder, out references))
-                {
-                    externalReferences[ObjectIds.ObjectsFolder] = references = new List<IReference>();
-                }
-
-                process.AddReference(ReferenceTypeIds.Organizes, true, ObjectIds.ObjectsFolder);
-                references.Add(new NodeStateReference(ReferenceTypeIds.Organizes, false, process.NodeId));
-
-                // a property to report the process state.
-                PropertyState<uint> state = m_stateNode = PropertyState<uint>.With<VariantBuilder>(process);
-
-                state.NodeId = new NodeId(2, NamespaceIndex);
-                state.BrowseName = new QualifiedName("State", NamespaceIndex);
-                state.DisplayName = new LocalizedText(state.BrowseName.Name);
-                state.TypeDefinitionId = VariableTypeIds.PropertyType;
-                state.ReferenceTypeId = ReferenceTypeIds.HasProperty;
-                state.DataType = DataTypeIds.UInt32;
-                state.ValueRank = ValueRanks.Scalar;
-
-                process.AddChild(state);
-
-                // a method to start the process.
-#pragma warning disable CA2000 // Justification: Node ownership is transferred to the server address space.
-                MethodState start = new MethodState(process);
-#pragma warning restore CA2000
-
-                start.NodeId = new NodeId(3, NamespaceIndex);
-                start.BrowseName = new QualifiedName("Start", NamespaceIndex);
-                start.DisplayName = new LocalizedText(start.BrowseName.Name);
-                start.ReferenceTypeId = ReferenceTypeIds.HasComponent;
-                start.UserExecutable = true;
-                start.Executable = true;
-
-                // add input arguments.
-                start.InputArguments = PropertyState<ArrayOf<Argument>>.With<StructureBuilder<Argument>>(start);
-                start.InputArguments.NodeId = new NodeId(4, NamespaceIndex);
-                start.InputArguments.BrowseName = new QualifiedName(BrowseNames.InputArguments);
-                start.InputArguments.DisplayName = new LocalizedText(start.InputArguments.BrowseName.Name);
-                start.InputArguments.TypeDefinitionId = VariableTypeIds.PropertyType;
-                start.InputArguments.ReferenceTypeId = ReferenceTypeIds.HasProperty;
-                start.InputArguments.DataType = DataTypeIds.Argument;
-                start.InputArguments.ValueRank = ValueRanks.OneDimension;
-
-                Argument[] args = new Argument[2];
-                args[0] = new Argument();
-                args[0].Name = "Initial State";
-                args[0].Description = new LocalizedText("The initialize state for the process.");
-                args[0].DataType = DataTypeIds.UInt32;
-                args[0].ValueRank = ValueRanks.Scalar;
-
-                args[1] = new Argument();
-                args[1].Name = "Final State";
-                args[1].Description = new LocalizedText("The final state for the process.");
-                args[1].DataType = DataTypeIds.UInt32;
-                args[1].ValueRank = ValueRanks.Scalar;
-
-                start.InputArguments.Value = args.ToArrayOf();
-
-                // add output arguments.
-                start.OutputArguments = PropertyState<ArrayOf<Argument>>.With<StructureBuilder<Argument>>(start);
-                start.OutputArguments.NodeId = new NodeId(5, NamespaceIndex);
-                start.OutputArguments.BrowseName = new QualifiedName(BrowseNames.OutputArguments);
-                start.OutputArguments.DisplayName = new LocalizedText(start.OutputArguments.BrowseName.Name);
-                start.OutputArguments.TypeDefinitionId = VariableTypeIds.PropertyType;
-                start.OutputArguments.ReferenceTypeId = ReferenceTypeIds.HasProperty;
-                start.OutputArguments.DataType = DataTypeIds.Argument;
-                start.OutputArguments.ValueRank = ValueRanks.OneDimension;
-
-                args = new Argument[2];
-                args[0] = new Argument();
-                args[0].Name = "Revised Initial State";
-                args[0].Description = new LocalizedText("The revised initialize state for the process.");
-                args[0].DataType = DataTypeIds.UInt32;
-                args[0].ValueRank = ValueRanks.Scalar;
-
-                args[1] = new Argument();
-                args[1].Name = "Revised Final State";
-                args[1].Description = new LocalizedText("The revised final state for the process.");
-                args[1].DataType = DataTypeIds.UInt32;
-                args[1].ValueRank = ValueRanks.Scalar;
-
-                start.OutputArguments.Value = args.ToArrayOf();
-
-                process.AddChild(start);
-
-                // save in dictionary. 
-                AddPredefinedNode(SystemContext, process);
-
-                // set up method handlers. 
-                start.OnCallMethod = new GenericMethodCalledEventHandler(OnStart);
+                externalReferences[ObjectIds.ObjectsFolder] = references = new List<IReference>();
             }
+
+            process.AddReference(ReferenceTypeIds.Organizes, true, ObjectIds.ObjectsFolder);
+            references.Add(new NodeStateReference(ReferenceTypeIds.Organizes, false, process.NodeId));
+
+            // a property to report the process state.
+            PropertyState<uint> state = m_stateNode = PropertyState<uint>.With<VariantBuilder>(process);
+
+            state.NodeId = new NodeId(2, NamespaceIndex);
+            state.BrowseName = new QualifiedName("State", NamespaceIndex);
+            state.DisplayName = new LocalizedText(state.BrowseName.Name);
+            state.TypeDefinitionId = VariableTypeIds.PropertyType;
+            state.ReferenceTypeId = ReferenceTypeIds.HasProperty;
+            state.DataType = DataTypeIds.UInt32;
+            state.ValueRank = ValueRanks.Scalar;
+
+            process.AddChild(state);
+
+            // a method to start the process.
+#pragma warning disable CA2000 // Justification: Node ownership is transferred to the server address space.
+            MethodState start = new MethodState(process);
+#pragma warning restore CA2000
+
+            start.NodeId = new NodeId(3, NamespaceIndex);
+            start.BrowseName = new QualifiedName("Start", NamespaceIndex);
+            start.DisplayName = new LocalizedText(start.BrowseName.Name);
+            start.ReferenceTypeId = ReferenceTypeIds.HasComponent;
+            start.UserExecutable = true;
+            start.Executable = true;
+
+            // add input arguments.
+            start.InputArguments = PropertyState<ArrayOf<Argument>>.With<StructureBuilder<Argument>>(start);
+            start.InputArguments.NodeId = new NodeId(4, NamespaceIndex);
+            start.InputArguments.BrowseName = new QualifiedName(BrowseNames.InputArguments);
+            start.InputArguments.DisplayName = new LocalizedText(start.InputArguments.BrowseName.Name);
+            start.InputArguments.TypeDefinitionId = VariableTypeIds.PropertyType;
+            start.InputArguments.ReferenceTypeId = ReferenceTypeIds.HasProperty;
+            start.InputArguments.DataType = DataTypeIds.Argument;
+            start.InputArguments.ValueRank = ValueRanks.OneDimension;
+
+            Argument[] args = new Argument[2];
+            args[0] = new Argument();
+            args[0].Name = "Initial State";
+            args[0].Description = new LocalizedText("The initialize state for the process.");
+            args[0].DataType = DataTypeIds.UInt32;
+            args[0].ValueRank = ValueRanks.Scalar;
+
+            args[1] = new Argument();
+            args[1].Name = "Final State";
+            args[1].Description = new LocalizedText("The final state for the process.");
+            args[1].DataType = DataTypeIds.UInt32;
+            args[1].ValueRank = ValueRanks.Scalar;
+
+            start.InputArguments.Value = args.ToArrayOf();
+
+            // add output arguments.
+            start.OutputArguments = PropertyState<ArrayOf<Argument>>.With<StructureBuilder<Argument>>(start);
+            start.OutputArguments.NodeId = new NodeId(5, NamespaceIndex);
+            start.OutputArguments.BrowseName = new QualifiedName(BrowseNames.OutputArguments);
+            start.OutputArguments.DisplayName = new LocalizedText(start.OutputArguments.BrowseName.Name);
+            start.OutputArguments.TypeDefinitionId = VariableTypeIds.PropertyType;
+            start.OutputArguments.ReferenceTypeId = ReferenceTypeIds.HasProperty;
+            start.OutputArguments.DataType = DataTypeIds.Argument;
+            start.OutputArguments.ValueRank = ValueRanks.OneDimension;
+
+            args = new Argument[2];
+            args[0] = new Argument();
+            args[0].Name = "Revised Initial State";
+            args[0].Description = new LocalizedText("The revised initialize state for the process.");
+            args[0].DataType = DataTypeIds.UInt32;
+            args[0].ValueRank = ValueRanks.Scalar;
+
+            args[1] = new Argument();
+            args[1].Name = "Revised Final State";
+            args[1].Description = new LocalizedText("The revised final state for the process.");
+            args[1].DataType = DataTypeIds.UInt32;
+            args[1].ValueRank = ValueRanks.Scalar;
+
+            start.OutputArguments.Value = args.ToArrayOf();
+
+            process.AddChild(start);
+
+            // save in dictionary.
+            await AddPredefinedNodeAsync(SystemContext, process, cancellationToken).ConfigureAwait(false);
+
+            // set up method handlers.
+            start.OnCallMethod2Async = OnStartAsync;
         }
 
         private object m_processLock = new object();
@@ -224,15 +222,19 @@ namespace Quickstarts.MethodsServer
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="method">The method.</param>
+        /// <param name="objectId">The id of the object the method belongs to.</param>
         /// <param name="inputArguments">The input arguments.</param>
         /// <param name="outputArguments">The output arguments.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns></returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1002:Do not expose generic lists", Justification = "GenericMethodCalledEventHandler target: the SDK hands the handler a mutable List<Variant> to fill, because ArrayOf<Variant> is immutable.")]
-        public ServiceResult OnStart(
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1002:Do not expose generic lists", Justification = "GenericMethodCalledEventHandler2Async target: the SDK hands the handler a mutable List<Variant> to fill, because ArrayOf<Variant> is immutable.")]
+        public async ValueTask<ServiceResult> OnStartAsync(
             ISystemContext context,
             MethodState method,
+            NodeId objectId,
             ArrayOf<Variant> inputArguments,
-            List<Variant> outputArguments)
+            List<Variant> outputArguments,
+            CancellationToken cancellationToken = default)
         {
             // all arguments must be provided.
             if (inputArguments.Count < 2)
@@ -249,6 +251,20 @@ namespace Quickstarts.MethodsServer
                 return StatusCodes.BadTypeMismatch;
             }
 
+            StartProcess(initialState.Value, finalState.Value, outputArguments);
+
+            // signal update to state node.
+            m_stateNode.Value = initialState.Value;
+            await m_stateNode.ClearChangeMasksAsync(SystemContext, true, cancellationToken).ConfigureAwait(false);
+
+            return ServiceResult.Good;
+        }
+
+        /// <summary>
+        /// Starts the process, replacing one which is still running.
+        /// </summary>
+        private void StartProcess(uint initialState, uint finalState, List<Variant> outputArguments)
+        {
             lock (m_processLock)
             {
                 // check if the process is running.
@@ -259,8 +275,8 @@ namespace Quickstarts.MethodsServer
                 }
 
                 // start the process.
-                m_state = initialState.Value;
-                m_finalState = finalState.Value;
+                m_state = initialState;
+                m_finalState = finalState;
                 m_processTimer = new Timer(OnUpdateProcess, null, 1000, 1000);
 
                 // the calling function sets default values for all output arguments.
@@ -268,15 +284,6 @@ namespace Quickstarts.MethodsServer
                 outputArguments[0] = Variant.From(m_state);
                 outputArguments[1] = Variant.From(m_finalState);
             }
-
-            // signal update to state node.
-            lock (Lock)
-            {
-                m_stateNode.Value = m_state;
-                m_stateNode.ClearChangeMasks(SystemContext, true);
-            }
-
-            return ServiceResult.Good;
         }
 
         /// <summary>
@@ -287,6 +294,8 @@ namespace Quickstarts.MethodsServer
         {
             try
             {
+                uint currentState;
+
                 lock (m_processLock)
                 {
                     // check if increasing.
@@ -307,94 +316,20 @@ namespace Quickstarts.MethodsServer
                         m_processTimer.Dispose();
                         m_processTimer = null;
                     }
-                    ;
+
+                    currentState = m_state;
                 }
 
-                // signal update to state node.
-                lock (Lock)
-                {
-                    m_stateNode.Value = m_state;
-                    m_stateNode.ClearChangeMasks(SystemContext, true);
-                }
+                // signal update to state node. the synchronous flush is safe on a timer
+                // thread: it drives the asynchronous notification sinks inline.
+                m_stateNode.Value = currentState;
+                m_stateNode.ClearChangeMasks(SystemContext, true);
             }
             catch (Exception e)
             {
                 m_logger.LogError(e, "Unexpected error updating process.");
             }
         }
-
-        /// <summary>
-        /// Frees any resources allocated for the address space.
-        /// </summary>
-        public override void DeleteAddressSpace()
-        {
-            lock (Lock)
-            {
-                // TBD
-            }
-        }
-
-        /// <summary>
-        /// Returns a unique handle for the node.
-        /// </summary>
-        protected override NodeHandle GetManagerHandle(ServerSystemContext context, NodeId nodeId, IDictionary<NodeId, NodeState> cache)
-        {
-            lock (Lock)
-            {
-                // quickly exclude nodes that are not in the namespace. 
-                if (!IsNodeIdInNamespace(nodeId))
-                {
-                    return null;
-                }
-
-                NodeState node = null;
-
-                if (!PredefinedNodes.TryGetValue(nodeId, out node))
-                {
-                    return null;
-                }
-
-                NodeHandle handle = new NodeHandle();
-
-                handle.NodeId = nodeId;
-                handle.Node = node;
-                handle.Validated = true;
-
-                return handle;
-            }
-        }
-
-        /// <summary>
-        /// Verifies that the specified node exists.
-        /// </summary>
-        protected override NodeState ValidateNode(
-            ServerSystemContext context,
-            NodeHandle handle,
-            IDictionary<NodeId, NodeState> cache)
-        {
-            // not valid if no root.
-            if (handle == null)
-            {
-                return null;
-            }
-
-            // check if previously validated.
-            if (handle.Validated)
-            {
-                return handle.Node;
-            }
-
-            // TBD
-
-            return null;
-        }
-        #endregion
-
-        #region Overridden Methods
-        #endregion
-
-        #region Private Fields
-        private MethodsServerConfiguration m_configuration;
         #endregion
     }
 }

--- a/Workshop/Methods/Server/MethodsServer.cs
+++ b/Workshop/Methods/Server/MethodsServer.cs
@@ -27,10 +27,6 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-using Microsoft.Extensions.Logging;
 using Opc.Ua;
 using Opc.Ua.Server;
 
@@ -43,8 +39,8 @@ namespace Quickstarts.MethodsServer
     /// Each server instance must have one instance of a StandardServer object which is
     /// responsible for reading the configuration file, creating the endpoints and dispatching
     /// incoming requests to the appropriate handler.
-    /// 
-    /// This sub-class specifies non-configurable metadata such as Product Name and initializes
+    ///
+    /// This sub-class specifies non-configurable metadata such as Product Name and registers
     /// the MethodsNodeManager which provides access to the data exposed by the Server.
     /// </remarks>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1724:Type names should not match namespaces", Justification = "Sample server type name intentionally mirrors the namespace.")]
@@ -52,31 +48,12 @@ namespace Quickstarts.MethodsServer
     {
         public MethodsServer(ITelemetryContext telemetry) : base(telemetry)
         {
+            // register the node manager factory. the server creates the node manager
+            // from it while it builds the master node manager on startup.
+            AddNodeManager(new MethodsNodeManagerFactory());
         }
 
         #region Overridden Methods
-        /// <summary>
-        /// Creates the node managers for the server.
-        /// </summary>
-        /// <remarks>
-        /// This method allows the sub-class create any additional node managers which it uses. The SDK
-        /// always creates a CoreNodeManager which handles the built-in nodes defined by the specification.
-        /// Any additional NodeManagers are expected to handle application specific nodes.
-        /// </remarks>
-        protected override MasterNodeManager CreateMasterNodeManager(IServerInternal server, ApplicationConfiguration configuration)
-        {
-            ILogger logger = server.Telemetry.CreateLogger<MethodsServer>();
-            logger.LogInformation("Creating the Node Managers.");
-
-            List<INodeManager> nodeManagers = new List<INodeManager>();
-
-            // create the custom node managers.
-            nodeManagers.Add(new MethodsNodeManager(server, configuration));
-
-            // create master node manager.
-            return new MasterNodeManager(server, configuration, null, nodeManagers.ToArray());
-        }
-
         /// <summary>
         /// Loads the non-configurable properties for the application.
         /// </summary>

--- a/Workshop/UserAuthentication/Server/UserAuthenticationNodeManager.cs
+++ b/Workshop/UserAuthentication/Server/UserAuthenticationNodeManager.cs
@@ -2,7 +2,7 @@
  * Copyright (c) 2005-2019 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
- * 
+ *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
  * files (the "Software"), to deal in the Software without
@@ -11,7 +11,7 @@
  * copies of the Software, and to permit persons to whom the
  * Software is furnished to do so, subject to the following
  * conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
@@ -29,21 +29,39 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
-using System.Diagnostics;
-using System.Xml;
 using System.IO;
 using System.Threading;
-using System.Reflection;
+using System.Threading.Tasks;
 using Opc.Ua;
 using Opc.Ua.Server;
 
 namespace Quickstarts.UserAuthenticationServer
 {
     /// <summary>
+    /// The factory the server registers to create the node manager.
+    /// </summary>
+    public class UserAuthenticationNodeManagerFactory : IAsyncNodeManagerFactory
+    {
+        /// <inheritdoc/>
+        public ValueTask<IAsyncNodeManager> CreateAsync(
+            IServerInternal server,
+            ApplicationConfiguration configuration,
+            CancellationToken cancellationToken = default)
+        {
+#pragma warning disable CA2000 // Justification: ownership of the node manager transfers to the caller.
+            return new ValueTask<IAsyncNodeManager>(
+                new UserAuthenticationNodeManager(server, configuration));
+#pragma warning restore CA2000
+        }
+
+        /// <inheritdoc/>
+        public ArrayOf<string> NamespacesUris => [Namespaces.UserAuthentication];
+    }
+
+    /// <summary>
     /// A node manager for a server that exposes several variables.
     /// </summary>
-    public class UserAuthenticationNodeManager : CustomNodeManager2
+    public class UserAuthenticationNodeManager : AsyncCustomNodeManager
     {
         #region Constructors
         /// <summary>
@@ -51,107 +69,79 @@ namespace Quickstarts.UserAuthenticationServer
         /// </summary>
         public UserAuthenticationNodeManager(IServerInternal server, ApplicationConfiguration configuration)
         :
-            base(server, Namespaces.UserAuthentication)
+            base(server, configuration, Namespaces.UserAuthentication)
         {
-            SystemContext.NodeIdFactory = this;
-
-            // get the configuration for the node manager.
-            m_configuration = configuration.ParseExtension<UserAuthenticationServerConfiguration>();
-
-            // use suitable defaults if no configuration exists.
-            if (m_configuration == null)
-            {
-                m_configuration = new UserAuthenticationServerConfiguration();
-            }
         }
         #endregion
 
-        #region IDisposable Members
-        /// <summary>
-        /// An overrideable version of the Dispose.
-        /// </summary>
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                // TBD
-            }
-
-            base.Dispose(disposing);
-        }
-        #endregion
-
-        #region INodeIdFactory Members
-        /// <summary>
-        /// Creates the NodeId for the specified node.
-        /// </summary>
-        public override NodeId New(ISystemContext context, NodeState node)
-        {
-            return node.NodeId;
-        }
-        #endregion
-
-        #region INodeManager Members
+        #region IAsyncNodeManager Members
         /// <summary>
         /// Does any initialization required before the address space can be used.
         /// </summary>
         /// <remarks>
         /// The externalReferences is an out parameter that allows the node manager to link to nodes
         /// in other node managers. For example, the 'Objects' node is managed by the CoreNodeManager and
-        /// should have a reference to the root folder node(s) exposed by this node manager.  
+        /// should have a reference to the root folder node(s) exposed by this node manager.
         /// </remarks>
-        public override void CreateAddressSpace(IDictionary<NodeId, IList<IReference>> externalReferences)
+        public override async ValueTask CreateAddressSpaceAsync(
+            IDictionary<NodeId, IList<IReference>> externalReferences,
+            CancellationToken cancellationToken = default)
         {
-            lock (Lock)
+            await base.CreateAddressSpaceAsync(externalReferences, cancellationToken).ConfigureAwait(false);
+
+            // create a object to represent the process being controlled.
+#pragma warning disable CA2000 // Justification: Node ownership is transferred to the server address space.
+            BaseObjectState process = new BaseObjectState(null);
+#pragma warning restore CA2000
+
+            process.NodeId = new NodeId(1, NamespaceIndex);
+            process.BrowseName = new QualifiedName("My Process", NamespaceIndex);
+            process.DisplayName = new LocalizedText(process.BrowseName.Name);
+            process.TypeDefinitionId = ObjectTypeIds.BaseObjectType;
+
+            // ensure the process object can be found via the server object.
+            IList<IReference> references = null;
+
+            if (!externalReferences.TryGetValue(ObjectIds.ObjectsFolder, out references))
             {
-                // create a object to represent the process being controlled.
-#pragma warning disable CA2000 // Justification: Node ownership is transferred to the server address space.
-                BaseObjectState process = new BaseObjectState(null);
-#pragma warning restore CA2000
-
-                process.NodeId = new NodeId(1, NamespaceIndex);
-                process.BrowseName = new QualifiedName("My Process", NamespaceIndex);
-                process.DisplayName = new LocalizedText(process.BrowseName.Name);
-                process.TypeDefinitionId = ObjectTypeIds.BaseObjectType;
-
-                // ensure the process object can be found via the server object. 
-                IList<IReference> references = null;
-
-                if (!externalReferences.TryGetValue(ObjectIds.ObjectsFolder, out references))
-                {
-                    externalReferences[ObjectIds.ObjectsFolder] = references = new List<IReference>();
-                }
-
-                process.AddReference(ReferenceTypeIds.Organizes, true, ObjectIds.ObjectsFolder);
-                references.Add(new NodeStateReference(ReferenceTypeIds.Organizes, false, process.NodeId));
-
-                // a property to report the process state.
-#pragma warning disable CA2000 // Justification: Node ownership is transferred to the server address space.
-                PropertyState<string> state = PropertyState<string>.With<VariantBuilder>(process);
-#pragma warning restore CA2000
-
-                state.NodeId = new NodeId(2, NamespaceIndex);
-                state.BrowseName = new QualifiedName("LogFilePath", NamespaceIndex);
-                state.DisplayName = new LocalizedText(state.BrowseName.Name);
-                state.TypeDefinitionId = VariableTypeIds.PropertyType;
-                state.ReferenceTypeId = ReferenceTypeIds.HasProperty;
-                state.DataType = DataTypeIds.String;
-                state.ValueRank = ValueRanks.Scalar;
-                state.AccessLevel = AccessLevels.CurrentReadOrWrite;
-                state.UserAccessLevel = AccessLevels.CurrentRead;
-                state.Value = ".\\Log.txt";
-
-                process.AddChild(state);
-
-                state.OnReadUserAccessLevel = OnReadUserAccessLevel;
-                state.OnSimpleWriteValue = OnWriteValue;
-
-                // save in dictionary. 
-                AddPredefinedNode(SystemContext, process);
+                externalReferences[ObjectIds.ObjectsFolder] = references = new List<IReference>();
             }
+
+            process.AddReference(ReferenceTypeIds.Organizes, true, ObjectIds.ObjectsFolder);
+            references.Add(new NodeStateReference(ReferenceTypeIds.Organizes, false, process.NodeId));
+
+            // a property to report the process state.
+#pragma warning disable CA2000 // Justification: Node ownership is transferred to the server address space.
+            PropertyState<string> state = PropertyState<string>.With<VariantBuilder>(process);
+#pragma warning restore CA2000
+
+            state.NodeId = new NodeId(2, NamespaceIndex);
+            state.BrowseName = new QualifiedName("LogFilePath", NamespaceIndex);
+            state.DisplayName = new LocalizedText(state.BrowseName.Name);
+            state.TypeDefinitionId = VariableTypeIds.PropertyType;
+            state.ReferenceTypeId = ReferenceTypeIds.HasProperty;
+            state.DataType = DataTypeIds.String;
+            state.ValueRank = ValueRanks.Scalar;
+            state.AccessLevel = AccessLevels.CurrentReadOrWrite;
+            state.UserAccessLevel = AccessLevels.CurrentRead;
+            state.Value = ".\\Log.txt";
+
+            process.AddChild(state);
+
+            // the user access level is answered per session, the write callback
+            // enforces the same identity check again before it touches the file system.
+            state.OnReadUserAccessLevel = OnReadUserAccessLevel;
+            state.OnSimpleWriteValueAsync = OnWriteValueAsync;
+
+            // save in dictionary.
+            await AddPredefinedNodeAsync(SystemContext, process, cancellationToken).ConfigureAwait(false);
         }
 
-        public ServiceResult OnWriteValue(ISystemContext context, NodeState node, ref Variant value)
+        public async ValueTask<AttributeWriteResult> OnWriteValueAsync(
+            ISystemContext context,
+            NodeState node,
+            Variant value,
+            CancellationToken cancellationToken)
         {
             UserTokenType? tokenType = (context as ISessionSystemContext)?.UserIdentity?.TokenType;
 
@@ -162,10 +152,12 @@ namespace Quickstarts.UserAuthenticationServer
                     "en-US",
                     "User cannot change value.");
 
-                return new ServiceResult(StatusCodes.BadUserAccessDenied, new LocalizedText(info));
+                return new AttributeWriteResult(
+                    new ServiceResult(StatusCodes.BadUserAccessDenied, new LocalizedText(info)));
             }
 
-            // attempt to update file system.
+            // attempt to update file system. on success the framework stores the
+            // written value in the variable, mirroring the synchronous write path.
             try
             {
                 string filePath = value.AsBoxedObject() as string;
@@ -185,20 +177,23 @@ namespace Quickstarts.UserAuthenticationServer
                 {
                     FileInfo file = new FileInfo(filePath);
 
-                    using (StreamWriter writer = file.CreateText())
+                    StreamWriter writer = file.CreateText();
+
+                    await using (writer.ConfigureAwait(false))
                     {
-                        writer.WriteLine(System.Security.Principal.WindowsIdentity.GetCurrent().Name);
+                        await writer.WriteLineAsync(
+                            System.Security.Principal.WindowsIdentity.GetCurrent().Name.AsMemory(),
+                            cancellationToken).ConfigureAwait(false);
                     }
                 }
-
-                value = new Variant(filePath);
             }
             catch (Exception e)
             {
-                return ServiceResult.Create(e, StatusCodes.BadUserAccessDenied, "Could not update file system.");
+                return new AttributeWriteResult(
+                    ServiceResult.Create(e, StatusCodes.BadUserAccessDenied, "Could not update file system."));
             }
 
-            return ServiceResult.Good;
+            return new AttributeWriteResult(ServiceResult.Good);
         }
 
         public ServiceResult OnReadUserAccessLevel(ISystemContext context, NodeState node, ref byte value)
@@ -216,79 +211,6 @@ namespace Quickstarts.UserAuthenticationServer
 
             return ServiceResult.Good;
         }
-
-        /// <summary>
-        /// Frees any resources allocated for the address space.
-        /// </summary>
-        public override void DeleteAddressSpace()
-        {
-            lock (Lock)
-            {
-                // TBD
-            }
-        }
-
-        /// <summary>
-        /// Returns a unique handle for the node.
-        /// </summary>
-        protected override NodeHandle GetManagerHandle(ServerSystemContext context, NodeId nodeId, IDictionary<NodeId, NodeState> cache)
-        {
-            lock (Lock)
-            {
-                // quickly exclude nodes that are not in the namespace. 
-                if (!IsNodeIdInNamespace(nodeId))
-                {
-                    return null;
-                }
-
-                NodeState node = null;
-
-                if (!PredefinedNodes.TryGetValue(nodeId, out node))
-                {
-                    return null;
-                }
-
-                NodeHandle handle = new NodeHandle();
-
-                handle.NodeId = nodeId;
-                handle.Node = node;
-                handle.Validated = true;
-
-                return handle;
-            }
-        }
-
-        /// <summary>
-        /// Verifies that the specified node exists.
-        /// </summary>
-        protected override NodeState ValidateNode(
-            ServerSystemContext context,
-            NodeHandle handle,
-            IDictionary<NodeId, NodeState> cache)
-        {
-            // not valid if no root.
-            if (handle == null)
-            {
-                return null;
-            }
-
-            // check if previously validated.
-            if (handle.Validated)
-            {
-                return handle.Node;
-            }
-
-            // TBD
-
-            return null;
-        }
-        #endregion
-
-        #region Overridden UserAuthentication
-        #endregion
-
-        #region Private Fields
-        private UserAuthenticationServerConfiguration m_configuration;
         #endregion
     }
 }

--- a/Workshop/UserAuthentication/Server/UserAuthenticationServer.cs
+++ b/Workshop/UserAuthentication/Server/UserAuthenticationServer.cs
@@ -51,7 +51,7 @@ namespace Quickstarts.UserAuthenticationServer
     /// responsible for reading the configuration file, creating the endpoints and dispatching
     /// incoming requests to the appropriate handler.
     ///
-    /// This sub-class specifies non-configurable metadata such as Product Name and initializes
+    /// This sub-class specifies non-configurable metadata such as Product Name and registers
     /// the UserAuthenticationNodeManager which provides access to the data exposed by the Server.
     /// </remarks>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1724:Type names should not match namespaces", Justification = "Sample server type name intentionally mirrors the namespace.")]
@@ -59,6 +59,9 @@ namespace Quickstarts.UserAuthenticationServer
     {
         public UserAuthenticationServer(ITelemetryContext telemetry) : base(telemetry)
         {
+            // register the node manager factory. the server creates the node manager
+            // from it while it builds the master node manager on startup.
+            AddNodeManager(new UserAuthenticationNodeManagerFactory());
         }
 
         #region Overridden UserAuthentication
@@ -90,27 +93,6 @@ namespace Quickstarts.UserAuthenticationServer
             // Register authenticators for user identity changes.
             server.IdentityRegistry.Register(new UserNamePasswordAuthenticator(AuthenticateUserNameAsync));
             server.IdentityRegistry.Register(new X509Authenticator(AuthenticateX509Async));
-        }
-
-        /// <summary>
-        /// Creates the node managers for the server.
-        /// </summary>
-        /// <remarks>
-        /// This method allows the sub-class create any additional node managers which it uses. The SDK
-        /// always creates a CoreNodeManager which handles the built-in nodes defined by the specification.
-        /// Any additional NodeManagers are expected to handle application specific nodes.
-        /// </remarks>
-        protected override MasterNodeManager CreateMasterNodeManager(IServerInternal server, ApplicationConfiguration configuration)
-        {
-            m_logger.LogInformation("Creating the Node Managers.");
-
-            List<INodeManager> nodeManagers = new List<INodeManager>();
-
-            // create the custom node managers.
-            nodeManagers.Add(new UserAuthenticationNodeManager(server, configuration));
-
-            // create master node manager.
-            return new MasterNodeManager(server, configuration, null, nodeManagers.ToArray());
         }
 
         /// <summary>
@@ -277,27 +259,27 @@ namespace Quickstarts.UserAuthenticationServer
                     throw new InvalidOperationException("No certificate validator configured.");
                 }
 
-                // Mimic X509CertificateValidator.PeerTrust by requiring the user certificate to
-                // exist in the Windows TrustedPeople store (CurrentUser or LocalMachine).
-                bool trusted = false;
-
-                foreach (var location in new[] { StoreLocation.CurrentUser, StoreLocation.LocalMachine })
-                {
-                    using var store = new X509Store(StoreName.TrustedPeople, location);
-                    store.Open(OpenFlags.ReadOnly);
+                // Mimic X509CertificateValidator.PeerTrust by requiring the user certificate to
+                // exist in the Windows TrustedPeople store (CurrentUser or LocalMachine).
+                bool trusted = false;
 
-                    if (store.Certificates.Find(X509FindType.FindByThumbprint, certificate.Thumbprint, validOnly: false).Count > 0)
+                foreach (var location in new[] { StoreLocation.CurrentUser, StoreLocation.LocalMachine })
+                {
+                    using var store = new X509Store(StoreName.TrustedPeople, location);
+                    store.Open(OpenFlags.ReadOnly);
+
+                    if (store.Certificates.Find(X509FindType.FindByThumbprint, certificate.Thumbprint, validOnly: false).Count > 0)
                     {
-                        trusted = true;
-                        break;
+                        trusted = true;
+                        break;
                     }
                 }
-
-                if (!trusted)
-                {
-                    throw new CryptographicException(
-                        "The user certificate is not present in the TrustedPeople store.");
-                }
+
+                if (!trusted)
+                {
+                    throw new CryptographicException(
+                        "The user certificate is not present in the TrustedPeople store.");
+                }
             }
             catch (Exception e)
             {


### PR DESCRIPTION
## Proposed changes

Migrates the three simple, hand-built Workshop server samples — Methods, Empty and UserAuthentication — to `AsyncCustomNodeManager`, per the plan in #762. None of them ships a generated model, so this is the Step-1-only shape: hand-written managers plus a hand-written `IAsyncNodeManagerFactory` each, following the DataTypes migration (#796).

**The common move.** Each node manager now derives from `AsyncCustomNodeManager`. The hand-built address space moves from `CreateAddressSpace` into an override of `CreateAddressSpaceAsync` which awaits the base class and registers its nodes through `AddPredefinedNodeAsync`; the `externalReferences` dance which links the roots under the Objects folder — and, for Empty, the `IsTriggerSource` reference to the Server object — is unchanged. The `lock (Lock)` blocks are gone with the base class that provided them: `AsyncCustomNodeManager` has no coarse manager lock and brings its own two-tier await-compatible locking. The `New` override, the `NodeIdFactory` assignment, the `GetManagerHandle`/`ValidateNode`/`DeleteAddressSpace` boilerplate and the parsed-but-never-read configuration fields fall away too; the async base class provides all of it. Each server registers its factory through `StandardServer.AddNodeManager` in the constructor, and the `CreateMasterNodeManager` overrides are gone. The clients are untouched.

- **Methods** wires the `Start` method through `OnCallMethod2Async`. The handler keeps its argument checks, swaps the process timer under the private process lock in a small synchronous helper (`Timer.Dispose` cannot be awaited under a lock, and CA1849 flags the synchronous call inside an async method), and then pushes the new state with `await ClearChangeMasksAsync`. The one-per-second ramp keeps updating the state node from its timer callback with the synchronous `ClearChangeMasks`, which is the pattern the SDK's own `ValueUpdater` uses from arbitrary threads: it drives the asynchronous notification sinks inline. The subscription test which demands every step of the ramp stays green on both paths.
- **UserAuthentication** converts the write callback to `OnSimpleWriteValueAsync`, which receives the value instead of a `ref` parameter and returns an `AttributeWriteResult`; on success the framework stores the written value, which is what the old handler's closing `value = ...` assignment amounted to. The log file is now written with genuinely asynchronous file I/O. Both identity checks stay: the write handler still refuses anonymous sessions itself, and `OnReadUserAccessLevel` still answers the user access level per session — it stays synchronous because attribute-level callbacks have no async sibling, and the async write path consults it before invoking the handler.
- **Empty** is the minimal case: the base-class swap and the async address-space build.

No `CustomNodeManager2` and no `lock (Lock)` remains in the three samples.

**Verification.** The existing fixtures pin the acceptance criteria of the issue and all pass: `EmptyNodeManagerTests` (3 — the trigger, the 2x2 matrix, the reference type in both directions), `MethodsNodeManagerTests` (6 — argument metadata, both validation refusals, the ramp, replacing a running process, and the per-step subscription), `UserAuthenticationNodeManagerTests` (4 passed; the authenticated write stays gated on a real Windows account and skips without one). The full node manager tier passes 81 with the 3 environment skips, all 17 server smoke tests pass, and all four solutions build with 0 warnings. The authenticated write path of the new async handler was additionally exercised end to end against `BaseVariableState.WriteAttributeAsync` in a throwaway harness: an anonymous write is refused leaving value and files untouched, an authenticated write deletes the old log, creates the new one and the framework stores the value.

## Related Issues

- Fixes #762
- Part of #753

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines.
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

No new tests were added on purpose: the Tier 1.5 fixtures from #788 were written ahead of these migrations precisely to pin the observable behaviour, and they cover every acceptance criterion of #762 already.

A reviewing note on the diff: `UserAuthenticationServer.cs` was the one file of the six whose stored blob still carried CRLF line endings, against the LF form `.gitattributes` declares for the repository. Touching it renormalized the blob, so its diff spans the whole file — read it with whitespace changes hidden; the real change there is the factory registration in the constructor and the removed `CreateMasterNodeManager` override, about 25 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
