### PR TITLE
Stop the AlarmCondition select clauses re-browsing the type model, and report tier 2 timeouts usefully

### DIFF
--- a/Tests/SampleClients.Tests/SampleClientTests.cs
+++ b/Tests/SampleClients.Tests/SampleClientTests.cs
@@ -9,6 +9,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.ExceptionServices;
 using System.Threading;
@@ -40,6 +41,19 @@ namespace Opc.Ua.Samples.Tests
         /// How long a sample gets to start its server, connect and disconnect again.
         /// </summary>
         private const int kTimeout = 90_000;
+
+        /// <summary>
+        /// How long a single service call of a sample client may take.
+        /// </summary>
+        /// <remarks>
+        /// The sample configurations allow ten minutes, which is longer than this whole
+        /// test may run: a request which never came back used to surface as a bare harness
+        /// timeout with nothing to point at. This cap is far above what any of these
+        /// operations need against a server on loopback - the slowest single call measured
+        /// is a few hundred milliseconds - so it only ever fires for a call which is stuck,
+        /// and then the test reports that call instead of the clock.
+        /// </remarks>
+        private const int kOperationTimeout = 30_000;
 
         /// <summary>
         /// How long the post connect logic of a sample gets to run before it is inspected.
@@ -172,15 +186,28 @@ namespace Opc.Ua.Samples.Tests
                 .ConfigureAwait(false);
 
             DialogWatchdog watchdog = null;
+            var phase = new ClientPhase();
 
-            await WinFormsHarness.RunAsync(
-                async dialogs => {
-                    watchdog = dialogs;
+            try
+            {
+                await WinFormsHarness.RunAsync(
+                    async dialogs => {
+                        watchdog = dialogs;
 
-                    await DriveClientAsync(client, host.EndpointUrl, ct).ConfigureAwait(true);
-                },
-                TimeSpan.FromMilliseconds(kTimeout) - TimeSpan.FromSeconds(15))
-                .ConfigureAwait(false);
+                        await DriveClientAsync(client, host.EndpointUrl, phase, ct).ConfigureAwait(true);
+                    },
+                    TimeSpan.FromMilliseconds(kTimeout) - TimeSpan.FromSeconds(15))
+                    .ConfigureAwait(false);
+            }
+            catch (TimeoutException expired)
+            {
+                // the bare message says only that the clock ran out, which is the same for
+                // every way a sample can hang. The step it was in is what tells them apart.
+                throw new TimeoutException(
+                    $"{expired.Message} It was {phase.Current}, " +
+                    $"and had been for {phase.Elapsed.TotalSeconds:F0} of those seconds.",
+                    expired);
+            }
 
             if (watchdog?.DuringTeardown.Count > 0)
             {
@@ -194,21 +221,33 @@ namespace Opc.Ua.Samples.Tests
         /// <summary>
         /// Runs on the STA thread of the harness, with a message loop pumping.
         /// </summary>
-        private static async Task DriveClientAsync(SampleClientUnderTest client, string endpointUrl, CancellationToken ct)
+        private static async Task DriveClientAsync(
+            SampleClientUnderTest client,
+            string endpointUrl,
+            ClientPhase phase,
+            CancellationToken ct)
         {
+            phase.Enter("loading the configuration of the sample");
+
             using var pki = new TemporaryPki($"client-{client.Sample.Name}");
 
             ApplicationConfiguration configuration = await SampleConfigurationLoader
                 .LoadAsync(client.Sample.ClientConfig, pki, ct)
                 .ConfigureAwait(true);
 
+            configuration.TransportQuotas.OperationTimeout = kOperationTimeout;
+
             await using var application = new ApplicationInstance(configuration, NullTelemetry.Instance);
+
+            phase.Enter("creating its client certificate");
 
             bool certificateOk = await application
                 .CheckApplicationInstanceCertificatesAsync(true, null, ct)
                 .ConfigureAwait(true);
 
             Assert.That(certificateOk, Is.True, "The client certificate of the sample could not be created.");
+
+            phase.Enter("building its main form");
 
             using Form form = client.CreateMainForm(configuration, NullTelemetry.Instance);
 
@@ -218,6 +257,8 @@ namespace Opc.Ua.Samples.Tests
 
             ConnectServerCtrl connect = WinFormsHarness.GetConnectControl(form);
 
+            phase.Enter($"connecting to {endpointUrl}");
+
             ISession session = await connect
                 .ConnectAsync(NullTelemetry.Instance, endpointUrl, false, 30_000, ct)
                 .ConfigureAwait(true);
@@ -225,6 +266,8 @@ namespace Opc.Ua.Samples.Tests
             Assert.That(session, Is.Not.Null, "The sample client did not create a session.");
             Assert.That(session.Connected, Is.True, "The session of the sample client is not connected.");
             Assert.That(connect.Session, Is.SameAs(session), "The connect control did not keep the session.");
+
+            phase.Enter("running its post connect logic");
 
             // let the post connect logic of the sample run, and give the watchdog a chance to
             // catch a dialog it opens while doing so
@@ -246,9 +289,47 @@ namespace Opc.Ua.Samples.Tests
                     "so its post connect logic did not complete.");
             }
 
+            phase.Enter("disconnecting");
+
             await connect.DisconnectAsync(ct).ConfigureAwait(true);
 
             Assert.That(connect.Session, Is.Null, "The sample client did not release its session on disconnect.");
+
+            phase.Enter("shutting down");
+        }
+
+        /// <summary>
+        /// The step a sample client is in, so that a harness timeout says where it hung.
+        /// </summary>
+        /// <remarks>
+        /// Written on the message loop thread and read by the test thread once the clock has
+        /// run out. Neither the reference nor the reading of the stopwatch tears, and a
+        /// message which names the step before last would still be enough to go on, so the
+        /// two are left unsynchronized rather than locked on every step.
+        /// </remarks>
+        private sealed class ClientPhase
+        {
+            private readonly Stopwatch m_since = Stopwatch.StartNew();
+            private volatile string m_current = "starting up";
+
+            /// <summary>
+            /// What the client is doing, phrased to follow "It was ".
+            /// </summary>
+            public string Current => m_current;
+
+            /// <summary>
+            /// How long it has been in that step.
+            /// </summary>
+            public TimeSpan Elapsed => m_since.Elapsed;
+
+            /// <summary>
+            /// Records that the client moved on to the next step.
+            /// </summary>
+            public void Enter(string what)
+            {
+                m_current = what;
+                m_since.Restart();
+            }
         }
     }
 }

--- a/Workshop/AlarmCondition/Client/FilterDefinition.cs
+++ b/Workshop/AlarmCondition/Client/FilterDefinition.cs
@@ -144,19 +144,27 @@ namespace Quickstarts.AlarmConditionClient
 
             selectClauses.Add(operand);
 
+            // the requested event types share most of their supertype chain - every
+            // condition type descends from BaseEventType through ConditionType - and each
+            // type in that chain carries a subtree of its own. One table of visited nodes
+            // for the whole call therefore browses each of those subtrees once instead of
+            // once per requested type. The fields are unaffected: they are keyed by browse
+            // path, and a node reached again through the same path adds nothing.
+            var foundNodes = new Dictionary<NodeId, List<QualifiedName>>();
+
             // add the fields for the selected EventTypes.
             if (eventTypeIds != null)
             {
                 for (int ii = 0; ii < eventTypeIds.Length; ii++)
                 {
-                    await CollectFieldsAsync(session, eventTypeIds[ii], selectClauses, ct);
+                    await CollectFieldsAsync(session, eventTypeIds[ii], selectClauses, foundNodes, ct);
                 }
             }
 
             // use BaseEventType as the default if no EventTypes specified.
             else
             {
-                await CollectFieldsAsync(session, ObjectTypeIds.BaseEventType, selectClauses, ct);
+                await CollectFieldsAsync(session, ObjectTypeIds.BaseEventType, selectClauses, foundNodes, ct);
             }
 
             return selectClauses;
@@ -273,8 +281,14 @@ namespace Quickstarts.AlarmConditionClient
         /// <param name="session">The session.</param>
         /// <param name="eventTypeId">The event type id.</param>
         /// <param name="eventFields">The event fields.</param>
+        /// <param name="foundNodes">The table of nodes already browsed, shared by the whole call.</param>
         /// <param name="ct">The token to cancel the request</param>
-        private async Task CollectFieldsAsync(ISession session, NodeId eventTypeId, List<SimpleAttributeOperand> eventFields, CancellationToken ct = default)
+        private async Task CollectFieldsAsync(
+            ISession session,
+            NodeId eventTypeId,
+            List<SimpleAttributeOperand> eventFields,
+            Dictionary<NodeId, List<QualifiedName>> foundNodes,
+            CancellationToken ct = default)
         {
             // get the supertypes.
             List<ReferenceDescription> supertypes = await FormUtils.BrowseSuperTypesAsync(session, eventTypeId, false, ct);
@@ -285,7 +299,6 @@ namespace Quickstarts.AlarmConditionClient
             }
 
             // process the types starting from the top of the tree.
-            Dictionary<NodeId, List<QualifiedName>> foundNodes = new Dictionary<NodeId, List<QualifiedName>>();
             List<QualifiedName> parentPath = new List<QualifiedName>();
 
             for (int ii = supertypes.Count - 1; ii >= 0; ii--)

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -429,6 +429,45 @@ The same unguarded continuation point check existed three times in
 onto the SDK's native historian interfaces removed those methods altogether: continuation
 points are owned by the SDK's historian dispatcher now.
 
+### What the AlarmCondition client actually waits for
+
+`ClientConnectsToItsSampleServer(AlarmCondition)` timed out on a hosted agent while the same
+commit passed on branch builds, so the case was measured rather than argued about. The
+AlarmCondition client was the slowest of the thirteen at 9.6 seconds against a 75 second
+budget, and the budget was not the problem: pinned to two cores it was unchanged, and pinned
+to a *single* core against twenty CPU hogs it still finished in 14 seconds. The path is not
+CPU bound, it waits.
+
+Most of what it waited for was its own disconnect. Closing a session which still carried a
+subscription waited for the publish pipeline to run dry, and that wait was a flat five
+seconds - the same with an empty subscription as with the sample's event subscription and its
+condition refresh backlog, and unchanged by turning publishing off. Deleting the subscription
+before closing took the same teardown to 20 ms.
+
+**That wait is gone.** Moving the control to `ManagedSession` and the V2 subscription engine
+removed it as a side effect: the disconnect of a client holding one subscription now measures
+70-110 ms without any change to the teardown order. The finding is recorded here because the
+five seconds are the reason this case sat closest to the timeout for so long, and because the
+shape is worth recognising - a teardown which costs the same whether the subscription is busy
+or empty is a pipeline draining, not a backlog being processed, and no amount of looking at
+the server will show it.
+
+What is left is the client's own startup, which was cheap by comparison but wasteful.
+`ConstructSelectClausesAsync` browses the type model for each of the five event types the form
+asks for, and built a fresh table of visited nodes per type - so the supertype chain every
+condition type shares, and the subtree hanging off each link of it, was walked three and four
+times over. One table for the whole call takes it from 576 browse round trips to 344, for the
+same 141 select clauses. On loopback that is worth a quarter of a second; it is worth
+proportionally more on an agent where a round trip is not free.
+
+Two things remain that no measurement here can rule out, and both are now reported rather
+than guessed at. The sample configurations allow **ten minutes** for a single service call,
+which is longer than the whole test may run, so one request that never came back used to
+surface as a bare "did not finish within 75 seconds"; tier 2 caps it at 30 seconds, far above
+the few hundred milliseconds the slowest call actually needs, so a stuck call is reported as
+itself. And the harness timeout now names the step the client was in and how long it had been
+there, because "the clock ran out" reads the same for every way a sample can hang.
+
 ## Status / roadmap
 
 - [x] Phase 1 - shared helpers, Tier 0 configuration tests, CI test stage


### PR DESCRIPTION
## Proposed changes

`ClientConnectsToItsSampleServer(AlarmCondition)` (tier 2) intermittently timed out with *"The sample client did not finish within 75 seconds"* on the hosted agent, while the identical commit passed on branch builds. This measures the case rather than guessing at it.

> **Rebased onto #805.** This PR originally also changed `ConnectServerCtrl.InternalDisconnectAsync` to delete subscriptions before closing the session, which was worth ~5 s per client. Re-measuring after #805 landed showed that the `ManagedSession` + V2 subscription engine migration **already removed that wait**, so the change was dropped rather than carried forward. What remains is the startup fix and the diagnostics. See "What changed after the rebase" below.

**The 75 second budget was not the problem.** Pinned to two cores - a hosted agent's vCPU count - the test was unchanged at ~9.8 s. Pinned to a *single* core against twenty CPU hogs it still finished in ~14 s. The path is wait bound, not CPU bound, so CPU starvation alone cannot produce a 75 second timeout.

**Most of what it waited for was its own disconnect - and #805 fixed that.** Closing a session which still carried a subscription waited a flat five seconds for the publish pipeline to run dry:

| Session at close (before #805) | Time |
|------------------|------|
| no subscription | 38 ms |
| an empty subscription | 5076 ms |
| the sample's event subscription, after a `ConditionRefresh` | 5050 ms |
| the same, with the subscription deleted first | 20 ms |

It was the pipeline draining, not the notification backlog: an *empty* subscription cost the same, and turning publishing off did not help. After #805 the same disconnect measures **70-110 ms** across four runs with no change to the teardown order. The measurement is kept in `docs/TESTING.md` because those five seconds are why this case sat closest to the timeout, and because a teardown which costs the same whether the subscription is busy or empty is a pipeline draining rather than a backlog - worth recognising next time.

**What is left is the client's own startup, which was cheap but wasteful.** `ConstructSelectClausesAsync` built a fresh table of visited nodes per event type, so the supertype chain every condition type shares - and the subtree hanging off each link of it - was walked three and four times over. One table for the whole call takes it from **576 browse round trips to 344**, for the same 141 select clauses. On loopback that is worth a quarter of a second; proportionally more where a round trip is not free.

**Two things remain which no measurement here can rule out, and both are now reported rather than guessed at.** The sample configurations allow **ten minutes** for a single service call, eight times the harness budget, so one request which never came back could only ever surface as a bare "did not finish within 75 seconds"; tier 2 caps it at 30 s, far above the few hundred milliseconds the slowest call actually needs. And the harness timeout now names the step:

> The sample client did not finish within 75 seconds. It was running its post connect logic, and had been for 1 of those seconds.

## What changed after the rebase

| | originally | now |
|---|---|---|
| `ConnectServerCtrl.cs` | deleted subscriptions before close | **dropped** - #805 already removed the 5 s wait |
| `FilterDefinition.cs` | 576 → 344 browse round trips | unchanged |
| `SampleClientTests.cs` | 30 s operation-timeout cap + phase reporting | unchanged |
| `docs/TESTING.md` | credited the disconnect fix to this PR | rewritten to credit #805 and keep the measurement |

## Related Issues

No tracking issue. Observed on the `Test Samples` job, PR build 17424 against branch builds 17421/17423 (2026-08-28).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [x] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

Tier 2 passes on the rebased tree (17/17, including #805's new `ControlsSubscribeAndReceiveDataChanges`), and the changed files build warning clean under the repo's `AnalysisMode=all`.

## Further comments

**Why no retry.** The third option considered was a retry policy. No other test in the suite has one, so it would have been inconsistent, and retrying would have hidden the signal rather than fixed anything.

**What is not proven.** The actual 75 second timeout could not be reproduced locally, even at one core under 20x oversubscription, so this does not *prove* what happened on build 17424. My read is that it was a stall in some unbounded call rather than gradual slowness, and that the 600 s operation timeout is what let a stall become a harness timeout. The next occurrence will say which step hung and which call was stuck.

**Unrelated flake seen in passing.** One back-to-back rerun failed with `Failed to establish tcp listener sockets on port 62544` - the fixed-port collision `docs/TESTING.md` already documents. It is a distinct failure mode and is left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
