### PR TITLE
Modernize shared client controls: Controls.Net4 (Managed Session + new Subscription Engine)

### DIFF
--- a/Samples/ClientControls.Net4/Common/Client/MonitoredItemHandle.cs
+++ b/Samples/ClientControls.Net4/Common/Client/MonitoredItemHandle.cs
@@ -68,6 +68,27 @@ namespace Opc.Ua.Client.Controls
         public string Name { get; }
 
         /// <summary>
+        /// The name a control displays for the item. Defaults to <see cref="Name"/>.
+        /// </summary>
+        /// <remarks>
+        /// The V2 engine identifies an item by its unique name and its options carry no
+        /// display name, so the friendly name the dialogs show lives on the handle.
+        /// </remarks>
+        public string DisplayName
+        {
+            get { return m_displayName ?? Name; }
+            set { m_displayName = value; }
+        }
+
+        /// <summary>
+        /// The node class of the node the item monitors, which the dialogs use to decide
+        /// between the data change and the event surfaces.
+        /// </summary>
+        public NodeClass NodeClass { get; set; } = NodeClass.Variable;
+
+        private string m_displayName;
+
+        /// <summary>
         /// The settings of the item. Reconfiguring the monitor is what modifies the item.
         /// </summary>
         public OptionsMonitor<MonitoredItemOptions> Options { get; }

--- a/Samples/ClientControls.Net4/Configuration/Common (OLD)/GuiUtils.cs
+++ b/Samples/ClientControls.Net4/Configuration/Common (OLD)/GuiUtils.cs
@@ -424,7 +424,7 @@ namespace Opc.Ua.Client.Controls
         /// <summary>
         /// Displays a dialog that allows a use to edit a value.
         /// </summary>
-        public static object EditValue(Session session, object value, ITelemetryContext telemetry)
+        public static object EditValue(ISession session, object value, ITelemetryContext telemetry)
         {
             TypeInfo typeInfo = TypeInfo.Construct(value);
 
@@ -439,7 +439,7 @@ namespace Opc.Ua.Client.Controls
         /// <summary>
         /// Displays a dialog that allows a use to edit a value.
         /// </summary>
-        public static object EditValue(Session session, object value, NodeId datatypeId, int valueRank, ITelemetryContext telemetry)
+        public static object EditValue(ISession session, object value, NodeId datatypeId, int valueRank, ITelemetryContext telemetry)
         {
             if (value == null)
             {

--- a/Samples/ClientControls.Net4/Configuration/Common (OLD)/NodeIdValueEditDlg.cs
+++ b/Samples/ClientControls.Net4/Configuration/Common (OLD)/NodeIdValueEditDlg.cs
@@ -60,7 +60,7 @@ namespace Opc.Ua.Client.Controls
         /// <summary>
         /// Displays the dialog.
         /// </summary>
-        public NodeId ShowDialog(Session session, NodeId value, ITelemetryContext telemetry)
+        public NodeId ShowDialog(ISession session, NodeId value, ITelemetryContext telemetry)
         {
             if (session == null) throw new ArgumentNullException(nameof(session));
 
@@ -80,7 +80,7 @@ namespace Opc.Ua.Client.Controls
         /// <summary>
         /// Displays the dialog.
         /// </summary>
-        public ExpandedNodeId ShowDialog(Session session, ExpandedNodeId value, ITelemetryContext telemetry)
+        public ExpandedNodeId ShowDialog(ISession session, ExpandedNodeId value, ITelemetryContext telemetry)
         {
             if (session == null) throw new ArgumentNullException(nameof(session));
 

--- a/Samples/Controls.Net4/ClientForm.cs
+++ b/Samples/Controls.Net4/ClientForm.cs
@@ -46,10 +46,7 @@ namespace Opc.Ua.Sample.Controls
     public partial class ClientForm : Form
     {
         #region Private Fields
-        private Session m_session;
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA2213:Disposable fields should be disposed", Justification = "Sample code preserves existing public API and behavior.")]
-        private SessionReconnectHandler m_reconnectHandler;
-        private int m_reconnectPeriod = 10;
+        private ISession m_session;
         private ApplicationInstance m_application;
         private Opc.Ua.Server.StandardServer m_server;
         private ConfiguredEndpointCollection m_endpoints;
@@ -176,14 +173,9 @@ namespace Opc.Ua.Sample.Controls
         {
             if (m_session != null)
             {
-                // stop any reconnect operation.
-                if (m_reconnectHandler != null)
-                {
-                    m_reconnectHandler.Dispose();
-                    m_reconnectHandler = null;
-                }
-
-                m_session.KeepAlive -= StandardClient_KeepAlive;
+                // closing the managed session also stops its connection state machine, so
+                // there is no separate reconnect handler to cancel.
+                DetachSession(m_session);
 
                 await m_session.CloseAsync(ct);
                 m_session = null;
@@ -195,7 +187,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Provides a user defined method.
         /// </summary>
-        protected virtual void DoTest(Session session)
+        protected virtual void DoTest(ISession session)
         {
             MessageBox.Show("A handy place to put test code.");
         }
@@ -235,21 +227,42 @@ namespace Opc.Ua.Sample.Controls
                 return;
             }
 
-            Session session = await SessionsCTRL.ConnectAsync(endpoint, telemetry, ct);
+            ISession session = await SessionsCTRL.ConnectAsync(endpoint, telemetry, ct);
 
             if (session != null)
             {
-                // stop any reconnect operation.
-                m_reconnectHandler?.CancelReconnect();
-                m_reconnectHandler?.Dispose();
-
-                m_reconnectHandler = new SessionReconnectHandler(telemetry, true);
-                session.TransferSubscriptionsOnReconnect = true;
-
+                // the managed session brings its own connection state machine and reconnect
+                // policy, so no SessionReconnectHandler is wired up here.
                 m_session = session;
-                m_session.KeepAlive += new KeepAliveEventHandler(StandardClient_KeepAlive);
+                AttachSession(m_session);
                 await BrowseCTRL.SetViewAsync(m_session, BrowseViewType.Objects, NodeId.Null, m_telemetry, ct);
                 StandardClient_KeepAlive(m_session, null);
+            }
+        }
+
+        /// <summary>
+        /// Subscribes to the session events the form reports on.
+        /// </summary>
+        private void AttachSession(ISession session)
+        {
+            session.KeepAlive += StandardClient_KeepAlive;
+
+            if (session is ManagedSession managedSession)
+            {
+                managedSession.ConnectionStateChanged += Session_ConnectionStateChanged;
+            }
+        }
+
+        /// <summary>
+        /// Unsubscribes from the session events the form reports on.
+        /// </summary>
+        private void DetachSession(ISession session)
+        {
+            session.KeepAlive -= StandardClient_KeepAlive;
+
+            if (session is ManagedSession managedSession)
+            {
+                managedSession.ConnectionStateChanged -= Session_ConnectionStateChanged;
             }
         }
 
@@ -299,17 +312,12 @@ namespace Opc.Ua.Sample.Controls
                 }
                 else
                 {
-                    var state = SessionReconnectHandler.ReconnectState.Ready;
-                    if (m_reconnectPeriod > 0)
-                    {
-                        state = m_reconnectHandler.BeginReconnect(m_session, m_reconnectPeriod * 1000, StandardClient_Server_ReconnectComplete);
-                    }
-
+                    // the managed session starts the reconnect sequence itself, this only
+                    // reports the communication error.
                     ServerStatusLB.Text = String.Format(
-                        "{0} {1}/{2}/{3}", e.Status,
+                        "{0} {1}/{2}", e.Status,
                         m_session.OutstandingRequestCount,
-                        m_session.DefunctRequestCount,
-                        state);
+                        m_session.DefunctRequestCount);
 
                     ServerStatusLB.ForeColor = Color.Red;
                     ServerStatusLB.Font = new Font(ServerStatusLB.Font, FontStyle.Bold);
@@ -317,39 +325,63 @@ namespace Opc.Ua.Sample.Controls
             }
         }
 
-        private void StandardClient_Server_ReconnectComplete(object sender, EventArgs e)
+        /// <summary>
+        /// Handles the connection state changes reported by the managed session.
+        /// </summary>
+        /// <remarks>
+        /// The managed session keeps the same <see cref="ISession"/> instance and its V2
+        /// subscriptions across a reconnect, so the form only has to refresh the display -
+        /// there is no session to swap out as there was with the SessionReconnectHandler.
+        /// </remarks>
+        private void Session_ConnectionStateChanged(object sender, ConnectionStateChangedEventArgs e)
         {
             if (InvokeRequired)
             {
-                BeginInvoke(new EventHandler(StandardClient_Server_ReconnectComplete), sender, e);
+                BeginInvoke(new EventHandler<ConnectionStateChangedEventArgs>(Session_ConnectionStateChanged), sender, e);
                 return;
             }
 
             try
             {
-                // ignore callbacks from discarded objects.
-                if (!Object.ReferenceEquals(sender, m_reconnectHandler))
+                // ignore callbacks from discarded sessions. The event may be raised by the
+                // session or by the connection state machine behind it, so only a sender which
+                // is a session is worth comparing.
+                if (m_session == null || (sender is ISession sessionOfEvent && !Object.ReferenceEquals(sessionOfEvent, m_session)))
                 {
                     return;
                 }
 
-                if (m_reconnectHandler.Session != null)
+                switch (e.NewState)
                 {
-                    if (!ReferenceEquals(m_session, m_reconnectHandler.Session))
+                    case ConnectionState.Reconnecting:
+                    case ConnectionState.Failover:
                     {
-                        var session = m_session;
-                        session.KeepAlive -= StandardClient_KeepAlive;
-                        m_session = m_reconnectHandler.Session as Session;
-                        m_session.KeepAlive += StandardClient_KeepAlive;
-                        session?.Dispose();
+                        ServerStatusLB.Text = String.Format("Reconnecting (attempt {0})", e.ReconnectAttempt);
+                        ServerStatusLB.ForeColor = Color.Red;
+                        ServerStatusLB.Font = new Font(ServerStatusLB.Font, FontStyle.Bold);
+                        break;
+                    }
+
+                    case ConnectionState.Connected:
+                    {
+                        if (e.PreviousState is ConnectionState.Reconnecting or ConnectionState.Failover)
+                        {
+                            BrowseCTRL.SetViewAsync(m_session, BrowseViewType.Objects, NodeId.Null, m_telemetry);
+                            SessionsCTRL.Reload(m_session);
+                        }
+
+                        StandardClient_KeepAlive(m_session, null);
+                        break;
+                    }
+
+                    case ConnectionState.Disconnected:
+                    {
+                        ServerStatusLB.Text = String.Format("Disconnected ({0})", e.Error);
+                        ServerStatusLB.ForeColor = Color.Red;
+                        ServerStatusLB.Font = new Font(ServerStatusLB.Font, FontStyle.Bold);
+                        break;
                     }
                 }
-
-                BrowseCTRL.SetViewAsync(m_session, BrowseViewType.Objects, NodeId.Null, m_telemetry);
-
-                SessionsCTRL.Reload(m_session);
-
-                StandardClient_KeepAlive(m_session, null);
             }
             catch (Exception exception)
             {

--- a/Samples/Controls.Net4/Common/ArgumentListCtrl.cs
+++ b/Samples/Controls.Net4/Common/ArgumentListCtrl.cs
@@ -51,7 +51,7 @@ namespace Opc.Ua.Sample.Controls
         }
 
         #region Private Fields
-        private Session m_session;
+        private ISession m_session;
 
         /// <summary>
 		/// The columns to display in the control.
@@ -78,7 +78,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Sets the nodes in the control.
         /// </summary>
-        public async Task<bool> UpdateAsync(Session session, NodeId methodId, bool inputArgs, ITelemetryContext telemetry, CancellationToken ct = default)
+        public async Task<bool> UpdateAsync(ISession session, NodeId methodId, bool inputArgs, ITelemetryContext telemetry, CancellationToken ct = default)
         {
             if (session == null) throw new ArgumentNullException(nameof(session));
             if (methodId.IsNull) throw new ArgumentNullException(nameof(methodId));

--- a/Samples/Controls.Net4/Common/AttributeListCtrl.cs
+++ b/Samples/Controls.Net4/Common/AttributeListCtrl.cs
@@ -52,7 +52,7 @@ namespace Opc.Ua.Sample.Controls
         }
 
         #region Private Fields
-        private Session m_session;
+        private ISession m_session;
         private NodeId m_nodeId;
         private bool m_readOnly;
 
@@ -90,7 +90,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Sets the nodes in the control.
         /// </summary>
-        public async Task InitializeAsync(Session session, ExpandedNodeId nodeId, ITelemetryContext telemetry, CancellationToken ct = default)
+        public async Task InitializeAsync(ISession session, ExpandedNodeId nodeId, ITelemetryContext telemetry, CancellationToken ct = default)
         {
             if (session == null) throw new ArgumentNullException(nameof(session));
 

--- a/Samples/Controls.Net4/Common/CallMethodDlg.cs
+++ b/Samples/Controls.Net4/Common/CallMethodDlg.cs
@@ -55,7 +55,7 @@ namespace Opc.Ua.Sample.Controls
         #endregion
 
         #region Private Fields
-        private Session m_session;
+        private ISession m_session;
         private EventHandler m_SessionClosing;
         private NodeId m_objectId;
         private NodeId m_methodId;
@@ -65,7 +65,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Displays the dialog.
         /// </summary>
-        public async Task ShowAsync(Session session, NodeId objectId, NodeId methodId, ITelemetryContext telemetry, CancellationToken ct = default)
+        public async Task ShowAsync(ISession session, NodeId objectId, NodeId methodId, ITelemetryContext telemetry, CancellationToken ct = default)
         {
             if (session == null) throw new ArgumentNullException(nameof(session));
             if (methodId.IsNull) throw new ArgumentNullException(nameof(methodId));

--- a/Samples/Controls.Net4/Common/DataValueListCtrl.cs
+++ b/Samples/Controls.Net4/Common/DataValueListCtrl.cs
@@ -53,7 +53,7 @@ namespace Opc.Ua.Sample.Controls
         #endregion
 
         #region Private Fields
-        private Session m_session;
+        private ISession m_session;
         private DataListCtrl m_DataListCtrl;
 
         /// <summary>
@@ -94,7 +94,7 @@ namespace Opc.Ua.Sample.Controls
         /// Sets the nodes in the control.
         /// </summary>
         public async Task InitializeAsync(
-            Session session,
+            ISession session,
             IList<ReadValueId> valueIds,
             IList<DataValue> values,
             IList<ServiceResult> results,
@@ -139,7 +139,7 @@ namespace Opc.Ua.Sample.Controls
         /// Sets the nodes in the control.
         /// </summary>
         public async Task InitializeAsync(
-            Session session,
+            ISession session,
             IList<WriteValue> values,
             IList<ServiceResult> results,
             CancellationToken ct = default)

--- a/Samples/Controls.Net4/Common/FindNodeDlg.cs
+++ b/Samples/Controls.Net4/Common/FindNodeDlg.cs
@@ -50,12 +50,12 @@ namespace Opc.Ua.Sample.Controls
             this.Icon = ClientUtils.GetAppIcon();
         }
 
-        private Session m_session;
+        private ISession m_session;
 
         /// <summary>
         /// Displays the dialog.
         /// </summary>
-        public IList<NodeId> ShowDialog(Session session, NodeId startNodeId)
+        public IList<NodeId> ShowDialog(ISession session, NodeId startNodeId)
         {
             m_session = session;
 

--- a/Samples/Controls.Net4/Common/NodeListCtrl.cs
+++ b/Samples/Controls.Net4/Common/NodeListCtrl.cs
@@ -52,7 +52,7 @@ namespace Opc.Ua.Sample.Controls
         }
 
         #region Private Fields
-        private Session m_session;
+        private ISession m_session;
         private IList<NodeId> m_nodeIds;
         private NodeClass m_nodeClassMask;
 
@@ -80,7 +80,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Sets the nodes in the control.
         /// </summary>
-        public async Task InitializeAsync(Session session, IList<NodeId> nodeIds, NodeClass nodeClassMask, ITelemetryContext telemetry, CancellationToken ct = default)
+        public async Task InitializeAsync(ISession session, IList<NodeId> nodeIds, NodeClass nodeClassMask, ITelemetryContext telemetry, CancellationToken ct = default)
         {
             if (session == null) throw new ArgumentNullException(nameof(session));
 

--- a/Samples/Controls.Net4/Common/PropertyListCtrl.cs
+++ b/Samples/Controls.Net4/Common/PropertyListCtrl.cs
@@ -52,7 +52,7 @@ namespace Opc.Ua.Sample.Controls
         }
 
         #region Private Fields
-        private Session m_session;
+        private ISession m_session;
         private bool m_showValues;
 
         /// <summary>
@@ -90,7 +90,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Sets the nodes in the control.
         /// </summary>
-        public async Task UpdateAsync(Session session, ReferenceDescription reference, CancellationToken ct = default)
+        public async Task UpdateAsync(ISession session, ReferenceDescription reference, CancellationToken ct = default)
         {
             if (session == null) throw new ArgumentNullException(nameof(session));
             #pragma warning disable CA1508 // Justification: Sample code retains existing ownership/lifetime and behavior.

--- a/Samples/Controls.Net4/Common/SelectNodesDlg.cs
+++ b/Samples/Controls.Net4/Common/SelectNodesDlg.cs
@@ -54,7 +54,7 @@ namespace Opc.Ua.Sample.Controls
         #endregion
 
         #region Private Fields
-        private Session m_session;
+        private ISession m_session;
         #endregion
 
         #region Public Interface
@@ -62,7 +62,7 @@ namespace Opc.Ua.Sample.Controls
         /// Displays the dialog.
         /// </summary>
         public async Task<IList<NodeId>> ShowDialogAsync(
-            Session session,
+            ISession session,
             BrowseViewType browseView,
             IList<NodeId> nodesIds,
             NodeClass nodeClassMask,

--- a/Samples/Controls.Net4/SelectLocaleDlg.cs
+++ b/Samples/Controls.Net4/SelectLocaleDlg.cs
@@ -54,7 +54,7 @@ namespace Opc.Ua.Sample.Controls
         #endregion
 
         #region Private Fields
-        private Session m_session;
+        private ISession m_session;
         #endregion
 
         #region Public Interface
@@ -63,7 +63,7 @@ namespace Opc.Ua.Sample.Controls
         /// </summary>
         /// <param name="session">The session.</param>
         /// <returns></returns>
-        public async Task<string> ShowDialogAsync(Session session, CancellationToken ct = default)
+        public async Task<string> ShowDialogAsync(ISession session, CancellationToken ct = default)
         {
             m_session = session;
 

--- a/Samples/Controls.Net4/Sessions/AddressSpaceDlg.cs
+++ b/Samples/Controls.Net4/Sessions/AddressSpaceDlg.cs
@@ -61,7 +61,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Displays the address space with the specified view
         /// </summary>
-        public void Show(Session session, BrowseViewType viewType, NodeId viewId, ITelemetryContext telemetry)
+        public void Show(ISession session, BrowseViewType viewType, NodeId viewId, ITelemetryContext telemetry)
         {
             if (session == null) throw new ArgumentNullException(nameof(session));
 

--- a/Samples/Controls.Net4/Sessions/BrowseDlg.cs
+++ b/Samples/Controls.Net4/Sessions/BrowseDlg.cs
@@ -55,7 +55,7 @@ namespace Opc.Ua.Sample.Controls
         #endregion
 
         #region Private Fields
-        private Session m_session;
+        private ISession m_session;
         private EventHandler m_SessionClosing;
         #endregion
 
@@ -63,7 +63,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Displays the address space with the specified view
         /// </summary>
-        public async Task ShowAsync(Session session, NodeId startId, CancellationToken ct = default)
+        public async Task ShowAsync(ISession session, NodeId startId, CancellationToken ct = default)
         {
             if (session == null) throw new ArgumentNullException(nameof(session));
 

--- a/Samples/Controls.Net4/Sessions/BrowseListCtrl.cs
+++ b/Samples/Controls.Net4/Sessions/BrowseListCtrl.cs
@@ -158,7 +158,7 @@ namespace Opc.Ua.Sample.Controls
             }
 
             m_browser = browser;
-            m_session = browser.Session as Session;
+            m_session = browser.Session as ISession;
             Telemetry = m_session?.MessageContext?.Telemetry;
             m_startId = startId;
             m_position = -1;
@@ -259,7 +259,7 @@ namespace Opc.Ua.Sample.Controls
                 }
 
                 ItemData item = new ItemData(referenceType, !reference.IsForward, target, typeDefinition);
-                AddItem(item, await GuiUtils.GetTargetIconAsync(m_browser.Session as Session, reference, ct), -1);
+                AddItem(item, await GuiUtils.GetTargetIconAsync(m_session, reference, ct), -1);
 
                 if ((target.NodeClass & (NodeClass.Variable | NodeClass.VariableType)) != 0)
                 {

--- a/Samples/Controls.Net4/Sessions/BrowseOptionsDlg.cs
+++ b/Samples/Controls.Net4/Sessions/BrowseOptionsDlg.cs
@@ -77,7 +77,7 @@ namespace Opc.Ua.Sample.Controls
             m_browser = browser;
             m_session = session;
             m_telemetry = telemetry;
-            await ReferenceTypeCTRL.InitializeAsync(m_browser.Session as Session, NodeId.Null, ct);
+            await ReferenceTypeCTRL.InitializeAsync(m_session, NodeId.Null, ct);
 
             ViewIdTB.Text = null;
             ViewTimestampDP.Value = ViewTimestampDP.MinDate;

--- a/Samples/Controls.Net4/Sessions/BrowseTreeCtrl.cs
+++ b/Samples/Controls.Net4/Sessions/BrowseTreeCtrl.cs
@@ -45,6 +45,10 @@ using Microsoft.Extensions.Logging;
 
 namespace Opc.Ua.Sample.Controls
 {
+    // the V2 subscription engine reuses names the classic engine already has in the
+    // Opc.Ua.Client namespace this file imports, so the V2 types are pinned explicitly.
+    using MonitoredItemOptions = Opc.Ua.Client.Subscriptions.MonitoredItems.MonitoredItemOptions;
+
     public partial class BrowseTreeCtrl : Opc.Ua.Client.Controls.BaseTreeCtrl
     {
         #region Contructors
@@ -221,7 +225,7 @@ namespace Opc.Ua.Sample.Controls
                 reference.TypeDefinition = ExpandedNodeId.Null;
 
                 string text = GetTargetText(reference);
-                string icon = await GuiUtils.GetTargetIconAsync(m_browser.Session as Session, reference, ct);
+                string icon = await GuiUtils.GetTargetIconAsync(m_session, reference, ct);
 
                 TreeNode root = AddNode(null, reference, text, icon);
                 root.Nodes.Add(new TreeNode());
@@ -232,7 +236,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Sets the root node for the control.
         /// </summary>
-        public Task SetRootAsync(Session session, NodeId rootId, ITelemetryContext telemetry, CancellationToken ct = default)
+        public Task SetRootAsync(ISession session, NodeId rootId, ITelemetryContext telemetry, CancellationToken ct = default)
         {
             return SetRootAsync(new Browser(session), rootId, session, telemetry, ct);
         }
@@ -240,7 +244,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Sets the view for the control.
         /// </summary>
-        public Task SetViewAsync(Session session, BrowseViewType viewType, NodeId viewId, ITelemetryContext telemetry, CancellationToken ct = default)
+        public Task SetViewAsync(ISession session, BrowseViewType viewType, NodeId viewId, ITelemetryContext telemetry, CancellationToken ct = default)
         {
             Clear();
 
@@ -389,7 +393,7 @@ namespace Opc.Ua.Sample.Controls
 
                         NodeId nodeId = ExpandedNodeId.ToNodeId(reference.NodeId, m_session.NamespaceUris);
 
-                        INode node = await m_browser.Session.ReadNodeAsync(nodeId);
+                        INode node = await m_session.ReadNodeAsync(nodeId);
 
                         byte accessLevel = 0;
                         byte eventNotifier = 0;
@@ -487,14 +491,14 @@ namespace Opc.Ua.Sample.Controls
                             CallMI.Enabled = executable;
                         }
 
-                        if (SubscribeMI.Enabled)
+                        if (SubscribeMI.Enabled && m_SessionTreeCtrl != null)
                         {
                             while (SubscribeMI.DropDown.Items.Count > 1)
                             {
                                 SubscribeMI.DropDown.Items.RemoveAt(SubscribeMI.DropDown.Items.Count - 1);
                             }
 
-                            foreach (Subscription subscription in m_session.Subscriptions)
+                            foreach (SubscriptionHandle subscription in m_SessionTreeCtrl.GetSubscriptions(m_session))
                             {
                                 if (subscription.Created)
                                 {
@@ -535,7 +539,7 @@ namespace Opc.Ua.Sample.Controls
                 {
                     if (reference != null)
                     {
-                        await m_AttributesCtrl.InitializeAsync(m_browser.Session as Session, reference.NodeId, Telemetry);
+                        await m_AttributesCtrl.InitializeAsync(m_session, reference.NodeId, Telemetry);
                     }
                     else
                     {
@@ -602,28 +606,31 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Adds a item to a subscription.
         /// </summary>
-        private async Task SubscribeAsync(Subscription subscription, ReferenceDescription reference, CancellationToken ct = default)
+        private async Task SubscribeAsync(SubscriptionHandle subscription, ReferenceDescription reference, CancellationToken ct = default)
         {
-            MonitoredItem monitoredItem = new MonitoredItem(subscription.DefaultItem);
+            string displayName = await subscription.Session.NodeCache.GetDisplayTextAsync(reference, ct);
+            NodeClass nodeClass = (NodeClass)reference.NodeClass;
 
-            monitoredItem.DisplayName = await subscription.Session.NodeCache.GetDisplayTextAsync(reference, ct);
-            monitoredItem.StartNodeId = (NodeId)reference.NodeId;
-            monitoredItem.NodeClass = (NodeClass)reference.NodeClass;
-            monitoredItem.AttributeId = Attributes.Value;
-            monitoredItem.SamplingInterval = 0;
-            monitoredItem.QueueSize = 1;
+            MonitoredItemOptions options = new MonitoredItemOptions {
+                StartNodeId = (NodeId)reference.NodeId,
+                AttributeId = Attributes.Value,
+                SamplingInterval = TimeSpan.Zero,
+                QueueSize = 1,
+            };
 
-            // add condition fields to any event filter.
-            EventFilter filter = monitoredItem.Filter as EventFilter;
-
-            if (filter != null)
+            // subscribe object and view nodes to their events.
+            if (nodeClass == NodeClass.Object || nodeClass == NodeClass.View)
             {
-                monitoredItem.AttributeId = Attributes.EventNotifier;
-                monitoredItem.QueueSize = 0;
+                options = options with {
+                    AttributeId = Attributes.EventNotifier,
+                    QueueSize = 0,
+                    Filter = SubscriptionHandle.CreateDefaultEventFilter(),
+                };
             }
 
-            subscription.AddItem(monitoredItem);
-            await subscription.ApplyChangesAsync(ct);
+            // adding the item is the request, the engine creates it on its own worker.
+            subscription.AddItem(displayName, nodeClass, options);
+            await subscription.WaitForPendingChangesAsync(TimeSpan.FromSeconds(10), ct);
         }
 
         /// <summary>
@@ -763,7 +770,7 @@ namespace Opc.Ua.Sample.Controls
                 }
 
                 string text = GetTargetText(reference);
-                string icon = await GuiUtils.GetTargetIconAsync(m_browser.Session as Session, reference, ct);
+                string icon = await GuiUtils.GetTargetIconAsync(m_session, reference, ct);
 
                 TreeNode container = parent;
 
@@ -1007,7 +1014,7 @@ namespace Opc.Ua.Sample.Controls
                 }
 
                 using var dialog = new NodeAttributesDlg();
-                await dialog.ShowDialogAsync(m_browser.Session as Session, reference.NodeId, Telemetry);
+                await dialog.ShowDialogAsync(m_session, reference.NodeId, Telemetry);
             }
             catch (Exception exception)
             {
@@ -1023,8 +1030,6 @@ namespace Opc.Ua.Sample.Controls
                 {
                     return;
                 }
-
-                Session session = m_browser.Session as Session;
 
                 ReferenceDescription reference = NodesTV.SelectedNode.Tag as ReferenceDescription;
 
@@ -1051,7 +1056,7 @@ namespace Opc.Ua.Sample.Controls
 
                 if (m_MethodCalled != null)
                 {
-                    MethodCalledEventArgs args = new MethodCalledEventArgs(m_browser.Session as Session, objectId, methodId);
+                    MethodCalledEventArgs args = new MethodCalledEventArgs(m_session, objectId, methodId);
                     m_MethodCalled(this, args);
 
                     if (args.Handled)
@@ -1061,7 +1066,7 @@ namespace Opc.Ua.Sample.Controls
                 }
 
                 using var dialog = new CallMethodDlg();
-                await dialog.ShowAsync(m_browser.Session as Session, objectId, methodId, Telemetry);
+                await dialog.ShowAsync(m_session, objectId, methodId, Telemetry);
             }
             catch (Exception exception)
             {
@@ -1085,8 +1090,6 @@ namespace Opc.Ua.Sample.Controls
                     return;
                 }
 
-                Session session = m_browser.Session as Session;
-
                 // build list of nodes to read.
                 List<ReadValueId> valueIds = new List<ReadValueId>();
 
@@ -1101,7 +1104,7 @@ namespace Opc.Ua.Sample.Controls
 
                 // show form.
                 using var dialog = new ReadDlg();
-                await dialog.ShowAsync(session, valueIds, Telemetry);
+                await dialog.ShowAsync(m_session, valueIds, Telemetry);
             }
             catch (Exception exception)
             {
@@ -1125,9 +1128,7 @@ namespace Opc.Ua.Sample.Controls
                     return;
                 }
 
-                Session session = m_browser.Session as Session;
-
-                // build list of nodes to read.
+                // build list of nodes to write.
                 List<WriteValue> values = new List<WriteValue>();
 
                 WriteValue value = new WriteValue();
@@ -1141,7 +1142,7 @@ namespace Opc.Ua.Sample.Controls
 
                 // show form.
                 using var dialog = new WriteDlg();
-                await dialog.ShowAsync(session, values, Telemetry);
+                await dialog.ShowAsync(m_session, values, Telemetry);
             }
             catch (Exception exception)
             {
@@ -1167,7 +1168,7 @@ namespace Opc.Ua.Sample.Controls
 
                 if (m_SessionTreeCtrl != null)
                 {
-                    Subscription subscription = await m_SessionTreeCtrl.CreateSubscriptionAsync(m_browser.Session as Session);
+                    SubscriptionHandle subscription = await m_SessionTreeCtrl.CreateSubscriptionAsync(m_session);
 
                     if (subscription != null)
                     {
@@ -1197,7 +1198,7 @@ namespace Opc.Ua.Sample.Controls
                     return;
                 }
 
-                Subscription subscription = ((ToolStripItem)sender).Tag as Subscription;
+                SubscriptionHandle subscription = ((ToolStripItem)sender).Tag as SubscriptionHandle;
 
                 if (subscription != null)
                 {
@@ -1227,7 +1228,7 @@ namespace Opc.Ua.Sample.Controls
                 }
 
                 using var dialog = new ReadHistoryDlg();
-                await dialog.ShowDialogAsync(m_browser.Session as Session, (NodeId)reference.NodeId);
+                await dialog.ShowDialogAsync(m_session, (NodeId)reference.NodeId);
             }
             catch (Exception exception)
             {
@@ -1252,7 +1253,7 @@ namespace Opc.Ua.Sample.Controls
                 }
 
                 using var dialog = new BrowseDlg();
-                await dialog.ShowAsync(m_browser.Session as Session, (NodeId)reference.NodeId);
+                await dialog.ShowAsync(m_session, (NodeId)reference.NodeId);
             }
             catch (Exception exception)
             {
@@ -1368,7 +1369,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Creates a new instance.
         /// </summary>
-        internal MethodCalledEventArgs(Session session, NodeId objectId, NodeId methodId)
+        internal MethodCalledEventArgs(ISession session, NodeId objectId, NodeId methodId)
         {
             m_session = session;
             m_objectId = objectId;
@@ -1380,7 +1381,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// The session
         /// </summary>
-        public Session Session
+        public ISession Session
         {
             get { return m_session; }
         }
@@ -1412,7 +1413,7 @@ namespace Opc.Ua.Sample.Controls
         #endregion
 
         #region Private Fields
-        private Session m_session;
+        private ISession m_session;
         private NodeId m_objectId;
         private NodeId m_methodId;
         private bool m_handled;

--- a/Samples/Controls.Net4/Sessions/BrowseTypesDlg.cs
+++ b/Samples/Controls.Net4/Sessions/BrowseTypesDlg.cs
@@ -54,7 +54,7 @@ namespace Opc.Ua.Sample.Controls
         #endregion
 
         #region Private Fields
-        private Session m_session;
+        private ISession m_session;
         private ILocalNode m_selectedType;
         #endregion
 
@@ -63,7 +63,7 @@ namespace Opc.Ua.Sample.Controls
         /// Displays the dialog.
         /// </summary>
         public async Task ShowAsync(
-            Session session,
+            ISession session,
             NodeId typeId,
             CancellationToken ct = default)
         {

--- a/Samples/Controls.Net4/Sessions/NodeAttributesDlg.cs
+++ b/Samples/Controls.Net4/Sessions/NodeAttributesDlg.cs
@@ -55,7 +55,7 @@ namespace Opc.Ua.Sample.Controls
         #endregion
 
         #region Private Fields
-        private Session m_session;
+        private ISession m_session;
         private ExpandedNodeId m_nodeId;
         private ITelemetryContext m_telemetry;
         #endregion
@@ -64,7 +64,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Displays the dialog.
         /// </summary>
-        public async Task ShowDialogAsync(Session session, ExpandedNodeId nodeId, ITelemetryContext telemetry, CancellationToken ct = default)
+        public async Task ShowDialogAsync(ISession session, ExpandedNodeId nodeId, ITelemetryContext telemetry, CancellationToken ct = default)
         {
             if (session == null) throw new ArgumentNullException(nameof(session));
             if (nodeId.IsNull) throw new ArgumentNullException(nameof(nodeId));

--- a/Samples/Controls.Net4/Sessions/ReadHistoryDlg.cs
+++ b/Samples/Controls.Net4/Sessions/ReadHistoryDlg.cs
@@ -77,7 +77,7 @@ namespace Opc.Ua.Sample.Controls
             Processed
         }
 
-        private Session m_session;
+        private ISession m_session;
         private NodeId m_nodeId;
         private HistoryReadResult m_result;
         private int m_index;
@@ -85,7 +85,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Displays the dialog.
         /// </summary>
-        public async Task<bool> ShowDialogAsync(Session session, NodeId nodeId, CancellationToken ct = default)
+        public async Task<bool> ShowDialogAsync(ISession session, NodeId nodeId, CancellationToken ct = default)
         {
             m_session = session;
             m_nodeId = nodeId;

--- a/Samples/Controls.Net4/Sessions/SessionOpenDlg.cs
+++ b/Samples/Controls.Net4/Sessions/SessionOpenDlg.cs
@@ -53,7 +53,10 @@ namespace Opc.Ua.Sample.Controls
         #endregion
 
         #region Private Fields
-        private Session m_session;
+        private ApplicationConfiguration m_configuration;
+        private ConfiguredEndpoint m_endpoint;
+        private ITelemetryContext m_telemetry;
+        private ISession m_session;
         private const string m_BrowseCertificates = "<Browse...>";
         private static uint m_Counter = 0;
         private IList<string> m_preferredLocales;
@@ -63,21 +66,33 @@ namespace Opc.Ua.Sample.Controls
 
         #region Public Interface
         /// <summary>
-        /// Displays the dialog.
+        /// Displays the dialog and creates the session when the user accepts it.
         /// </summary>
+        /// <remarks>
+        /// The session is created with a <see cref="ManagedSessionFactory"/>, so the returned
+        /// session runs the V2 subscription engine and reconnects on its own.
+        /// </remarks>
+        /// <returns>The open session, or null if the user cancelled the dialog.</returns>
         [System.ComponentModel.DesignerSerializationVisibility(System.ComponentModel.DesignerSerializationVisibility.Hidden)]
-        public bool ShowDialog(Session session, IList<string> preferredLocales)
+        public ISession ShowDialog(ApplicationConfiguration configuration, ConfiguredEndpoint endpoint, IList<string> preferredLocales, ITelemetryContext telemetry)
         {
-            if (session == null) throw new ArgumentNullException(nameof(session));
+            if (configuration == null) throw new ArgumentNullException(nameof(configuration));
+            if (endpoint == null) throw new ArgumentNullException(nameof(endpoint));
 
-            m_session = session;
+            m_configuration = configuration;
+            m_endpoint = endpoint;
             m_preferredLocales = preferredLocales;
+            m_telemetry = telemetry;
+            m_session = null;
 
             UserIdentityTypeCB.Items.Clear();
 
-            foreach (UserTokenPolicy policy in session.Endpoint.UserIdentityTokens)
+            foreach (UserTokenPolicy policy in endpoint.Description.UserIdentityTokens)
             {
-                UserIdentityTypeCB.Items.Add(policy.TokenType);
+                if (!UserIdentityTypeCB.Items.Contains(policy.TokenType))
+                {
+                    UserIdentityTypeCB.Items.Add(policy.TokenType);
+                }
             }
 
             if (UserIdentityTypeCB.Items.Count == 0)
@@ -87,24 +102,14 @@ namespace Opc.Ua.Sample.Controls
 
             UserIdentityTypeCB.SelectedIndex = 0;
 
-            SessionNameTB.Text = session.SessionName;
-
-            if (String.IsNullOrEmpty(SessionNameTB.Text))
-            {
-                SessionNameTB.Text = Utils.Format("MySession {0}", Utils.IncrementIdentifier(ref m_Counter));
-            }
-
-            if (session.Identity != null)
-            {
-                UserIdentityTypeCB.SelectedItem = session.Identity.TokenType;
-            }
+            SessionNameTB.Text = Utils.Format("MySession {0}", Utils.IncrementIdentifier(ref m_Counter));
 
             if (ShowDialog() != DialogResult.OK)
             {
-                return false;
+                return null;
             }
 
-            return true;
+            return m_session;
         }
         #endregion
 
@@ -128,19 +133,10 @@ namespace Opc.Ua.Sample.Controls
                     UserNameCB.Items.Add(m_BrowseCertificates);
                     UserNameCB.SelectedIndex = 0;
                 }
-
-                // populate list.
-                foreach (IUserIdentity identity in m_session.IdentityHistory)
-                {
-                    if (identity.TokenType == tokenType)
-                    {
-                        UserNameCB.Items.Add(identity.DisplayName);
-                    }
-                }
             }
             catch (Exception exception)
             {
-                GuiUtils.HandleException(m_session?.MessageContext?.Telemetry, this.Text, MethodBase.GetCurrentMethod(), exception);
+                GuiUtils.HandleException(m_telemetry, this.Text, MethodBase.GetCurrentMethod(), exception);
             }
         }
 
@@ -186,7 +182,7 @@ namespace Opc.Ua.Sample.Controls
             }
             catch (Exception exception)
             {
-                GuiUtils.HandleException(m_session?.MessageContext?.Telemetry, this.Text, MethodBase.GetCurrentMethod(), exception);
+                GuiUtils.HandleException(m_telemetry, this.Text, MethodBase.GetCurrentMethod(), exception);
             }
         }
 
@@ -258,7 +254,7 @@ namespace Opc.Ua.Sample.Controls
 
                     if (!String.IsNullOrEmpty(username) || !String.IsNullOrEmpty(PasswordTB.Text))
                     {
-                        #pragma warning disable CA2000 // Justification: Sample code retains existing ownership/lifetime and behavior.
+                        #pragma warning disable CA2000 // Justification: UserIdentity ownership is transferred to the created session.
                         identity = new UserIdentity(username, Encoding.UTF8.GetBytes(PasswordTB.Text));
                         #pragma warning restore CA2000
                     }
@@ -277,21 +273,21 @@ namespace Opc.Ua.Sample.Controls
                         return;
                     }
 
-                    #pragma warning disable CA2000 // Justification: UserIdentity ownership is transferred to the active session.
+                    #pragma warning disable CA2000 // Justification: UserIdentity ownership is transferred to the created session.
                     identity = new UserIdentity(new X509IdentityToken { CertificateData = m_userCertificate.RawData.ToByteString() });
                     #pragma warning restore CA2000
                 }
 
                 Cursor = Cursors.WaitCursor;
 
-                Task.Run(() => OpenAsync(m_session, SessionNameTB.Text, identity, m_preferredLocales, m_checkDomain));
+                Task.Run(() => OpenAsync(SessionNameTB.Text, identity, m_checkDomain));
 
                 CancelBTN.Enabled = false;
                 OkBTN.Enabled = false;
             }
             catch (Exception exception)
             {
-                GuiUtils.HandleException(m_session?.MessageContext?.Telemetry, this.Text, MethodBase.GetCurrentMethod(), exception);
+                GuiUtils.HandleException(m_telemetry, this.Text, MethodBase.GetCurrentMethod(), exception);
             }
         }
 
@@ -339,19 +335,22 @@ namespace Opc.Ua.Sample.Controls
                             return;
                         }
 
-                        DialogResult = DialogResult.OK;
                         return;
                     }
                 }
 
-                if (e != null)
+                if (e is Exception exception)
                 {
-                    GuiUtils.HandleException(m_session?.MessageContext?.Telemetry, this.Text, MethodBase.GetCurrentMethod(), (Exception)e);
+                    // leave the dialog open so the user can retry with other settings.
+                    GuiUtils.HandleException(m_telemetry, this.Text, MethodBase.GetCurrentMethod(), exception);
+                    return;
                 }
 
-                if (m_session.Connected && m_session.SessionTimeout < 1000)
+                m_session = e as ISession;
+
+                if (m_session != null && m_session.Connected && m_session.SessionTimeout < 1000)
                 {
-                    DialogResult result = MessageBox.Show(
+                    MessageBox.Show(
                         "Warning: the session time out might be too small: " + m_session.SessionTimeout,
                         "Session revised timeout",
                         MessageBoxButtons.OK,
@@ -368,19 +367,32 @@ namespace Opc.Ua.Sample.Controls
         }
 
         /// <summary>
-        /// Asynchronously open the session.
+        /// Asynchronously creates and opens the session.
         /// </summary>
-        private async Task OpenAsync(Session session, string sessionName, IUserIdentity identity, IList<string> preferredLocales, bool? checkDomain, CancellationToken ct = default)
+        /// <remarks>
+        /// The managed session factory discovers the endpoint, creates the secure channel and
+        /// opens the session in one step, which replaces the channel the control used to build
+        /// by hand before handing it to a raw session.
+        /// </remarks>
+        private async Task OpenAsync(string sessionName, IUserIdentity identity, bool checkDomain, CancellationToken ct = default)
         {
             try
             {
-                // open the session.
-                await session.OpenAsync(sessionName, (uint)session.SessionTimeout, identity, preferredLocales.ToArray(), checkDomain ?? true, false, ct);
+                ISession session = await new ManagedSessionFactory(m_telemetry).CreateAsync(
+                    m_configuration,
+                    m_endpoint,
+                    false,
+                    checkDomain,
+                    sessionName,
+                    (uint)m_configuration.ClientConfiguration.DefaultSessionTimeout,
+                    identity,
+                    m_preferredLocales?.ToArray(),
+                    ct);
 
-                var typeSystemLoader = new ComplexTypeSystemFactory(session.MessageContext.Telemetry).Create(session);
+                var typeSystemLoader = new ComplexTypeSystemFactory(m_telemetry).Create(session);
                 _ = await typeSystemLoader.LoadAsync(ct: ct);
 
-                OpenComplete(null);
+                OpenComplete(session);
             }
             catch (Exception exception)
             {

--- a/Samples/Controls.Net4/Sessions/SessionTreeCtrl.Designer.cs
+++ b/Samples/Controls.Net4/Sessions/SessionTreeCtrl.Designer.cs
@@ -125,7 +125,7 @@ namespace Opc.Ua.Sample.Controls
             this.SessionSaveMI.Name = "SessionSaveMI";
             this.SessionSaveMI.Size = new System.Drawing.Size(183, 22);
             this.SessionSaveMI.Text = "Save Subscriptions...";
-            this.SessionSaveMI.Click += new System.EventHandler(this.SessionSaveMI_Click);
+            this.SessionSaveMI.Click += new System.EventHandler(this.SessionSaveMI_ClickAsync);
             // 
             // SessionLoadMI
             // 

--- a/Samples/Controls.Net4/Sessions/SessionTreeCtrl.cs
+++ b/Samples/Controls.Net4/Sessions/SessionTreeCtrl.cs
@@ -35,12 +35,16 @@ using System.IO;
 
 using Opc.Ua.Client;
 using Opc.Ua.Client.Controls;
-using System.Security.Cryptography.X509Certificates;
+using Opc.Ua.Client.Subscriptions;
 using System.Threading.Tasks;
 using System.Threading;
 
 namespace Opc.Ua.Sample.Controls
 {
+    // the V2 subscription engine reuses names the classic engine already has in the
+    // Opc.Ua.Client namespace this file imports, so the V2 types are pinned explicitly.
+    using SubscriptionState = Opc.Ua.Client.Subscriptions.SubscriptionState;
+
     public partial class SessionTreeCtrl : Opc.Ua.Client.Controls.BaseTreeCtrl
     {
         #region Contructors
@@ -50,10 +54,10 @@ namespace Opc.Ua.Sample.Controls
 
             m_eventRegistrations = new Dictionary<object, TreeNode>();
             m_endpointUrls = new List<string>();
-            m_dialogs = new Dictionary<Subscription, SubscriptionDlg>();
+            m_subscriptions = new List<SubscriptionHandle>();
+            m_dialogs = new Dictionary<SubscriptionHandle, SubscriptionDlg>();
 
-            m_SessionSubscriptionsChanged = new EventHandler(Session_SubscriptionsChanged);
-            m_SubscriptionStateChanged = new SubscriptionStateChangedEventHandler(Subscription_StateChanged);
+            m_SubscriptionStateChanged = new Action<ISubscription, SubscriptionState, PublishState>(Subscription_StateChanged);
         }
         #endregion
 
@@ -61,11 +65,11 @@ namespace Opc.Ua.Sample.Controls
         private BrowseTreeCtrl m_AddressSpaceCtrl;
         private NotificationMessageListCtrl m_NotificationMessagesCtrl;
         private ToolStripStatusLabel m_ServerStatusCtrl;
-        private EventHandler m_SessionSubscriptionsChanged;
-        private SubscriptionStateChangedEventHandler m_SubscriptionStateChanged;
+        private Action<ISubscription, SubscriptionState, PublishState> m_SubscriptionStateChanged;
         private Dictionary<object, TreeNode> m_eventRegistrations;
         private List<string> m_endpointUrls;
-        private Dictionary<Subscription, SubscriptionDlg> m_dialogs;
+        private List<SubscriptionHandle> m_subscriptions;
+        private Dictionary<SubscriptionHandle, SubscriptionDlg> m_dialogs;
         private ApplicationConfiguration m_configuration;
         private ServiceMessageContext m_messageContext;
         private ConfiguredEndpoint m_endpoint;
@@ -110,17 +114,6 @@ namespace Opc.Ua.Sample.Controls
                 dialog.Close();
             }
 
-            // close all active sessions.
-            foreach (TreeNode root in NodesTV.Nodes)
-            {
-                Session session = root.Tag as Session;
-
-                if (session != null)
-                {
-                    await session.CloseAsync(ct);
-                }
-            }
-
             await ClearAsync(ct);
         }
 
@@ -132,7 +125,7 @@ namespace Opc.Ua.Sample.Controls
             // close all active sessions.
             foreach (TreeNode root in NodesTV.Nodes)
             {
-                Session session = root.Tag as Session;
+                ISession session = root.Tag as ISession;
 
                 if (session != null)
                 {
@@ -140,6 +133,7 @@ namespace Opc.Ua.Sample.Controls
                 }
             }
 
+            m_subscriptions.Clear();
             Clear(NodesTV.Nodes);
         }
 
@@ -176,13 +170,15 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Creates a session with the endpoint.
         /// </summary>
-        public async Task<Session> ConnectAsync(ConfiguredEndpoint endpoint, ITelemetryContext telemetry, CancellationToken ct = default)
+        /// <remarks>
+        /// The session is created with a <see cref="ManagedSessionFactory"/> by the open
+        /// dialog, so it reconnects on its own and runs the V2 subscription engine.
+        /// </remarks>
+        public async Task<ISession> ConnectAsync(ConfiguredEndpoint endpoint, ITelemetryContext telemetry, CancellationToken ct = default)
         {
             if (endpoint == null) throw new ArgumentNullException(nameof(endpoint));
 
             Telemetry = telemetry;
-
-            IList<EndpointDescription> availableEndpoints = null;
 
             // check if the endpoint needs to be updated.
             if (endpoint.UpdateBeforeConnect)
@@ -190,7 +186,7 @@ namespace Opc.Ua.Sample.Controls
                 #pragma warning disable CA2000 // Justification: Sample code retains existing ownership/lifetime and behavior.
                 ConfiguredServerDlg configurationDialog = new ConfiguredServerDlg();
                 #pragma warning restore CA2000
-                #pragma warning disable CA1849 // Justification: Sample code retains existing ownership/lifetime and behavior.
+                #pragma warning disable CA1849 // Justification: modal dialogs pump their own message loop.
                 endpoint = configurationDialog.ShowDialog(endpoint, m_configuration);
                 #pragma warning restore CA1849
 
@@ -198,7 +194,6 @@ namespace Opc.Ua.Sample.Controls
                 {
                     return null;
                 }
-                availableEndpoints = configurationDialog.AvailableEnpoints;
             }
 
             m_endpoint = endpoint;
@@ -206,91 +201,30 @@ namespace Opc.Ua.Sample.Controls
             // copy the message context.
             m_messageContext = m_configuration.CreateMessageContext();
 
-            Opc.Ua.Security.Certificates.Certificate clientCertificate = null;
+            // create and open the session.
+            #pragma warning disable CA2000, CA1849 // Justification: modal dialogs pump their own message loop; sample code retains existing ownership/lifetime and behavior.
+            ISession session = new SessionOpenDlg().ShowDialog(m_configuration, endpoint, PreferredLocales, telemetry);
+            #pragma warning restore CA2000, CA1849
 
-            if (endpoint.Description.SecurityPolicyUri != SecurityPolicies.None)
+            if (session == null)
             {
-                if (m_configuration.SecurityConfiguration.ApplicationCertificate == null)
-                {
-                    throw ServiceResultException.Create(StatusCodes.BadConfigurationError, "ApplicationCertificate must be specified.");
-                }
-
-                clientCertificate = await m_configuration.CertificateManager.CertificateProvider.GetPrivateKeyCertificateAsync(
-                    m_configuration.SecurityConfiguration.ApplicationCertificate,
-                    null,
-                    null,
-                    ct);
-
-                if (clientCertificate == null)
-                {
-                    throw ServiceResultException.Create(StatusCodes.BadConfigurationError, "ApplicationCertificate cannot be found.");
-                }
-
+                return null;
             }
 
-            // create the channel.
-            ITransportChannel channel = await UaChannelBase.CreateUaBinaryChannelAsync(
-                m_configuration,
-                endpoint.Description,
-                endpoint.Configuration,
-                clientCertificate,
-                m_messageContext,
-                ct);
+            // delete the existing session.
+            await CloseAsync(ct);
 
-            // create the session.
-            return await ConnectAsync(endpoint, channel, availableEndpoints, telemetry, ct);
-        }
+            // add session to tree.
+            AddNode(session);
 
-        /// <summary>
-        /// Opens a new session.
-        /// </summary>
-        public async Task<Session> ConnectAsync(ConfiguredEndpoint endpoint, ITransportChannel channel, IList<EndpointDescription> availableEndpoints, ITelemetryContext telemetry, CancellationToken ct = default)
-        {
-            if (channel == null) throw new ArgumentNullException(nameof(channel));
-
-            Telemetry = telemetry;
-
-            try
-            {
-                // create the session.
-                #pragma warning disable CA2000 // Justification: Sample code retains existing ownership/lifetime and behavior.
-                Session session = new Session(channel, m_configuration, endpoint, null);
-                #pragma warning restore CA2000
-                session.ReturnDiagnostics = DiagnosticsMasks.All;
-
-                #pragma warning disable CA1849, CA2000 // Justification: Sample code retains existing ownership/lifetime and behavior.
-                if (!new SessionOpenDlg().ShowDialog(session, PreferredLocales))
-                #pragma warning restore CA1849, CA2000
-                {
-                    return null;
-                }
-
-                // session now owns the channel.
-                channel = null;
-
-                // delete the existing session.
-                await CloseAsync(ct);
-
-                // add session to tree.
-                AddNode(session);
-
-                // return the new session.
-                return session;
-            }
-            finally
-            {
-                // ensure the channel is closed on error.
-                if (channel != null)
-                {
-                    await channel.CloseAsync(ct);
-                }
-            }
+            // return the new session.
+            return session;
         }
 
         /// <summary>
         /// Deletes a session.
         /// </summary>
-        public async Task DeleteAsync(Session session, CancellationToken ct = default)
+        public async Task DeleteAsync(ISession session, CancellationToken ct = default)
         {
             if (session == null) throw new ArgumentNullException(nameof(session));
 
@@ -310,6 +244,8 @@ namespace Opc.Ua.Sample.Controls
                 dialog.Close();
             }
 
+            m_subscriptions.RemoveAll(handle => Object.ReferenceEquals(handle.Session, session));
+
             await session.CloseAsync(ct);
             NodesTV.SelectedNode = null;
             SelectNode();
@@ -318,7 +254,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Deletes a subscription.
         /// </summary>
-        public async Task DeleteAsync(Subscription subscription, CancellationToken ct = default)
+        public async Task DeleteAsync(SubscriptionHandle subscription, CancellationToken ct = default)
         {
             if (subscription == null) throw new ArgumentNullException(nameof(subscription));
 
@@ -330,8 +266,11 @@ namespace Opc.Ua.Sample.Controls
                 dialog.Close();
             }
 
-            Session session = subscription.Session as Session;
-            await session.RemoveSubscriptionAsync(subscription, ct);
+            // disposing the subscription deletes it on the server and drops it from the
+            // subscription manager of the session.
+            await subscription.DeleteAsync();
+
+            m_subscriptions.Remove(subscription);
 
             TreeNode node = FindNode(NodesTV.Nodes, subscription);
 
@@ -343,14 +282,15 @@ namespace Opc.Ua.Sample.Controls
                 node.Remove();
             }
 
-            NodesTV.SelectedNode = FindNode(NodesTV.Nodes, session);
+            NodesTV.SelectedNode = FindNode(NodesTV.Nodes, subscription.Session);
         }
 
         /// <summary>
         /// Deletes a monitored item.
         /// </summary>
-        public async Task DeleteAsync(MonitoredItem monitoredItem, CancellationToken ct = default)
+        public async Task DeleteAsync(SubscriptionHandle subscription, MonitoredItemHandle monitoredItem, CancellationToken ct = default)
         {
+            if (subscription == null) throw new ArgumentNullException(nameof(subscription));
             if (monitoredItem == null) throw new ArgumentNullException(nameof(monitoredItem));
 
             TreeNode node = FindNode(NodesTV.Nodes, monitoredItem);
@@ -363,16 +303,17 @@ namespace Opc.Ua.Sample.Controls
                 node.Remove();
             }
 
-            Subscription subscription = monitoredItem.Subscription;
+            // removing the item is the request, the engine deletes it on its own worker.
             subscription.RemoveItem(monitoredItem);
-            await subscription.ApplyChangesAsync(ct);
+            await subscription.WaitForPendingChangesAsync(TimeSpan.FromSeconds(10), ct);
+
             NodesTV.SelectedNode = FindNode(NodesTV.Nodes, subscription);
         }
 
         /// <summary>
         /// Creates a new subscription.
         /// </summary>
-        public async Task<Subscription> CreateSubscriptionAsync(Session session, CancellationToken ct = default)
+        public async Task<SubscriptionHandle> CreateSubscriptionAsync(ISession session, CancellationToken ct = default)
         {
             // create form.
             #pragma warning disable CA2000 // Justification: Sample code retains existing ownership/lifetime and behavior.
@@ -381,30 +322,49 @@ namespace Opc.Ua.Sample.Controls
             dialog.FormClosing += new FormClosingEventHandler(Subscription_FormClosing);
 
             // create subscription.
-            Subscription subscription = await dialog.NewAsync(session, Telemetry, ct);
+            SubscriptionHandle subscription = dialog.New(session, Telemetry);
 
             if (subscription != null)
             {
                 m_dialogs.Add(subscription, dialog);
-                subscription.Handle = dialog;
+                AddSubscription(subscription);
                 return subscription;
             }
 
             return null;
         }
 
-        public void Reload(Session session)
+        /// <summary>
+        /// The subscriptions of the session which the control keeps track of.
+        /// </summary>
+        public IList<SubscriptionHandle> GetSubscriptions(ISession session)
+        {
+            List<SubscriptionHandle> subscriptions = new List<SubscriptionHandle>();
+
+            foreach (SubscriptionHandle handle in m_subscriptions)
+            {
+                if (Object.ReferenceEquals(handle.Session, session))
+                {
+                    subscriptions.Add(handle);
+                }
+            }
+
+            return subscriptions;
+        }
+
+        /// <summary>
+        /// Rebuilds the tree for the session, e.g. after a reconnect.
+        /// </summary>
+        /// <remarks>
+        /// The managed session keeps the same session instance and its V2 subscriptions
+        /// across a reconnect, so this only refreshes the display.
+        /// </remarks>
+        public void Reload(ISession session)
         {
             // update any dialogs.
-            foreach (SubscriptionDlg dialog in new List<SubscriptionDlg>(m_dialogs.Values))
+            foreach (KeyValuePair<SubscriptionHandle, SubscriptionDlg> current in new List<KeyValuePair<SubscriptionHandle, SubscriptionDlg>>(m_dialogs))
             {
-                foreach (Subscription subscription in session.Subscriptions)
-                {
-                    if (subscription.Handle == dialog)
-                    {
-                        dialog.Show(subscription);
-                    }
-                }
+                current.Value.Show(current.Key);
             }
 
             // clear all nodes.
@@ -424,7 +384,7 @@ namespace Opc.Ua.Sample.Controls
             NewWindowMI.Visible = this.FindForm() is ClientForm;
             NewWindowMI.Enabled = true;
 
-            Session session = clickedNode.Tag as Session;
+            ISession session = clickedNode.Tag as ISession;
 
             if (session != null)
             {
@@ -447,7 +407,7 @@ namespace Opc.Ua.Sample.Controls
                 SubscriptionCreateMI.Enabled = SubscriptionMI.Enabled;
             }
 
-            Subscription subscription = clickedNode.Tag as Subscription;
+            SubscriptionHandle subscription = clickedNode.Tag as SubscriptionHandle;
 
             if (subscription != null)
             {
@@ -457,10 +417,10 @@ namespace Opc.Ua.Sample.Controls
                 SubscriptionMI.Enabled = subscription.Session.Connected;
                 SubscriptionMonitorMI.Enabled = SubscriptionMI.Enabled;
                 SubscriptionEnabledPublishingMI.Enabled = SubscriptionMI.Enabled;
-                SubscriptionEnabledPublishingMI.Checked = subscription.CurrentPublishingEnabled;
+                SubscriptionEnabledPublishingMI.Checked = (subscription.Subscription != null) ? subscription.Subscription.CurrentPublishingEnabled : subscription.Settings.PublishingEnabled;
             }
 
-            MonitoredItem monitoredItem = clickedNode.Tag as MonitoredItem;
+            MonitoredItemHandle monitoredItem = clickedNode.Tag as MonitoredItemHandle;
 
             if (monitoredItem != null)
             {
@@ -495,8 +455,8 @@ namespace Opc.Ua.Sample.Controls
 
             TreeNode selectedNode = NodesTV.SelectedNode;
 
-            Session session = Get<Session>(selectedNode);
-            Subscription subscription = Get<Subscription>(selectedNode);
+            ISession session = Get<ISession>(selectedNode);
+            SubscriptionHandle subscription = Get<SubscriptionHandle>(selectedNode);
 
             // update address space control.
             if (m_AddressSpaceCtrl != null)
@@ -507,7 +467,7 @@ namespace Opc.Ua.Sample.Controls
             // update notification messages control.
             if (m_NotificationMessagesCtrl != null)
             {
-                m_NotificationMessagesCtrl.Initialize(session, subscription);
+                m_NotificationMessagesCtrl.Initialize(session, GetSubscriptions(session), subscription);
             }
         }
         #endregion
@@ -519,20 +479,19 @@ namespace Opc.Ua.Sample.Controls
         {
             foreach (TreeNode node in nodes)
             {
-                if (m_eventRegistrations.Remove(node.Tag))
+                if (node.Tag != null && m_eventRegistrations.Remove(node.Tag))
                 {
-                    if (node.Tag is Session)
+                    if (node.Tag is SubscriptionHandle subscription)
                     {
-                        ((Session)node.Tag).SubscriptionsChanged -= m_SessionSubscriptionsChanged;
-                    }
-
-                    else if (node.Tag is Subscription)
-                    {
-                        ((Subscription)node.Tag).StateChanged -= m_SubscriptionStateChanged;
+                        subscription.Callbacks.StateChangedCallback -= m_SubscriptionStateChanged;
                     }
                 }
 
+                #pragma warning disable CA1849 // Justification: Sample code retains existing ownership/lifetime and behavior.
+
                 Clear(node.Nodes);
+
+                #pragma warning restore CA1849
             }
 
             nodes.Clear();
@@ -540,47 +499,52 @@ namespace Opc.Ua.Sample.Controls
 
         #region Private Members
         /// <summary>
-        /// Called when the set of items for a subscription changes.
+        /// Called by the V2 subscription engine when the state of a subscription changes,
+        /// which includes the engine finishing to apply monitored item changes.
         /// </summary>
-        private void Subscription_StateChanged(object sender, EventArgs e)
+        private void Subscription_StateChanged(ISubscription subscription, SubscriptionState state, PublishState publishStateMask)
         {
             if (InvokeRequired)
             {
-                BeginInvoke(new EventHandler(Subscription_StateChanged), sender, e);
+                BeginInvoke(m_SubscriptionStateChanged, subscription, state, publishStateMask);
+                return;
+            }
+            else if (!IsHandleCreated)
+            {
                 return;
             }
 
-            TreeNode node = FindNode(NodesTV.Nodes, sender);
+            SubscriptionHandle handle = FindSubscription(subscription);
+
+            if (handle == null)
+            {
+                return;
+            }
+
+            TreeNode node = FindNode(NodesTV.Nodes, handle);
 
             if (node == null)
             {
                 return;
             }
 
-            UpdateNode(node, sender as Subscription);
+            UpdateNode(node, handle);
         }
 
         /// <summary>
-        /// Called when the set of subscriptions for a session changes.
+        /// Finds the handle for a subscription of the V2 engine.
         /// </summary>
-        private void Session_SubscriptionsChanged(object sender, EventArgs e)
+        private SubscriptionHandle FindSubscription(ISubscription subscription)
         {
-            if (InvokeRequired)
+            foreach (SubscriptionHandle handle in m_subscriptions)
             {
-                BeginInvoke(new EventHandler(Session_SubscriptionsChanged), sender, e);
-                return;
+                if (Object.ReferenceEquals(handle.Subscription, subscription))
+                {
+                    return handle;
+                }
             }
 
-            TreeNode node = FindNode(NodesTV.Nodes, sender);
-
-            if (node == null)
-            {
-                return;
-            }
-
-            UpdateNode(node, sender as Session);
-            node.EnsureVisible();
-            node.Expand();
+            return null;
         }
 
         /// <summary>
@@ -607,43 +571,31 @@ namespace Opc.Ua.Sample.Controls
         }
 
         /// <summary>
-        /// Recursively finds the node with the specified tag and returns the immediate child with the specified child tag.
+        /// Registers a subscription created on behalf of the control and adds it to the tree.
         /// </summary>
-        private TreeNode FindChild(TreeNodeCollection collection, object tag, object childTag)
+        private void AddSubscription(SubscriptionHandle subscription)
         {
-            TreeNode parent = FindNode(collection, tag);
+            m_subscriptions.Add(subscription);
 
-            if (parent == null)
+            TreeNode parent = FindNode(NodesTV.Nodes, subscription.Session);
+
+            if (parent != null)
             {
-                return null;
+                AddNode(parent, subscription);
+                parent.EnsureVisible();
+                parent.Expand();
             }
-
-            foreach (TreeNode child in parent.Nodes)
-            {
-                if (Object.ReferenceEquals(child.Tag, childTag))
-                {
-                    return child;
-                }
-            }
-
-            return null;
         }
 
         /// <summary>
         /// Adds a session to the tree.
         /// </summary>
-        private void AddNode(Session session)
+        private void AddNode(ISession session)
         {
             if (session == null) throw new ArgumentNullException(nameof(session));
 
             TreeNode node = AddNode(null, session, session.SessionName, "Server");
             UpdateNode(node, session);
-
-            if (!m_eventRegistrations.ContainsKey(session))
-            {
-                session.SubscriptionsChanged += m_SessionSubscriptionsChanged;
-                m_eventRegistrations.Add(session, node);
-            }
 
             NodesTV.SelectedNode = node;
         }
@@ -651,14 +603,14 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Updates a session node in the tree.
         /// </summary>
-        private void UpdateNode(TreeNode parent, Session session)
+        private void UpdateNode(TreeNode parent, ISession session)
         {
             UpdateNode(parent, session, session.SessionName, (session.Connected) ? "Server" : "ServerStopped");
             Clear(parent.Nodes);
 
             if (Object.ReferenceEquals(parent.Tag, session))
             {
-                foreach (Subscription subscription in session.Subscriptions)
+                foreach (SubscriptionHandle subscription in GetSubscriptions(session))
                 {
                     AddNode(parent, subscription);
                 }
@@ -668,14 +620,14 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Adds a subscription to the tree.
         /// </summary>
-        private void AddNode(TreeNode parent, Subscription subscription)
+        private void AddNode(TreeNode parent, SubscriptionHandle subscription)
         {
             TreeNode node = AddNode(parent, subscription, subscription.DisplayName, "Object");
             UpdateNode(node, subscription);
 
             if (!m_eventRegistrations.ContainsKey(subscription))
             {
-                subscription.StateChanged += m_SubscriptionStateChanged;
+                subscription.Callbacks.StateChangedCallback += m_SubscriptionStateChanged;
                 m_eventRegistrations.Add(subscription, node);
             }
         }
@@ -683,12 +635,12 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Updates a subscription node in the tree.
         /// </summary>
-        private void UpdateNode(TreeNode parent, Subscription subscription)
+        private void UpdateNode(TreeNode parent, SubscriptionHandle subscription)
         {
             Clear(parent.Nodes);
             parent.Text = subscription.DisplayName;
 
-            foreach (MonitoredItem monitoredItem in subscription.MonitoredItems)
+            foreach (MonitoredItemHandle monitoredItem in subscription.Items)
             {
                 AddNode(parent, monitoredItem, monitoredItem.DisplayName, "Property");
             }
@@ -708,7 +660,7 @@ namespace Opc.Ua.Sample.Controls
                 }
 
                 // get selected session.
-                Session session = selectedNode.Tag as Session;
+                ISession session = selectedNode.Tag as ISession;
 
                 if (session != null)
                 {
@@ -736,7 +688,7 @@ namespace Opc.Ua.Sample.Controls
                 }
 
                 // get selected session.
-                Session session = selectedNode.Tag as Session;
+                ISession session = selectedNode.Tag as ISession;
 
                 if (session != null)
                 {
@@ -764,7 +716,7 @@ namespace Opc.Ua.Sample.Controls
                 }
 
                 // get selected session.
-                Session session = selectedNode.Tag as Session;
+                ISession session = selectedNode.Tag as ISession;
 
                 if (session != null)
                 {
@@ -792,7 +744,7 @@ namespace Opc.Ua.Sample.Controls
                 }
 
                 // get selected session.
-                Session session = selectedNode.Tag as Session;
+                ISession session = selectedNode.Tag as ISession;
 
                 if (session != null)
                 {
@@ -820,7 +772,7 @@ namespace Opc.Ua.Sample.Controls
                 }
 
                 // get selected session.
-                Session session = selectedNode.Tag as Session;
+                ISession session = selectedNode.Tag as ISession;
 
                 if (session != null)
                 {
@@ -848,7 +800,7 @@ namespace Opc.Ua.Sample.Controls
                 }
 
                 // get selected session.
-                Session session = selectedNode.Tag as Session;
+                ISession session = selectedNode.Tag as ISession;
 
                 if (session != null)
                 {
@@ -876,7 +828,7 @@ namespace Opc.Ua.Sample.Controls
                 }
 
                 // get selected session.
-                Session session = selectedNode.Tag as Session;
+                ISession session = selectedNode.Tag as ISession;
 
                 if (session != null)
                 {
@@ -904,7 +856,7 @@ namespace Opc.Ua.Sample.Controls
                 }
 
                 // get selected session.
-                Session session = selectedNode.Tag as Session;
+                ISession session = selectedNode.Tag as ISession;
 
                 if (session != null)
                 {
@@ -947,7 +899,7 @@ namespace Opc.Ua.Sample.Controls
                 }
 
                 // get selected session.
-                Session session = selectedNode.Tag as Session;
+                ISession session = selectedNode.Tag as ISession;
 
                 if (session != null)
                 {
@@ -986,7 +938,7 @@ namespace Opc.Ua.Sample.Controls
                 }
 
                 // get selected session.
-                Session session = selectedNode.Tag as Session;
+                ISession session = selectedNode.Tag as ISession;
 
                 if (session == null)
                 {
@@ -1004,7 +956,7 @@ namespace Opc.Ua.Sample.Controls
 
         private void Subscription_FormClosing(object sender, FormClosingEventArgs e)
         {
-            foreach (KeyValuePair<Subscription, SubscriptionDlg> current in m_dialogs)
+            foreach (KeyValuePair<SubscriptionHandle, SubscriptionDlg> current in m_dialogs)
             {
                 if (current.Value == sender)
                 {
@@ -1039,7 +991,7 @@ namespace Opc.Ua.Sample.Controls
                 }
 
                 // delete session.
-                Session session = selectedNode.Tag as Session;
+                ISession session = selectedNode.Tag as ISession;
 
                 if (session != null)
                 {
@@ -1047,7 +999,7 @@ namespace Opc.Ua.Sample.Controls
                 }
 
                 // delete subscription
-                Subscription subscription = selectedNode.Tag as Subscription;
+                SubscriptionHandle subscription = selectedNode.Tag as SubscriptionHandle;
 
                 if (subscription != null)
                 {
@@ -1055,11 +1007,16 @@ namespace Opc.Ua.Sample.Controls
                 }
 
                 // delete monitored item
-                MonitoredItem monitoredItem = selectedNode.Tag as MonitoredItem;
+                MonitoredItemHandle monitoredItem = selectedNode.Tag as MonitoredItemHandle;
 
                 if (monitoredItem != null)
                 {
-                    await DeleteAsync(monitoredItem);
+                    subscription = Get<SubscriptionHandle>(selectedNode);
+
+                    if (subscription != null)
+                    {
+                        await DeleteAsync(subscription, monitoredItem);
+                    }
                 }
             }
             catch (Exception exception)
@@ -1073,7 +1030,7 @@ namespace Opc.Ua.Sample.Controls
             try
             {
                 // get the current session.
-                Session session = Get<Session>(NodesTV.SelectedNode);
+                ISession session = Get<ISession>(NodesTV.SelectedNode);
 
                 if (session == null || !session.Connected)
                 {
@@ -1083,35 +1040,21 @@ namespace Opc.Ua.Sample.Controls
                 // build list of nodes to read.
                 List<ReadValueId> valueIds = new List<ReadValueId>();
 
-                MonitoredItem monitoredItem = Get<MonitoredItem>(NodesTV.SelectedNode);
+                MonitoredItemHandle monitoredItem = Get<MonitoredItemHandle>(NodesTV.SelectedNode);
 
                 if (monitoredItem != null)
                 {
-                    ReadValueId valueId = new ReadValueId();
-
-                    valueId.NodeId = monitoredItem.ResolvedNodeId;
-                    valueId.AttributeId = monitoredItem.AttributeId;
-                    valueId.IndexRange = monitoredItem.IndexRange;
-                    valueId.DataEncoding = monitoredItem.Encoding;
-
-                    valueIds.Add(valueId);
+                    valueIds.Add(ToReadValueId(monitoredItem));
                 }
                 else
                 {
-                    Subscription subscription = Get<Subscription>(NodesTV.SelectedNode);
+                    SubscriptionHandle subscription = Get<SubscriptionHandle>(NodesTV.SelectedNode);
 
                     if (subscription != null)
                     {
-                        foreach (MonitoredItem item in subscription.MonitoredItems)
+                        foreach (MonitoredItemHandle item in subscription.Items)
                         {
-                            ReadValueId valueId = new ReadValueId();
-
-                            valueId.NodeId = item.ResolvedNodeId;
-                            valueId.AttributeId = item.AttributeId;
-                            valueId.IndexRange = item.IndexRange;
-                            valueId.DataEncoding = item.Encoding;
-
-                            valueIds.Add(valueId);
+                            valueIds.Add(ToReadValueId(item));
                         }
                     }
                 }
@@ -1127,62 +1070,49 @@ namespace Opc.Ua.Sample.Controls
             }
         }
 
+        /// <summary>
+        /// Builds the read request for the node a monitored item watches.
+        /// </summary>
+        private static ReadValueId ToReadValueId(MonitoredItemHandle monitoredItem)
+        {
+            return new ReadValueId {
+                NodeId = monitoredItem.Settings.StartNodeId,
+                AttributeId = monitoredItem.Settings.AttributeId,
+                IndexRange = monitoredItem.Settings.IndexRange,
+                DataEncoding = monitoredItem.Settings.Encoding ?? QualifiedName.Null,
+            };
+        }
+
         private async void WriteMI_ClickAsync(object sender, EventArgs e)
         {
             try
             {
                 // get the current session.
-                Session session = Get<Session>(NodesTV.SelectedNode);
+                ISession session = Get<ISession>(NodesTV.SelectedNode);
 
                 if (session == null || !session.Connected)
                 {
                     return;
                 }
 
-                // build list of nodes to read.
+                // build list of nodes to write.
                 List<WriteValue> values = new List<WriteValue>();
 
-                MonitoredItem monitoredItem = Get<MonitoredItem>(NodesTV.SelectedNode);
+                MonitoredItemHandle monitoredItem = Get<MonitoredItemHandle>(NodesTV.SelectedNode);
 
                 if (monitoredItem != null)
                 {
-                    WriteValue value = new WriteValue();
-
-                    value.NodeId = monitoredItem.ResolvedNodeId;
-                    value.AttributeId = monitoredItem.AttributeId;
-                    value.IndexRange = monitoredItem.IndexRange;
-
-                    MonitoredItemNotification datachange = monitoredItem.LastValue as MonitoredItemNotification;
-
-                    if (datachange != null)
-                    {
-                        value.Value = datachange.Value;
-                    }
-
-                    values.Add(value);
+                    values.Add(ToWriteValue(monitoredItem));
                 }
                 else
                 {
-                    Subscription subscription = Get<Subscription>(NodesTV.SelectedNode);
+                    SubscriptionHandle subscription = Get<SubscriptionHandle>(NodesTV.SelectedNode);
 
                     if (subscription != null)
                     {
-                        foreach (MonitoredItem item in subscription.MonitoredItems)
+                        foreach (MonitoredItemHandle item in subscription.Items)
                         {
-                            WriteValue value = new WriteValue();
-
-                            value.NodeId = item.ResolvedNodeId;
-                            value.AttributeId = item.AttributeId;
-                            value.IndexRange = item.IndexRange;
-
-                            MonitoredItemNotification datachange = item.LastValue as MonitoredItemNotification;
-
-                            if (datachange != null)
-                            {
-                                value.Value = datachange.Value;
-                            }
-
-                            values.Add(value);
+                            values.Add(ToWriteValue(item));
                         }
                     }
                 }
@@ -1198,6 +1128,18 @@ namespace Opc.Ua.Sample.Controls
             }
         }
 
+        /// <summary>
+        /// Builds the write request for the node a monitored item watches.
+        /// </summary>
+        private static WriteValue ToWriteValue(MonitoredItemHandle monitoredItem)
+        {
+            return new WriteValue {
+                NodeId = monitoredItem.Settings.StartNodeId,
+                AttributeId = monitoredItem.Settings.AttributeId,
+                IndexRange = monitoredItem.Settings.IndexRange,
+            };
+        }
+
         private async void SubscriptionEnabledPublishingMI_ClickAsync(object sender, EventArgs e)
         {
             try
@@ -1210,12 +1152,15 @@ namespace Opc.Ua.Sample.Controls
                     return;
                 }
 
-                // delete session.
-                Subscription subscription = selectedNode.Tag as Subscription;
+                SubscriptionHandle subscription = selectedNode.Tag as SubscriptionHandle;
 
                 if (subscription != null)
                 {
-                    await subscription.SetPublishingModeAsync(SubscriptionEnabledPublishingMI.Checked);
+                    // reconfiguring the options is the request, the engine applies it on its
+                    // own worker.
+                    bool enabled = SubscriptionEnabledPublishingMI.Checked;
+                    subscription.Configure(options => options with { PublishingEnabled = enabled });
+                    await subscription.WaitForPendingChangesAsync(TimeSpan.FromSeconds(10));
                 }
             }
             catch (Exception exception)
@@ -1228,8 +1173,8 @@ namespace Opc.Ua.Sample.Controls
         {
             try
             {
-                // get selected session.
-                Subscription subscription = SelectedTag as Subscription;
+                // get selected subscription.
+                SubscriptionHandle subscription = SelectedTag as SubscriptionHandle;
 
                 if (subscription == null)
                 {
@@ -1244,7 +1189,6 @@ namespace Opc.Ua.Sample.Controls
                     dialog = new SubscriptionDlg();
                     dialog.FormClosing += new FormClosingEventHandler(Subscription_FormClosing);
                     m_dialogs.Add(subscription, dialog);
-                    subscription.Handle = dialog;
                 }
 
                 dialog.Show(subscription);
@@ -1255,14 +1199,14 @@ namespace Opc.Ua.Sample.Controls
             }
         }
 
-        private void SessionSaveMI_Click(object sender, EventArgs e)
+        private async void SessionSaveMI_ClickAsync(object sender, EventArgs e)
         {
             try
             {
                 // get selected session.
-                Session session = SelectedTag as Session;
+                ISession session = SelectedTag as ISession;
 
-                if (session == null)
+                if (session is not ManagedSession managedSession)
                 {
                     return;
                 }
@@ -1275,7 +1219,7 @@ namespace Opc.Ua.Sample.Controls
                     m_filePath = defaultInfo.DirectoryName;
                     m_filePath += Path.DirectorySeparatorChar;
                     m_filePath += session.SessionName;
-                    m_filePath += ".xml";
+                    m_filePath += ".uasubs";
                 }
 
                 // prompt user to select file.
@@ -1287,8 +1231,8 @@ namespace Opc.Ua.Sample.Controls
 
                 dialog.CheckFileExists = false;
                 dialog.CheckPathExists = true;
-                dialog.DefaultExt = ".xml";
-                dialog.Filter = "Result Files (*.xml)|*.xml|All Files (*.*)|*.*";
+                dialog.DefaultExt = ".uasubs";
+                dialog.Filter = "Subscription Files (*.uasubs)|*.uasubs|All Files (*.*)|*.*";
                 dialog.ValidateNames = true;
                 dialog.Title = "Save Subscriptions";
                 dialog.FileName = m_filePath;
@@ -1300,8 +1244,11 @@ namespace Opc.Ua.Sample.Controls
                     return;
                 }
 
-                // save file.
-                session.Save(dialog.FileName);
+                // save the subscriptions of the V2 engine.
+                using (FileStream stream = new FileStream(dialog.FileName, FileMode.Create))
+                {
+                    await managedSession.SaveSubscriptionsAsync(stream, null);
+                }
 
                 // remember file path.
                 m_filePath = dialog.FileName;
@@ -1317,9 +1264,9 @@ namespace Opc.Ua.Sample.Controls
             try
             {
                 // get selected session.
-                Session session = SelectedTag as Session;
+                ISession session = SelectedTag as ISession;
 
-                if (session == null)
+                if (session is not ManagedSession managedSession)
                 {
                     return;
                 }
@@ -1332,7 +1279,7 @@ namespace Opc.Ua.Sample.Controls
                     m_filePath = defaultInfo.DirectoryName;
                     m_filePath += Path.DirectorySeparatorChar;
                     m_filePath += session.SessionName;
-                    m_filePath += ".xml";
+                    m_filePath += ".uasubs";
                 }
 
                 FileInfo fileInfo = new FileInfo(m_filePath);
@@ -1343,8 +1290,8 @@ namespace Opc.Ua.Sample.Controls
 
                 dialog.CheckFileExists = true;
                 dialog.CheckPathExists = true;
-                dialog.DefaultExt = ".xml";
-                dialog.Filter = "Result Files (*.xml)|*.xml|All Files (*.*)|*.*";
+                dialog.DefaultExt = ".uasubs";
+                dialog.Filter = "Subscription Files (*.uasubs)|*.uasubs|All Files (*.*)|*.*";
                 dialog.Multiselect = false;
                 dialog.ValidateNames = true;
                 dialog.Title = "Load Subscriptions";
@@ -1360,15 +1307,37 @@ namespace Opc.Ua.Sample.Controls
                 // remember file path.
                 m_filePath = dialog.FileName;
 
-                // load file.
-                IEnumerable<Subscription> subscriptions = session.Load(dialog.FileName);
+                // restore the subscriptions into the V2 engine. Each restored subscription
+                // gets its own handle, whose callbacks the engine takes as the notification
+                // handler.
+                List<SubscriptionHandle> loaded = new List<SubscriptionHandle>();
 
-                // create the subscriptions automatically if the session is connected.
-                if (session.Connected)
+                using (FileStream stream = new FileStream(dialog.FileName, FileMode.Open))
                 {
-                    foreach (Subscription subscription in subscriptions)
+                    await managedSession.LoadSubscriptionsAsync(
+                        stream,
+                        name => {
+                            SubscriptionHandle handle = new SubscriptionHandle(session, name, ClientUtils.DefaultSubscriptionOptions);
+                            loaded.Add(handle);
+                            return handle.Callbacks;
+                        },
+                        false);
+                }
+
+                // the engine holds the restored subscriptions, so pair each new one with the
+                // handle whose callbacks it was created with.
+                if (loaded.Count > 0 && session.TryGetSubscriptionManager(out ISubscriptionManager manager))
+                {
+                    int index = 0;
+
+                    foreach (ISubscription subscription in manager.Items)
                     {
-                        await subscription.CreateAsync();
+                        if (FindSubscription(subscription) == null && index < loaded.Count)
+                        {
+                            loaded[index].Attach(subscription);
+                            AddSubscription(loaded[index]);
+                            index++;
+                        }
                     }
                 }
             }
@@ -1400,7 +1369,7 @@ namespace Opc.Ua.Sample.Controls
             try
             {
                 // get selected session.
-                Session session = SelectedTag as Session;
+                ISession session = SelectedTag as ISession;
 
                 if (session == null)
                 {

--- a/Samples/Controls.Net4/Sessions/TypeHierarchyListCtrl.cs
+++ b/Samples/Controls.Net4/Sessions/TypeHierarchyListCtrl.cs
@@ -54,7 +54,7 @@ namespace Opc.Ua.Sample
         #endregion
 
         #region Private Fields
-        private Session m_session;
+        private ISession m_session;
 
         // The columns to display in the control.
         private readonly object[][] m_ColumnNames = new object[][]
@@ -77,7 +77,7 @@ namespace Opc.Ua.Sample
         /// <summary>
         /// Initializes the control.
         /// </summary>
-        public async Task InitializeAsync(Session session, NodeId typeId, CancellationToken ct = default)
+        public async Task InitializeAsync(ISession session, NodeId typeId, CancellationToken ct = default)
         {
             ItemsLV.Items.Clear();
             AdjustColumns();

--- a/Samples/Controls.Net4/Sessions/TypeNavigatorCtrl.cs
+++ b/Samples/Controls.Net4/Sessions/TypeNavigatorCtrl.cs
@@ -53,7 +53,7 @@ namespace Opc.Ua.Sample
         #endregion
 
         #region Private Fields
-        private Session m_session;
+        private ISession m_session;
         private event TypeNavigatorEventHandler m_TypeSelected;
         #endregion
 
@@ -70,7 +70,7 @@ namespace Opc.Ua.Sample
         /// <summary>
         /// Initializes the control.
         /// </summary>
-        public async Task InitializeAsync(Session session, NodeId typeId, CancellationToken ct = default)
+        public async Task InitializeAsync(ISession session, NodeId typeId, CancellationToken ct = default)
         {
             if (session == null)
             {

--- a/Samples/Controls.Net4/Subscriptions/ContentFilterElementListCtrl.cs
+++ b/Samples/Controls.Net4/Subscriptions/ContentFilterElementListCtrl.cs
@@ -52,7 +52,7 @@ namespace Opc.Ua.Sample.Controls
         }
 
         #region Private Fields
-        private Session m_session;
+        private ISession m_session;
         private Browser m_browser;
         private ContentFilter m_filter;
 
@@ -79,7 +79,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Sets the nodes in the control.
         /// </summary>
-        public void Initialize(Session session, ContentFilter filter, ITelemetryContext telemetry)
+        public void Initialize(ISession session, ContentFilter filter, ITelemetryContext telemetry)
         {
             if (session == null) throw new ArgumentNullException(nameof(session));
 

--- a/Samples/Controls.Net4/Subscriptions/CreateMonitoredItemsDlg.cs
+++ b/Samples/Controls.Net4/Subscriptions/CreateMonitoredItemsDlg.cs
@@ -38,9 +38,14 @@ using System.Reflection;
 
 using Opc.Ua.Client;
 using Opc.Ua.Client.Controls;
+using Opc.Ua.Client.Subscriptions;
 
 namespace Opc.Ua.Sample.Controls
 {
+    // the V2 subscription engine reuses names the classic engine already has in the
+    // Opc.Ua.Client namespace this file imports, so the V2 types are pinned explicitly.
+    using SubscriptionState = Opc.Ua.Client.Subscriptions.SubscriptionState;
+
     public partial class CreateMonitoredItemsDlg : Form
     {
         #region Constructors
@@ -48,48 +53,44 @@ namespace Opc.Ua.Sample.Controls
         {
             InitializeComponent();
             this.Icon = ClientUtils.GetAppIcon();
-            m_SubscriptionStateChanged = new SubscriptionStateChangedEventHandler(Subscription_StateChanged);
+
+            m_StateChangedCallback = new Action<ISubscription, SubscriptionState, PublishState>(OnSubscriptionStateChanged);
+
+            FormClosing += new FormClosingEventHandler(CreateMonitoredItemsDlg_FormClosing);
         }
         #endregion
 
         #region Private Fields
-        private Subscription m_subscription;
+        private SubscriptionHandle m_subscription;
         private ITelemetryContext m_telemetry;
-        private SubscriptionStateChangedEventHandler m_SubscriptionStateChanged;
+        private readonly Action<ISubscription, SubscriptionState, PublishState> m_StateChangedCallback;
         #endregion
 
         #region Public Interface
         /// <summary>
         /// Displays the dialog.
         /// </summary>
-        public void Show(Subscription subscription, bool useTypeModel, ITelemetryContext telemetry)
+        public void Show(SubscriptionHandle subscription, bool useTypeModel, ITelemetryContext telemetry)
         {
             if (subscription == null) throw new ArgumentNullException(nameof(subscription));
 
             Show();
             BringToFront();
 
-            // remove previous subscription.
+            // stop receiving notifications from the previous subscription.
             if (m_subscription != null)
             {
-                m_subscription.StateChanged -= m_SubscriptionStateChanged;
+                m_subscription.Callbacks.StateChangedCallback -= m_StateChangedCallback;
             }
 
             // start receiving notifications from the new subscription.
             m_subscription = subscription;
             m_telemetry = telemetry;
 
-            #pragma warning disable CA1508 // Justification: Sample code retains existing ownership/lifetime and behavior.
-            if (subscription != null)
-            #pragma warning restore CA1508
-            {
-                m_subscription.StateChanged += m_SubscriptionStateChanged;
-            }
-
-            m_subscription = subscription;
+            m_subscription.Callbacks.StateChangedCallback += m_StateChangedCallback;
 
             BrowseCTRL.AllowPick = true;
-            BrowseCTRL.SetViewAsync(subscription.Session as Session, (useTypeModel) ? BrowseViewType.ObjectTypes : BrowseViewType.Objects, NodeId.Null, telemetry);
+            BrowseCTRL.SetViewAsync(subscription.Session, (useTypeModel) ? BrowseViewType.ObjectTypes : BrowseViewType.Objects, NodeId.Null, telemetry);
 
             MonitoredItemsCTRL.Initialize(subscription, telemetry);
         }
@@ -97,13 +98,14 @@ namespace Opc.Ua.Sample.Controls
 
         #region Event Handlers
         /// <summary>
-        /// Handles a change to the state of the subscription.
+        /// Handles a change to the state of the subscription, which is also what reports that
+        /// the engine finished applying monitored item changes.
         /// </summary>
-        void Subscription_StateChanged(Subscription subscription, SubscriptionStateChangedEventArgs e)
+        private void OnSubscriptionStateChanged(ISubscription subscription, SubscriptionState state, PublishState publishStateMask)
         {
             if (InvokeRequired)
             {
-                BeginInvoke(m_SubscriptionStateChanged, subscription, e);
+                BeginInvoke(m_StateChangedCallback, subscription, state, publishStateMask);
                 return;
             }
             else if (!IsHandleCreated)
@@ -114,13 +116,28 @@ namespace Opc.Ua.Sample.Controls
             try
             {
                 // ignore notifications for other subscriptions.
-                if (!Object.ReferenceEquals(m_subscription, subscription))
+                if (m_subscription == null || !Object.ReferenceEquals(m_subscription.Subscription, subscription))
                 {
                     return;
                 }
 
                 // notify controls of the change.
-                MonitoredItemsCTRL.SubscriptionChanged(e);
+                MonitoredItemsCTRL.SubscriptionChanged();
+            }
+            catch (Exception exception)
+            {
+                GuiUtils.HandleException(m_telemetry, this.Text, MethodBase.GetCurrentMethod(), exception);
+            }
+        }
+
+        private void CreateMonitoredItemsDlg_FormClosing(object sender, FormClosingEventArgs e)
+        {
+            try
+            {
+                if (m_subscription != null)
+                {
+                    m_subscription.Callbacks.StateChangedCallback -= m_StateChangedCallback;
+                }
             }
             catch (Exception exception)
             {

--- a/Samples/Controls.Net4/Subscriptions/DataChangeFilterEditDlg.cs
+++ b/Samples/Controls.Net4/Subscriptions/DataChangeFilterEditDlg.cs
@@ -64,13 +64,17 @@ namespace Opc.Ua.Sample.Controls
         }
 
         /// <summary>
-        /// Prompts the user to specify the browse options.
+        /// Prompts the user to specify the data change filter for a monitored item.
         /// </summary>
-        public bool ShowDialog(Session session, MonitoredItem monitoredItem)
+        /// <remarks>
+        /// Reconfiguring the options monitor of the handle is the modify request: the V2
+        /// engine applies the new filter on its own worker.
+        /// </remarks>
+        public bool ShowDialog(ISession session, MonitoredItemHandle monitoredItem)
         {
             if (monitoredItem == null) throw new ArgumentNullException(nameof(monitoredItem));
 
-            DataChangeFilter filter = monitoredItem.Filter as DataChangeFilter;
+            DataChangeFilter filter = monitoredItem.Settings.Filter as DataChangeFilter;
 
             if (filter == null)
             {
@@ -94,7 +98,7 @@ namespace Opc.Ua.Sample.Controls
             filter.DeadbandType = Convert.ToUInt32(DeadbandTypeCB.SelectedItem);
             filter.DeadbandValue = (double)DeadbandNC.Value;
 
-            monitoredItem.Filter = filter;
+            monitoredItem.Configure(options => options with { Filter = filter });
 
             return true;
         }

--- a/Samples/Controls.Net4/Subscriptions/DataChangeNotificationListCtrl.cs
+++ b/Samples/Controls.Net4/Subscriptions/DataChangeNotificationListCtrl.cs
@@ -39,6 +39,7 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using Opc.Ua.Client;
 using Opc.Ua.Client.Controls;
+using Opc.Ua.Client.Subscriptions;
 
 namespace Opc.Ua.Sample.Controls
 {
@@ -53,8 +54,18 @@ namespace Opc.Ua.Sample.Controls
         #region Private Fields
         private int m_maxChangeCount = 20;
         private bool m_showHistory = false;
-        private Subscription m_subscription;
-        private MonitoredItem m_monitoredItem;
+        private SubscriptionHandle m_subscription;
+        private MonitoredItemHandle m_monitoredItem;
+        private bool m_publishingStopped;
+
+        /// <summary>
+        /// A data change displayed in the control.
+        /// </summary>
+        private sealed class ItemNotification
+        {
+            public MonitoredItemHandle MonitoredItem;
+            public DataValue Value;
+        }
 
         /// <summary>
 		/// The columns to display in the control.
@@ -101,87 +112,49 @@ namespace Opc.Ua.Sample.Controls
         }
 
         /// <summary>
-        /// Sets the nodes in the control.
+        /// Sets the subscription (and optionally the single item) displayed in the control.
         /// </summary>
-        public async void InitializeAsync(Subscription subscription, MonitoredItem monitoredItem, CancellationToken ct = default)
+        /// <remarks>
+        /// The V2 engine keeps no notification cache, so the control starts empty and fills
+        /// itself from the notifications the owner forwards.
+        /// </remarks>
+        public void Initialize(SubscriptionHandle subscription, MonitoredItemHandle monitoredItem)
         {
-            if (subscription == null) throw new ArgumentNullException(nameof(subscription));
-
             Clear();
 
-            // start receiving notifications from the new subscription.
             m_subscription = subscription;
             m_monitoredItem = monitoredItem;
-            #pragma warning disable CA1508 // Justification: Sample code retains existing ownership/lifetime and behavior.
+            m_publishingStopped = false;
             Telemetry = m_subscription?.Session?.MessageContext?.Telemetry;
-            #pragma warning restore CA1508
 
-            // get the events.
-            List<MonitoredItemNotification> changes = new List<MonitoredItemNotification>();
-
-            foreach (NotificationMessage notification in m_subscription.Notifications)
-            {
-                foreach (MonitoredItemNotification change in notification.GetDataChanges(false))
-                {
-                    if (m_monitoredItem != null)
-                    {
-                        if (m_monitoredItem.ClientHandle != change.ClientHandle)
-                        {
-                            continue;
-                        }
-                    }
-                    else
-                    {
-                        if (m_subscription.FindItemByClientHandle(change.ClientHandle) == null)
-                        {
-                            continue;
-                        }
-                    }
-
-                    changes.Add(change);
-
-                    if (changes.Count >= MaxChangeCount)
-                    {
-                        break;
-                    }
-                }
-
-                if (changes.Count >= MaxChangeCount)
-                {
-                    break;
-                }
-            }
-
-            await UpdateChangesAsync(changes, 0, ct);
             AdjustColumns();
         }
 
         /// <summary>
-        /// Processes a new notification.
+        /// Processes the data changes of a notification.
         /// </summary>
-        public async Task NotificationReceivedAsync(NotificationEventArgs e, CancellationToken ct = default)
+        public async Task NotificationReceivedAsync(DataValueChange[] notifications, PublishState publishStateMask, CancellationToken ct = default)
         {
+            m_publishingStopped = (publishStateMask & PublishState.Stopped) != 0;
+
             // get the changes.
-            List<MonitoredItemNotification> changes = new List<MonitoredItemNotification>();
+            List<ItemNotification> changes = new List<ItemNotification>();
 
-            foreach (MonitoredItemNotification change in e.NotificationMessage.GetDataChanges(false))
+            foreach (DataValueChange notification in notifications)
             {
-                if (m_monitoredItem != null)
+                MonitoredItemHandle handle = m_subscription?.FindItem(notification.MonitoredItem);
+
+                if (handle == null)
                 {
-                    if (m_monitoredItem.ClientHandle != change.ClientHandle)
-                    {
-                        continue;
-                    }
-                }
-                else
-                {
-                    if (m_subscription.FindItemByClientHandle(change.ClientHandle) == null)
-                    {
-                        continue;
-                    }
+                    continue;
                 }
 
-                changes.Add(change);
+                if (m_monitoredItem != null && !Object.ReferenceEquals(handle, m_monitoredItem))
+                {
+                    continue;
+                }
+
+                changes.Add(new ItemNotification { MonitoredItem = handle, Value = notification.Value });
             }
 
             // check if nothing more to do.
@@ -197,19 +170,11 @@ namespace Opc.Ua.Sample.Controls
                 // fill in earlier changes.
                 foreach (ListViewItem listItem in ItemsLV.Items)
                 {
-                    MonitoredItemNotification change = listItem.Tag as MonitoredItemNotification;
+                    ItemNotification change = listItem.Tag as ItemNotification;
 
                     if (change == null)
                     {
                         continue;
-                    }
-
-                    if (m_monitoredItem != null)
-                    {
-                        if (m_monitoredItem.ClientHandle != change.ClientHandle)
-                        {
-                            continue;
-                        }
                     }
 
                     changes.Add(change);
@@ -219,9 +184,6 @@ namespace Opc.Ua.Sample.Controls
                         break;
                     }
                 }
-
-                // ensure the newest changes appear first.
-                changes.Reverse();
             }
 
             await UpdateChangesAsync(changes, offset, ct);
@@ -229,101 +191,47 @@ namespace Opc.Ua.Sample.Controls
         }
 
         /// <summary>
-        /// Processes a new notification.
-        /// </summary>
-        public async Task NotificationReceivedAsync(MonitoredItemNotificationEventArgs e, CancellationToken ct = default)
-        {
-            MonitoredItemNotification change = e.NotificationValue as MonitoredItemNotification;
-
-            if (change == null)
-            {
-                return;
-            }
-
-            if (m_monitoredItem != null)
-            {
-                if (m_monitoredItem.ClientHandle != change.ClientHandle)
-                {
-                    return;
-                }
-            }
-
-            // add new change.
-            List<MonitoredItemNotification> changes = new List<MonitoredItemNotification>();
-            changes.Add(change);
-
-            // fill in earlier changes.
-            if (m_showHistory)
-            {
-                foreach (ListViewItem listItem in ItemsLV.Items)
-                {
-                    change = listItem.Tag as MonitoredItemNotification;
-
-                    if (change == null)
-                    {
-                        continue;
-                    }
-
-                    if (m_monitoredItem != null)
-                    {
-                        if (m_monitoredItem.ClientHandle != change.ClientHandle)
-                        {
-                            continue;
-                        }
-                    }
-
-                    changes.Add(change);
-
-                    if (changes.Count >= MaxChangeCount)
-                    {
-                        break;
-                    }
-                }
-            }
-
-            await UpdateChangesAsync(changes, 1, ct);
-            AdjustColumns();
-        }
-
-        /// <summary>
         /// Processes a change to the subscription.
         /// </summary>
-        public void SubscriptionChanged(SubscriptionStateChangedEventArgs e)
+        public void SubscriptionChanged()
         {
-            if ((e.Status & SubscriptionChangeMask.ItemsDeleted) != 0)
+            // collect changes for items that have been deleted.
+            List<ListViewItem> itemsToRemove = new List<ListViewItem>();
+
+            foreach (ListViewItem listItem in ItemsLV.Items)
             {
-                // collect events for items that have been deleted.
-                List<ListViewItem> itemsToRemove = new List<ListViewItem>();
+                ItemNotification change = listItem.Tag as ItemNotification;
 
-                foreach (ListViewItem listItem in ItemsLV.Items)
+                if (change != null && m_subscription != null && !m_subscription.Items.Contains(change.MonitoredItem))
                 {
-                    MonitoredItemNotification change = listItem.Tag as MonitoredItemNotification;
-
-                    if (change != null)
-                    {
-                        if (m_subscription.FindItemByClientHandle(change.ClientHandle) == null)
-                        {
-                            itemsToRemove.Add(listItem);
-                        }
-                    }
+                    itemsToRemove.Add(listItem);
                 }
+            }
 
-                // remove events for items that have been deleted.
-                foreach (ListViewItem listItem in itemsToRemove)
-                {
-                    listItem.Remove();
-                }
+            // remove changes for items that have been deleted.
+            foreach (ListViewItem listItem in itemsToRemove)
+            {
+                listItem.Remove();
             }
         }
 
         /// <summary>
         /// Updates the display after the publish status for the subscription changes.
         /// </summary>
-        public async Task PublishStatusChangedAsync(CancellationToken ct = default)
+        public async Task PublishStatusChangedAsync(PublishState publishStateMask, CancellationToken ct = default)
         {
+            if ((publishStateMask & PublishState.Stopped) != 0)
+            {
+                m_publishingStopped = true;
+            }
+            else if ((publishStateMask & PublishState.Recovered) != 0)
+            {
+                m_publishingStopped = false;
+            }
+
             foreach (ListViewItem listItem in ItemsLV.Items)
             {
-                MonitoredItemNotification change = listItem.Tag as MonitoredItemNotification;
+                ItemNotification change = listItem.Tag as ItemNotification;
 
                 if (change != null)
                 {
@@ -351,9 +259,9 @@ namespace Opc.Ua.Sample.Controls
         }
 
         /// <summary>
-        /// Updates the events displayed in the control.
+        /// Updates the changes displayed in the control.
         /// </summary>
-        private async Task UpdateChangesAsync(IList<MonitoredItemNotification> changes, int offset, CancellationToken ct = default)
+        private async Task UpdateChangesAsync(IList<ItemNotification> changes, int offset, CancellationToken ct = default)
         {
             // save selected indexes.
             List<int> indexes = new List<int>(ItemsLV.SelectedIndices.Count);
@@ -368,7 +276,7 @@ namespace Opc.Ua.Sample.Controls
             {
                 BeginUpdate();
 
-                foreach (MonitoredItemNotification change in changes)
+                foreach (ItemNotification change in changes)
                 {
                     AddItem(change);
                 }
@@ -390,9 +298,9 @@ namespace Opc.Ua.Sample.Controls
 
                     foreach (ListViewItem listItem in ItemsLV.Items)
                     {
-                        MonitoredItemNotification change = listItem.Tag as MonitoredItemNotification;
+                        ItemNotification change = listItem.Tag as ItemNotification;
 
-                        if (change != null && change.ClientHandle == changes[ii].ClientHandle)
+                        if (change != null && Object.ReferenceEquals(change.MonitoredItem, changes[ii].MonitoredItem))
                         {
                             await UpdateItemAsync(listItem, changes[ii], ct);
                             found = true;
@@ -423,7 +331,7 @@ namespace Opc.Ua.Sample.Controls
         /// <see cref="BaseListCtrl.UpdateItemAsync" />
         protected override async Task UpdateItemAsync(ListViewItem listItem, object item, CancellationToken ct = default)
         {
-            MonitoredItemNotification change = item as MonitoredItemNotification;
+            ItemNotification change = item as ItemNotification;
 
             if (change == null)
             {
@@ -432,28 +340,12 @@ namespace Opc.Ua.Sample.Controls
             }
 
             // fill in the columns.
-            listItem.SubItems[0].Text = String.Format("[{0}]", change.ClientHandle);
-
-            MonitoredItem monitoredItem = null;
-
-            if (m_subscription != null)
-            {
-                monitoredItem = m_subscription.FindItemByClientHandle(change.ClientHandle);
-            }
-
-            if (monitoredItem != null)
-            {
-                listItem.SubItems[1].Text = String.Format("{0}", monitoredItem.DisplayName);
-            }
-            else
-            {
-                listItem.SubItems[1].Text = "(unknown)";
-            }
-
+            listItem.SubItems[0].Text = String.Format("[{0}]", (change.MonitoredItem.Item != null) ? change.MonitoredItem.Item.ServerId : 0);
+            listItem.SubItems[1].Text = String.Format("{0}", change.MonitoredItem.DisplayName);
             listItem.SubItems[2].Text = String.Format("{0}", change.Value.WrappedValue);
 
-            // check of publishing has stopped for some reason.
-            if (m_subscription.PublishingStopped)
+            // check if publishing has stopped for some reason.
+            if (m_publishingStopped)
             {
                 listItem.SubItems[3].Text = String.Format("{0}", (StatusCode)StatusCodes.UncertainNoCommunicationLastUsableValue);
             }
@@ -464,9 +356,7 @@ namespace Opc.Ua.Sample.Controls
 
             DateTime time = change.Value.SourceTimestamp.ToDateTime();
 
-            #pragma warning disable CS8073 // Justification: Sample code retains existing ownership/lifetime and behavior.
-            if (time != null && time != DateTime.MinValue)
-            #pragma warning restore CS8073
+            if (time != DateTime.MinValue)
             {
                 listItem.SubItems[4].Text = String.Format("{0:HH:mm:ss.fff}", time.ToLocalTime());
             }
@@ -477,9 +367,7 @@ namespace Opc.Ua.Sample.Controls
 
             time = change.Value.ServerTimestamp.ToDateTime();
 
-            #pragma warning disable CS8073 // Justification: Sample code retains existing ownership/lifetime and behavior.
-            if (time != null && time != DateTime.MinValue)
-            #pragma warning restore CS8073
+            if (time != DateTime.MinValue)
             {
                 listItem.SubItems[5].Text = String.Format("{0:HH:mm:ss.fff}", time.ToLocalTime());
             }
@@ -489,7 +377,7 @@ namespace Opc.Ua.Sample.Controls
             }
 
             listItem.Tag = change;
-            listItem.ForeColor = (m_subscription.PublishingStopped) ? Color.Red : Color.Empty;
+            listItem.ForeColor = (m_publishingStopped) ? Color.Red : Color.Empty;
         }
         #endregion
 
@@ -498,7 +386,7 @@ namespace Opc.Ua.Sample.Controls
         {
             try
             {
-                MonitoredItemNotification change = SelectedTag as MonitoredItemNotification;
+                ItemNotification change = SelectedTag as ItemNotification;
 
                 if (change == null)
                 {
@@ -506,7 +394,7 @@ namespace Opc.Ua.Sample.Controls
                 }
 
                 #pragma warning disable CA2000 // Justification: Sample code retains existing ownership/lifetime and behavior.
-                new ComplexValueEditDlg().ShowDialog(change, Telemetry);
+                new ComplexValueEditDlg().ShowDialog(change.Value, Telemetry);
                 #pragma warning restore CA2000
             }
             catch (Exception exception)

--- a/Samples/Controls.Net4/Subscriptions/EventFilterDlg.cs
+++ b/Samples/Controls.Net4/Subscriptions/EventFilterDlg.cs
@@ -53,7 +53,7 @@ namespace Opc.Ua.Sample.Controls
         #endregion
 
         #region Private Fields
-        private Session m_session;
+        private ISession m_session;
         private ITelemetryContext m_telemetry;
         private EventFilter m_filter;
         #endregion
@@ -62,7 +62,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Displays the dialog.
         /// </summary>
-        public EventFilter ShowDialog(Session session, ITelemetryContext telemetry, EventFilter filter, bool editWhereClause)
+        public EventFilter ShowDialog(ISession session, ITelemetryContext telemetry, EventFilter filter, bool editWhereClause)
         {
             if (session == null) throw new ArgumentNullException(nameof(session));
             if (filter == null) throw new ArgumentNullException(nameof(filter));

--- a/Samples/Controls.Net4/Subscriptions/EventNotificationListCtrl.cs
+++ b/Samples/Controls.Net4/Subscriptions/EventNotificationListCtrl.cs
@@ -39,6 +39,7 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using Opc.Ua.Client;
 using Opc.Ua.Client.Controls;
+using Opc.Ua.Client.Subscriptions;
 
 namespace Opc.Ua.Sample.Controls
 {
@@ -52,8 +53,17 @@ namespace Opc.Ua.Sample.Controls
 
         #region Private Fields
         private int m_maxEventCount = 20;
-        private Subscription m_subscription;
-        private MonitoredItem m_monitoredItem;
+        private SubscriptionHandle m_subscription;
+        private MonitoredItemHandle m_monitoredItem;
+
+        /// <summary>
+        /// An event displayed in the control.
+        /// </summary>
+        private sealed class ItemEvent
+        {
+            public MonitoredItemHandle MonitoredItem;
+            public EventNotification Notification;
+        }
 
         /// <summary>
 		/// The columns to display in the control.
@@ -90,87 +100,46 @@ namespace Opc.Ua.Sample.Controls
         }
 
         /// <summary>
-        /// Sets the nodes in the control.
+        /// Sets the subscription (and optionally the single item) displayed in the control.
         /// </summary>
-        public void Initialize(Subscription subscription, MonitoredItem monitoredItem)
+        /// <remarks>
+        /// The V2 engine keeps no notification cache, so the control starts empty and fills
+        /// itself from the notifications the owner forwards.
+        /// </remarks>
+        public void Initialize(SubscriptionHandle subscription, MonitoredItemHandle monitoredItem)
         {
-            if (subscription == null) throw new ArgumentNullException(nameof(subscription));
-
             Clear();
 
-            // start receiving notifications from the new subscription.
             m_subscription = subscription;
             m_monitoredItem = monitoredItem;
-            #pragma warning disable CA1508 // Justification: Sample code retains existing ownership/lifetime and behavior.
             Telemetry = m_subscription?.Session?.MessageContext?.Telemetry;
-            #pragma warning restore CA1508
 
-            // get the events.
-            List<EventFieldList> events = new List<EventFieldList>();
-
-            foreach (NotificationMessage message in m_subscription.Notifications)
-            {
-                foreach (EventFieldList eventFields in message.GetEvents(true))
-                {
-                    if (m_monitoredItem != null)
-                    {
-                        if (m_monitoredItem.ClientHandle != eventFields.ClientHandle)
-                        {
-                            continue;
-                        }
-                    }
-                    else
-                    {
-                        if (m_subscription.FindItemByClientHandle(eventFields.ClientHandle) == null)
-                        {
-                            continue;
-                        }
-                    }
-
-                    events.Add(eventFields);
-
-                    if (events.Count >= MaxEventCount)
-                    {
-                        break;
-                    }
-                }
-
-                if (events.Count >= MaxEventCount)
-                {
-                    break;
-                }
-            }
-
-            UpdateEvents(events, 0);
             AdjustColumns();
         }
 
         /// <summary>
-        /// Processes a new notification.
+        /// Processes the events of a notification.
         /// </summary>
-        public void NotificationReceived(NotificationEventArgs e)
+        public void NotificationReceived(EventNotification[] notifications)
         {
             // get the events.
-            List<EventFieldList> events = new List<EventFieldList>();
+            List<ItemEvent> events = new List<ItemEvent>();
 
-            foreach (EventFieldList eventFields in e.NotificationMessage.GetEvents(true))
+            foreach (EventNotification notification in notifications)
             {
-                if (m_monitoredItem != null)
+                MonitoredItemHandle handle = m_subscription?.FindItem(notification.MonitoredItem);
+
+                if (handle == null)
                 {
-                    if (m_monitoredItem.ClientHandle != eventFields.ClientHandle)
-                    {
-                        continue;
-                    }
-                }
-                else
-                {
-                    if (m_subscription.FindItemByClientHandle(eventFields.ClientHandle) == null)
-                    {
-                        continue;
-                    }
+                    continue;
                 }
 
-                events.Add(eventFields);
+                if (m_monitoredItem != null && !Object.ReferenceEquals(handle, m_monitoredItem))
+                {
+                    continue;
+                }
+
+                events.Add(new ItemEvent { MonitoredItem = handle, Notification = notification });
 
                 if (events.Count >= MaxEventCount)
                 {
@@ -189,22 +158,14 @@ namespace Opc.Ua.Sample.Controls
             // fill in earlier events.
             foreach (ListViewItem listItem in ItemsLV.Items)
             {
-                EventFieldList eventFields = listItem.Tag as EventFieldList;
+                ItemEvent earlierEvent = listItem.Tag as ItemEvent;
 
-                if (eventFields == null)
+                if (earlierEvent == null)
                 {
                     continue;
                 }
 
-                if (m_monitoredItem != null)
-                {
-                    if (m_monitoredItem.ClientHandle != eventFields.ClientHandle)
-                    {
-                        continue;
-                    }
-                }
-
-                events.Add(eventFields);
+                events.Add(earlierEvent);
 
                 if (events.Count >= MaxEventCount)
                 {
@@ -217,85 +178,27 @@ namespace Opc.Ua.Sample.Controls
         }
 
         /// <summary>
-        /// Processes a new notification.
-        /// </summary>
-        public void NotificationReceived(MonitoredItemNotificationEventArgs e)
-        {
-            EventFieldList eventFields = e.NotificationValue as EventFieldList;
-
-            if (eventFields == null)
-            {
-                return;
-            }
-
-            if (m_monitoredItem != null)
-            {
-                if (m_monitoredItem.ClientHandle != eventFields.ClientHandle)
-                {
-                    return;
-                }
-            }
-
-            // get the events.
-            List<EventFieldList> events = new List<EventFieldList>();
-            events.Add(eventFields);
-
-            // fill in earlier events.
-            foreach (ListViewItem listItem in ItemsLV.Items)
-            {
-                eventFields = listItem.Tag as EventFieldList;
-
-                if (m_monitoredItem != null)
-                {
-                    if (m_monitoredItem.ClientHandle != eventFields.ClientHandle)
-                    {
-                        continue;
-                    }
-                }
-
-                if (eventFields != null)
-                {
-                    events.Add(eventFields);
-                }
-
-                if (events.Count >= MaxEventCount)
-                {
-                    break;
-                }
-            }
-
-            UpdateEvents(events, 1);
-            AdjustColumns();
-        }
-
-        /// <summary>
         /// Processes a change to the subscription.
         /// </summary>
-        public void SubscriptionChanged(SubscriptionStateChangedEventArgs e)
+        public void SubscriptionChanged()
         {
-            if ((e.Status & SubscriptionChangeMask.ItemsDeleted) != 0)
+            // collect events for items that have been deleted.
+            List<ListViewItem> itemsToRemove = new List<ListViewItem>();
+
+            foreach (ListViewItem listItem in ItemsLV.Items)
             {
-                // collect events for items that have been deleted.
-                List<ListViewItem> itemsToRemove = new List<ListViewItem>();
+                ItemEvent itemEvent = listItem.Tag as ItemEvent;
 
-                foreach (ListViewItem listItem in ItemsLV.Items)
+                if (itemEvent != null && m_subscription != null && !m_subscription.Items.Contains(itemEvent.MonitoredItem))
                 {
-                    EventFieldList eventFields = listItem.Tag as EventFieldList;
-
-                    if (eventFields != null)
-                    {
-                        if (m_subscription.FindItemByClientHandle(eventFields.ClientHandle) == null)
-                        {
-                            itemsToRemove.Add(listItem);
-                        }
-                    }
+                    itemsToRemove.Add(listItem);
                 }
+            }
 
-                // remove events for items that have been deleted.
-                foreach (ListViewItem listItem in itemsToRemove)
-                {
-                    listItem.Remove();
-                }
+            // remove events for items that have been deleted.
+            foreach (ListViewItem listItem in itemsToRemove)
+            {
+                listItem.Remove();
             }
         }
         #endregion
@@ -318,7 +221,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Updates the events displayed in the control.
         /// </summary>
-        private void UpdateEvents(IList<EventFieldList> events, int offset)
+        private void UpdateEvents(IList<ItemEvent> events, int offset)
         {
             // save selected indexes.
             List<int> indexes = new List<int>(ItemsLV.SelectedIndices.Count);
@@ -331,9 +234,9 @@ namespace Opc.Ua.Sample.Controls
             // update items.
             BeginUpdate();
 
-            foreach (EventFieldList eventFields in events)
+            foreach (ItemEvent itemEvent in events)
             {
-                AddItem(eventFields);
+                AddItem(itemEvent);
             }
 
             EndUpdate();
@@ -353,38 +256,26 @@ namespace Opc.Ua.Sample.Controls
         /// <see cref="BaseListCtrl.UpdateItemAsync" />
         protected override async Task UpdateItemAsync(ListViewItem listItem, object item, CancellationToken ct = default)
         {
-            EventFieldList eventFields = item as EventFieldList;
+            ItemEvent itemEvent = item as ItemEvent;
 
-            if (eventFields == null)
+            if (itemEvent == null)
             {
                 await base.UpdateItemAsync(listItem, item, ct);
                 return;
             }
 
-            MonitoredItem monitoredItem = m_subscription.FindItemByClientHandle(eventFields.ClientHandle);
+            MonitoredItemHandle monitoredItem = itemEvent.MonitoredItem;
+            EventNotification notification = itemEvent.Notification;
 
-            if (monitoredItem == null)
-            {
-                listItem.SubItems[0].Text = String.Format("[{0}]", eventFields.ClientHandle);
-                listItem.SubItems[1].Text = "(unknown)";
-                listItem.SubItems[2].Text = null;
-                listItem.SubItems[3].Text = null;
-                listItem.SubItems[4].Text = null;
-                listItem.SubItems[5].Text = null;
-
-                listItem.Tag = eventFields;
-                return;
-            }
-
-            // get the event fields.
-            NodeId eventType = monitoredItem.GetFieldValue(eventFields, new NodeId(ObjectTypes.BaseEventType), new QualifiedName(Opc.Ua.BrowseNames.EventType)) is NodeId eventTypeNodeId ? eventTypeNodeId : NodeId.Null;
-            string sourceName = monitoredItem.GetFieldValue(eventFields, new NodeId(ObjectTypes.BaseEventType), new QualifiedName(Opc.Ua.BrowseNames.SourceName)) as string;
-            DateTime? time = monitoredItem.GetFieldValue(eventFields, new NodeId(ObjectTypes.BaseEventType), new QualifiedName(Opc.Ua.BrowseNames.Time)) as DateTime?;
-            ushort? severity = monitoredItem.GetFieldValue(eventFields, new NodeId(ObjectTypes.BaseEventType), new QualifiedName(Opc.Ua.BrowseNames.Severity)) as ushort?;
-            LocalizedText message = monitoredItem.GetFieldValue(eventFields, new NodeId(ObjectTypes.BaseEventType), new QualifiedName(Opc.Ua.BrowseNames.Message)) is LocalizedText messageText ? messageText : LocalizedText.Null;
+            // get the event fields selected by the filter the item was created with.
+            NodeId eventType = SubscriptionHandle.GetEventFieldValue(monitoredItem, notification, new QualifiedName(Opc.Ua.BrowseNames.EventType)) is NodeId eventTypeId ? eventTypeId : NodeId.Null;
+            string sourceName = SubscriptionHandle.GetEventFieldValue(monitoredItem, notification, new QualifiedName(Opc.Ua.BrowseNames.SourceName)) as string;
+            DateTime? time = SubscriptionHandle.GetEventFieldValue(monitoredItem, notification, new QualifiedName(Opc.Ua.BrowseNames.Time)) as DateTime?;
+            ushort? severity = SubscriptionHandle.GetEventFieldValue(monitoredItem, notification, new QualifiedName(Opc.Ua.BrowseNames.Severity)) as ushort?;
+            LocalizedText message = SubscriptionHandle.GetEventFieldValue(monitoredItem, notification, new QualifiedName(Opc.Ua.BrowseNames.Message)) is LocalizedText messageText ? messageText : LocalizedText.Null;
 
             // fill in the columns.
-            listItem.SubItems[0].Text = String.Format("[{0}]", eventFields.ClientHandle);
+            listItem.SubItems[0].Text = String.Format("[{0}]", (monitoredItem.Item != null) ? monitoredItem.Item.ServerId : 0);
 
             INode typeNode = await m_subscription.Session.NodeCache.FindAsync(eventType, ct);
 
@@ -419,7 +310,7 @@ namespace Opc.Ua.Sample.Controls
                 listItem.SubItems[5].Text = String.Empty;
             }
 
-            listItem.Tag = eventFields;
+            listItem.Tag = item;
         }
         #endregion
 
@@ -428,15 +319,15 @@ namespace Opc.Ua.Sample.Controls
         {
             try
             {
-                EventFieldList fieldList = SelectedTag as EventFieldList;
+                ItemEvent itemEvent = SelectedTag as ItemEvent;
 
-                if (fieldList == null)
+                if (itemEvent == null)
                 {
                     return;
                 }
 
                 #pragma warning disable CA2000 // Justification: Sample code retains existing ownership/lifetime and behavior.
-                new ComplexValueEditDlg().ShowDialog(fieldList, m_subscription.FindItemByClientHandle(fieldList.ClientHandle), Telemetry);
+                new ComplexValueEditDlg().ShowDialog(itemEvent.Notification.Fields.ToArray(), Telemetry);
                 #pragma warning restore CA2000
             }
             catch (Exception exception)

--- a/Samples/Controls.Net4/Subscriptions/FilterOperandEditDlg.cs
+++ b/Samples/Controls.Net4/Subscriptions/FilterOperandEditDlg.cs
@@ -65,7 +65,7 @@ namespace Opc.Ua.Sample.Controls
         #endregion
 
         #region Private Fields
-        private Session m_session;
+        private ISession m_session;
         #endregion
 
         #region Public Interface
@@ -73,7 +73,7 @@ namespace Opc.Ua.Sample.Controls
         /// Displays the dialog.
         /// </summary>
         public FilterOperand ShowDialog(
-            Session session,
+            ISession session,
             IList<ContentFilterElement> elements,
             int index,
             FilterOperand operand,

--- a/Samples/Controls.Net4/Subscriptions/FilterOperandListCtrl.cs
+++ b/Samples/Controls.Net4/Subscriptions/FilterOperandListCtrl.cs
@@ -51,7 +51,7 @@ namespace Opc.Ua.Sample.Controls
         }
 
         #region Private Fields
-        private Session m_session;
+        private ISession m_session;
         private IList<ContentFilterElement> m_elements;
         private int m_index;
 
@@ -78,7 +78,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Sets the nodes in the control.
         /// </summary>
-        public void Initialize(Session session, IList<ContentFilterElement> elements, int index, ITelemetryContext telemetry)
+        public void Initialize(ISession session, IList<ContentFilterElement> elements, int index, ITelemetryContext telemetry)
         {
             if (session == null) throw new ArgumentNullException(nameof(session));
 

--- a/Samples/Controls.Net4/Subscriptions/HistoryReadDetails.cs
+++ b/Samples/Controls.Net4/Subscriptions/HistoryReadDetails.cs
@@ -49,7 +49,7 @@ namespace Opc.Ua.Sample
             QueryTypeCB.Items.Add("Read Raw or Modified");
         }
 
-        private Session m_session;
+        private ISession m_session;
         private ReadRawModifiedDetails m_details;
 
         #region Private Methods
@@ -60,7 +60,7 @@ namespace Opc.Ua.Sample
         /// <param name="details"></param>
         /// <param name="nodes"></param>
         public void Initialize(
-            Session session,
+            ISession session,
             ReadRawModifiedDetails details,
             IList<ILocalNode> nodes)
         {

--- a/Samples/Controls.Net4/Subscriptions/HistoryReadDlg.cs
+++ b/Samples/Controls.Net4/Subscriptions/HistoryReadDlg.cs
@@ -55,14 +55,14 @@ namespace Opc.Ua.Sample.Controls
         #endregion
 
         #region Private Fields
-        private Session m_session;
+        private ISession m_session;
         #endregion
 
         #region Public Interface
         /// <summary>
         /// Displays the dialog.
         /// </summary>
-        public void Show(Session session, IList<ReadValueId> valueIds, ITelemetryContext telemetry)
+        public void Show(ISession session, IList<ReadValueId> valueIds, ITelemetryContext telemetry)
         {
             if (session == null) throw new ArgumentNullException(nameof(session));
 

--- a/Samples/Controls.Net4/Subscriptions/MonitoredItemConfigCtrl.cs
+++ b/Samples/Controls.Net4/Subscriptions/MonitoredItemConfigCtrl.cs
@@ -40,11 +40,21 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using Opc.Ua.Client;
 using Opc.Ua.Client.Controls;
+using Opc.Ua.Client.Subscriptions.MonitoredItems;
 
 namespace Opc.Ua.Sample.Controls
 {
+    // the V2 subscription engine reuses names the classic engine already has in the
+    // Opc.Ua.Client namespace this file imports, so the V2 types are pinned explicitly.
+    using MonitoredItemOptions = Opc.Ua.Client.Subscriptions.MonitoredItems.MonitoredItemOptions;
+
     public partial class MonitoredItemConfigCtrl : Opc.Ua.Client.Controls.BaseListCtrl
     {
+        /// <summary>
+        /// How long the control waits for the subscription engine to apply the item changes.
+        /// </summary>
+        private static readonly TimeSpan kApplyTimeout = TimeSpan.FromSeconds(10);
+
         #region Constructors
         /// <summary>
         /// Initializes the object with default values.
@@ -53,13 +63,13 @@ namespace Opc.Ua.Sample.Controls
         {
             InitializeComponent();
             SetColumns(m_ColumnNames);
-            m_dialogs = new Dictionary<uint, MonitoredItemDlg>();
+            m_dialogs = new Dictionary<MonitoredItemHandle, MonitoredItemDlg>();
         }
         #endregion
 
         #region Private Fields
-        private Subscription m_subscription;
-        private Dictionary<uint, MonitoredItemDlg> m_dialogs;
+        private SubscriptionHandle m_subscription;
+        private Dictionary<MonitoredItemHandle, MonitoredItemDlg> m_dialogs;
         private bool m_batchUpdates;
 
         /// <summary>
@@ -71,7 +81,6 @@ namespace Opc.Ua.Sample.Controls
             new object[] { "Name",                      HorizontalAlignment.Left,   null       },
             new object[] { "Class",                     HorizontalAlignment.Left,   "Variable" },
             new object[] { "Node ID",                   HorizontalAlignment.Left,   null       },
-            new object[] { "Path",                      HorizontalAlignment.Left,   ""         },
             new object[] { "Attribute",                 HorizontalAlignment.Left,   "Value"    },
             new object[] { "Indexes",                   HorizontalAlignment.Left,   ""         },
             new object[] { "Encoding",                  HorizontalAlignment.Left,   ""         },
@@ -108,7 +117,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Displays the items for the specified subscription in the control.
         /// </summary>
-        public void Initialize(Subscription subscription, ITelemetryContext telemetry)
+        public void Initialize(SubscriptionHandle subscription, ITelemetryContext telemetry)
         {
             // do nothing if same subscription provided.
             if (Object.ReferenceEquals(m_subscription, subscription))
@@ -124,54 +133,59 @@ namespace Opc.Ua.Sample.Controls
         }
 
         /// <summary>
-        /// Called when the subscription changes.
+        /// Called when the state of the subscription changes, which includes the engine
+        /// finishing to apply monitored item changes.
         /// </summary>
-        public void SubscriptionChanged(SubscriptionStateChangedEventArgs e)
+        public void SubscriptionChanged()
         {
             UpdateItems();
 
-            // close any monitoring windows.
-            if ((e.Status | SubscriptionChangeMask.ItemsDeleted) != 0)
+            // close any monitoring windows for items that are gone.
+            List<MonitoredItemDlg> dialogsToClose = new List<MonitoredItemDlg>();
+
+            foreach (KeyValuePair<MonitoredItemHandle, MonitoredItemDlg> current in m_dialogs)
             {
-                List<MonitoredItemDlg> dialogsToClose = new List<MonitoredItemDlg>();
-
-                foreach (KeyValuePair<uint, MonitoredItemDlg> current in m_dialogs)
+                if (m_subscription == null || !m_subscription.Items.Contains(current.Key))
                 {
-                    if (m_subscription.FindItemByClientHandle(current.Key) == null)
-                    {
-                        dialogsToClose.Add(current.Value);
-                    }
+                    dialogsToClose.Add(current.Value);
                 }
+            }
 
-                // this invokes a callback which will remove the dialog from the table.
-                foreach (MonitoredItemDlg dialog in dialogsToClose)
-                {
-                    dialog.Close();
-                }
+            // this invokes a callback which will remove the dialog from the table.
+            foreach (MonitoredItemDlg dialog in dialogsToClose)
+            {
+                dialog.Close();
             }
         }
 
         /// <summary>
-        /// Creates a new group item.
+        /// Creates a new monitored item after prompting the user for its settings.
         /// </summary>
-        public MonitoredItem CreateItem(Subscription subscription, ITelemetryContext telemetry)
+        public MonitoredItemHandle CreateItem()
         {
-            if (subscription == null) throw new ArgumentNullException(nameof(subscription));
+            if (m_subscription == null)
+            {
+                return null;
+            }
 
-            MonitoredItem monitoredItem = new MonitoredItem(subscription.DefaultItem);
-            monitoredItem.QueueSize = 1;
+            // let the user edit a handle which is not part of the subscription yet.
+            MonitoredItemHandle monitoredItem = new MonitoredItemHandle(
+                Utils.Format("MonitoredItem {0}", m_subscription.Items.Count + 1),
+                new MonitoredItemOptions { QueueSize = 1 });
+
+            monitoredItem.DisplayName = monitoredItem.Name;
 
             #pragma warning disable CA2000 // Justification: Sample code retains existing ownership/lifetime and behavior.
-            if (!new MonitoredItemEditDlg().ShowDialog(subscription.Session as Session, monitoredItem, telemetry))
+            if (!new MonitoredItemEditDlg().ShowDialog(m_subscription.Session, monitoredItem, Telemetry))
             #pragma warning restore CA2000
             {
                 return null;
             }
 
-            subscription.AddItem(monitoredItem);
-            subscription.ChangesCompleted();
-
-            return monitoredItem;
+            // stage the item so the containing dialog decides when it is handed to the engine.
+            MonitoredItemHandle handle = m_subscription.StageItem(monitoredItem.DisplayName, monitoredItem.NodeClass, monitoredItem.Settings);
+            UpdateItems();
+            return handle;
         }
 
         /// <summary>
@@ -183,7 +197,7 @@ namespace Opc.Ua.Sample.Controls
             {
                 BeginUpdate();
 
-                foreach (MonitoredItem monitoredItem in m_subscription.MonitoredItems)
+                foreach (MonitoredItemHandle monitoredItem in m_subscription.Items)
                 {
                     AddItem(monitoredItem);
                 }
@@ -203,23 +217,9 @@ namespace Opc.Ua.Sample.Controls
 
             if (parents.Count > 0)
             {
-                bool followToType = false;
-
                 foreach (IReference parentReference in parents)
                 {
-                    Node parent = await m_subscription.Session.NodeCache.FindAsync(parentReference.TargetId, ct) as Node;
-
-                    if (followToType)
-                    {
-                        if (parent.NodeClass == NodeClass.VariableType || parent.NodeClass == NodeClass.ObjectType)
-                        {
-                            return parent;
-                        }
-                    }
-                    else
-                    {
-                        return parent;
-                    }
+                    return await m_subscription.Session.NodeCache.FindAsync(parentReference.TargetId, ct) as Node;
                 }
             }
 
@@ -231,7 +231,7 @@ namespace Opc.Ua.Sample.Controls
         /// </summary>
         public async Task AddItemAsync(ReferenceDescription reference, CancellationToken ct = default)
         {
-            if (reference == null)
+            if (reference == null || m_subscription == null)
             {
                 return;
             }
@@ -243,73 +243,41 @@ namespace Opc.Ua.Sample.Controls
                 return;
             }
 
-            Node parent = null;
+            // use the parent to build a friendlier display name.
+            Node parent = await FindParentAsync(node, ct);
 
-            // if the NodeId is of type string and contains '.' do not use relative paths
-            if (node.NodeId.IdType != IdType.String || (!node.NodeId.IdentifierAsString.Contains('.', StringComparison.Ordinal) && !node.NodeId.IdentifierAsString.Contains('/', StringComparison.Ordinal)))
+            string displayName = (parent != null) ? String.Format("{0}.{1}", parent, node) : String.Format("{0}", node);
+
+            MonitoredItemOptions options = new MonitoredItemOptions {
+                StartNodeId = node.NodeId,
+                AttributeId = Attributes.Value,
+                QueueSize = 1,
+            };
+
+            // subscribe object and view nodes to their events.
+            if (node.NodeClass == NodeClass.Object || node.NodeClass == NodeClass.View)
             {
-                parent = await FindParentAsync(node, ct);
+                options = options with {
+                    AttributeId = Attributes.EventNotifier,
+                    QueueSize = 0,
+                    Filter = SubscriptionHandle.CreateDefaultEventFilter(),
+                };
             }
 
-            MonitoredItem monitoredItem = new MonitoredItem(m_subscription.DefaultItem);
-
-            if (parent != null)
-            {
-                monitoredItem.DisplayName = String.Format("{0}.{1}", parent, node);
-            }
-            else
-            {
-                monitoredItem.DisplayName = String.Format("{0}", node);
-            }
-
-            monitoredItem.StartNodeId = node.NodeId;
-            monitoredItem.NodeClass = node.NodeClass;
-
-            if (parent != null)
-            {
-                List<Node> parents = new List<Node>();
-                parents.Add(parent);
-
-                while (parent.NodeClass != NodeClass.ObjectType && parent.NodeClass != NodeClass.VariableType)
-                {
-                    parent = await FindParentAsync(parent, ct);
-
-                    if (parent == null)
-                    {
-                        break;
-                    }
-
-                    parents.Add(parent);
-                }
-
-                monitoredItem.StartNodeId = parents[parents.Count - 1].NodeId;
-
-                StringBuilder relativePath = new StringBuilder();
-
-                for (int ii = parents.Count - 2; ii >= 0; ii--)
-                {
-                    relativePath.AppendFormat(".{0}", parents[ii].BrowseName);
-                }
-
-                relativePath.AppendFormat(".{0}", node.BrowseName);
-
-                monitoredItem.RelativePath = relativePath.ToString();
-            }
-
-            Session session = m_subscription.Session as Session;
-
-            if (node.NodeClass == NodeClass.Object || node.NodeClass == NodeClass.Variable)
-            {
-                node.Find(ReferenceTypeIds.HasChild, true);
-
-            }
-
-            m_subscription.AddItem(monitoredItem);
+            // stage the item so the containing dialog can apply all new items in one step.
+            m_subscription.StageItem(displayName, node.NodeClass, options);
+            UpdateItems();
         }
 
         /// <summary>
         /// Apply any changes to the set of items.
         /// </summary>
+        /// <remarks>
+        /// The V2 engine has no ApplyChanges: handing an item to the engine or reconfiguring
+        /// its options is the request, and the engine applies it on its own worker. This step
+        /// hands over the staged items and waits for that worker to settle so the revised
+        /// values can be shown.
+        /// </remarks>
         public async Task ApplyChangesAsync(bool force, CancellationToken ct = default)
         {
             if (m_batchUpdates && !force)
@@ -319,7 +287,9 @@ namespace Opc.Ua.Sample.Controls
 
             if (m_subscription != null)
             {
-                await m_subscription.ApplyChangesAsync(ct);
+                m_subscription.ApplyChanges();
+
+                await m_subscription.WaitForPendingChangesAsync(kApplyTimeout, ct);
 
                 foreach (ListViewItem listItem in ItemsLV.Items)
                 {
@@ -335,12 +305,7 @@ namespace Opc.Ua.Sample.Controls
         /// </summary>
         public void FormClosing()
         {
-            List<MonitoredItemDlg> dialogsToClose = new List<MonitoredItemDlg>();
-
-            foreach (KeyValuePair<uint, MonitoredItemDlg> current in m_dialogs)
-            {
-                dialogsToClose.Add(current.Value);
-            }
+            List<MonitoredItemDlg> dialogsToClose = new List<MonitoredItemDlg>(m_dialogs.Values);
 
             // this invokes a callback which will remove the dialog from the table.
             foreach (MonitoredItemDlg dialog in dialogsToClose)
@@ -376,64 +341,67 @@ namespace Opc.Ua.Sample.Controls
         /// <see cref="BaseListCtrl.UpdateItemAsync" />
         protected override async Task UpdateItemAsync(ListViewItem listItem, object item, CancellationToken ct = default)
         {
-            MonitoredItem monitoredItem = item as MonitoredItem;
+            MonitoredItemHandle handle = item as MonitoredItemHandle;
 
-            if (monitoredItem == null)
+            if (handle == null)
             {
                 await base.UpdateItemAsync(listItem, item, ct);
                 return;
             }
 
-            listItem.SubItems[0].Text = String.Format("{0}", monitoredItem.Status.Id);
-            listItem.SubItems[1].Text = String.Format("{0}", monitoredItem.DisplayName);
-            listItem.SubItems[2].Text = String.Format("{0}", monitoredItem.NodeClass);
-            listItem.SubItems[3].Text = String.Format("{0}", monitoredItem.StartNodeId);
-            listItem.SubItems[4].Text = String.Format("{0}", monitoredItem.RelativePath);
-            listItem.SubItems[5].Text = String.Format("{0}", Attributes.GetBrowseName(monitoredItem.AttributeId));
-            listItem.SubItems[6].Text = String.Format("{0}", monitoredItem.IndexRange);
-            listItem.SubItems[7].Text = String.Format("{0}", monitoredItem.Encoding);
-            listItem.SubItems[8].Text = String.Format("{0}", monitoredItem.MonitoringMode);
-            listItem.SubItems[9].Text = String.Format("{0}", monitoredItem.SamplingInterval);
+            MonitoredItemOptions settings = handle.Settings;
+            IMonitoredItem monitoredItem = handle.Item;
 
-            double revisedSampingInterval = monitoredItem.Created ? monitoredItem.Status.SamplingInterval : (double)0.0;
+            listItem.SubItems[0].Text = String.Format("{0}", (monitoredItem != null) ? monitoredItem.ServerId : 0);
+            listItem.SubItems[1].Text = String.Format("{0}", handle.DisplayName);
+            listItem.SubItems[2].Text = String.Format("{0}", handle.NodeClass);
+            listItem.SubItems[3].Text = String.Format("{0}", settings.StartNodeId);
+            listItem.SubItems[4].Text = String.Format("{0}", Attributes.GetBrowseName(settings.AttributeId));
+            listItem.SubItems[5].Text = String.Format("{0}", settings.IndexRange);
+            listItem.SubItems[6].Text = String.Format("{0}", settings.Encoding);
+            listItem.SubItems[7].Text = String.Format("{0}", (monitoredItem != null && monitoredItem.Created) ? monitoredItem.CurrentMonitoringMode : settings.MonitoringMode);
+            listItem.SubItems[8].Text = String.Format("{0}", settings.SamplingInterval.TotalMilliseconds);
 
-            listItem.SubItems[10].Text = String.Format("{0}", revisedSampingInterval);
-            listItem.SubItems[11].Text = String.Format("{0}", monitoredItem.QueueSize);
+            double revisedSampingInterval = handle.Created ? monitoredItem.CurrentSamplingInterval.TotalMilliseconds : 0.0;
 
-            uint revisedQueueSize = monitoredItem.Created ? monitoredItem.Status.QueueSize : 0;
+            listItem.SubItems[9].Text = String.Format("{0}", revisedSampingInterval);
+            listItem.SubItems[10].Text = String.Format("{0}", settings.QueueSize);
 
-            listItem.SubItems[12].Text = String.Format("{0}", revisedQueueSize);
-            listItem.SubItems[13].Text = String.Format("{0}", monitoredItem.DiscardOldest);
-            listItem.SubItems[14].Text = String.Format("{0}", monitoredItem.Status.Error);
+            uint revisedQueueSize = handle.Created ? monitoredItem.CurrentQueueSize : 0;
+
+            listItem.SubItems[11].Text = String.Format("{0}", revisedQueueSize);
+            listItem.SubItems[12].Text = String.Format("{0}", settings.DiscardOldest);
+            listItem.SubItems[13].Text = String.Format("{0}", monitoredItem?.Error);
 
             listItem.ForeColor = Color.Gray;
 
-            if (monitoredItem.Status.Created)
+            if (handle.Created)
             {
                 listItem.ForeColor = Color.Empty;
 
-                if ((revisedQueueSize != monitoredItem.QueueSize) && monitoredItem.AttributeId != Opc.Ua.Attributes.EventNotifier)
+                if ((revisedQueueSize != settings.QueueSize) && settings.AttributeId != Opc.Ua.Attributes.EventNotifier)
                 {
                     listItem.ForeColor = Color.DarkOrange;
                 }
 
-                if ((revisedSampingInterval != monitoredItem.SamplingInterval) && monitoredItem.AttributeId != Opc.Ua.Attributes.EventNotifier)
+                if ((revisedSampingInterval != settings.SamplingInterval.TotalMilliseconds) && settings.AttributeId != Opc.Ua.Attributes.EventNotifier)
                 {
                     listItem.ForeColor = Color.DarkOrange;
                 }
             }
 
-            if (monitoredItem.Status.Id == 0)
+            if (monitoredItem == null || monitoredItem.ServerId == 0)
             {
                 listItem.ForeColor = Color.DarkOrange;
             }
 
-            if (monitoredItem.Status.Error != null && ServiceResult.IsBad(monitoredItem.Status.Error))
+            if (monitoredItem != null && ServiceResult.IsBad(monitoredItem.Error))
             {
                 listItem.ForeColor = Color.Red;
             }
 
-            if (monitoredItem.AttributesModified)
+            // the engine has not applied the latest options yet.
+            if (monitoredItem is IMonitoredItemApplyState applyState && applyState.HasPendingChanges)
             {
                 listItem.ForeColor = Color.Red;
             }
@@ -475,7 +443,7 @@ namespace Opc.Ua.Sample.Controls
                     return;
                 }
 
-                CreateItem(m_subscription, Telemetry);
+                CreateItem();
                 await ApplyChangesAsync(false);
             }
             catch (Exception exception)
@@ -488,7 +456,7 @@ namespace Opc.Ua.Sample.Controls
         {
             try
             {
-                MonitoredItem monitoredItem = SelectedTag as MonitoredItem;
+                MonitoredItemHandle monitoredItem = SelectedTag as MonitoredItemHandle;
 
                 if (monitoredItem == null)
                 {
@@ -501,7 +469,7 @@ namespace Opc.Ua.Sample.Controls
                 }
 
                 #pragma warning disable CA2000 // Justification: Sample code retains existing ownership/lifetime and behavior.
-                if (!new MonitoredItemEditDlg().ShowDialog(m_subscription.Session as Session, monitoredItem, true, Telemetry))
+                if (!new MonitoredItemEditDlg().ShowDialog(m_subscription.Session, monitoredItem, monitoredItem.Created, Telemetry))
                 #pragma warning restore CA2000
                 {
                     return;
@@ -524,38 +492,18 @@ namespace Opc.Ua.Sample.Controls
                     return;
                 }
 
-                MonitoredItem[] monitoredItems = (MonitoredItem[])GetSelectedItems(typeof(MonitoredItem));
+                MonitoredItemHandle[] monitoredItems = (MonitoredItemHandle[])GetSelectedItems(typeof(MonitoredItemHandle));
 
-                if (monitoredItems.Length > 0)
+                foreach (MonitoredItemHandle monitoredItem in monitoredItems)
                 {
-                    m_subscription.RemoveItems(monitoredItems);
+                    // removing the item is the request, the engine deletes it on the server
+                    // from its own worker.
+                    m_subscription.RemoveItem(monitoredItem);
                 }
 
-                IList<MonitoredItem> deletedItems = (await m_subscription.DeleteItemsAsync()).ToList();
+                await m_subscription.WaitForPendingChangesAsync(kApplyTimeout);
 
-                string errorString = string.Empty;
-
-                foreach (MonitoredItem item in deletedItems)
-                {
-                    if (item.Status.Error != null && ServiceResult.IsBad(item.Status.Error))
-                    {
-                        errorString += System.Environment.NewLine + item.Status.Error;
-                    }
-                }
-
-                foreach (ListViewItem listItem in ItemsLV.Items)
-                {
-                    await UpdateItemAsync(listItem, listItem.Tag);
-                }
-
-                AdjustColumns();
-
-                if (!String.IsNullOrEmpty(errorString))
-                {
-                    #pragma warning disable CA2201 // Justification: Sample code retains existing ownership/lifetime and behavior.
-                    throw new Exception(String.Format("DeleteMonitoredItems error: {0}", errorString));
-                    #pragma warning restore CA2201
-                }
+                UpdateItems();
             }
             catch (Exception exception)
             {
@@ -572,11 +520,11 @@ namespace Opc.Ua.Sample.Controls
                     return;
                 }
 
-                MonitoredItem[] monitoredItems = (MonitoredItem[])GetSelectedItems(typeof(MonitoredItem));
+                MonitoredItemHandle[] monitoredItems = (MonitoredItemHandle[])GetSelectedItems(typeof(MonitoredItemHandle));
 
                 if (monitoredItems.Length > 0)
                 {
-                    MonitoringMode monitoringMode = monitoredItems[0].MonitoringMode;
+                    MonitoringMode monitoringMode = monitoredItems[0].Settings.MonitoringMode;
 
                     #pragma warning disable CA2000 // Justification: Sample code retains existing ownership/lifetime and behavior.
                     if (!new SetMonitoringModeDlg().ShowDialog(ref monitoringMode))
@@ -585,21 +533,15 @@ namespace Opc.Ua.Sample.Controls
                         return;
                     }
 
-                    List<ServiceResult> errors = await m_subscription.SetMonitoringModeAsync(monitoringMode, monitoredItems);
-
-                    if (errors != null)
+                    // reconfiguring the options is the request: the engine sends
+                    // SetMonitoringMode for the items which already exist and creates the rest
+                    // with the new mode.
+                    foreach (MonitoredItemHandle monitoredItem in monitoredItems)
                     {
-                        string errorString = string.Empty;
-
-                        foreach (ServiceResult result in errors)
-                        {
-                            errorString += System.Environment.NewLine + result;
-                        }
-
-                        #pragma warning disable CA2201 // Justification: Sample code retains existing ownership/lifetime and behavior.
-                        throw new Exception(String.Format("SetMonitoringMode error: {0}", errorString));
-                        #pragma warning restore CA2201
+                        monitoredItem.Configure(options => options with { MonitoringMode = monitoringMode });
                     }
+
+                    await ApplyChangesAsync(false);
                 }
             }
             catch (Exception exception)
@@ -617,14 +559,14 @@ namespace Opc.Ua.Sample.Controls
                     return;
                 }
 
-                MonitoredItem[] monitoredItems = (MonitoredItem[])GetSelectedItems(typeof(MonitoredItem));
+                MonitoredItemHandle[] monitoredItems = (MonitoredItemHandle[])GetSelectedItems(typeof(MonitoredItemHandle));
 
                 if (monitoredItems.Length == 1)
                 {
                     if (monitoredItems[0].NodeClass == NodeClass.Variable || monitoredItems[0].NodeClass == NodeClass.VariableType)
                     {
                         #pragma warning disable CA2000 // Justification: Sample code retains existing ownership/lifetime and behavior.
-                        if (!new DataChangeFilterEditDlg().ShowDialog(m_subscription.Session as Session, monitoredItems[0]))
+                        if (!new DataChangeFilterEditDlg().ShowDialog(m_subscription.Session, monitoredItems[0]))
                         #pragma warning restore CA2000
                         {
                             return;
@@ -633,7 +575,7 @@ namespace Opc.Ua.Sample.Controls
                     else
                     {
                         #pragma warning disable CA2000 // Justification: Sample code retains existing ownership/lifetime and behavior.
-                        EventFilter filter = new EventFilterDlg().ShowDialog(m_subscription.Session as Session, Telemetry, monitoredItems[0].Filter as EventFilter, false);
+                        EventFilter filter = new EventFilterDlg().ShowDialog(m_subscription.Session, Telemetry, monitoredItems[0].Settings.Filter as EventFilter, false);
                         #pragma warning restore CA2000
 
                         if (filter == null)
@@ -641,10 +583,9 @@ namespace Opc.Ua.Sample.Controls
                             return;
                         }
 
-                        monitoredItems[0].Filter = filter;
+                        monitoredItems[0].Configure(options => options with { Filter = filter });
                     }
 
-                    await m_subscription.ModifyItemsAsync();
                     await ApplyChangesAsync(false);
                 }
             }
@@ -658,7 +599,7 @@ namespace Opc.Ua.Sample.Controls
         {
             try
             {
-                MonitoredItem monitoredItem = SelectedTag as MonitoredItem;
+                MonitoredItemHandle monitoredItem = SelectedTag as MonitoredItemHandle;
 
                 if (monitoredItem == null)
                 {
@@ -672,13 +613,13 @@ namespace Opc.Ua.Sample.Controls
 
                 MonitoredItemDlg dialog = null;
 
-                if (!m_dialogs.TryGetValue(monitoredItem.ClientHandle, out dialog))
+                if (!m_dialogs.TryGetValue(monitoredItem, out dialog))
                 {
-                    m_dialogs[monitoredItem.ClientHandle] = dialog = new MonitoredItemDlg();
+                    m_dialogs[monitoredItem] = dialog = new MonitoredItemDlg();
                     dialog.FormClosing += new FormClosingEventHandler(MonitoredItemDlg_FormClosing);
                 }
 
-                dialog.Show(monitoredItem);
+                dialog.Show(m_subscription, monitoredItem);
             }
             catch (Exception exception)
             {
@@ -690,7 +631,7 @@ namespace Opc.Ua.Sample.Controls
         {
             try
             {
-                foreach (KeyValuePair<uint, MonitoredItemDlg> current in m_dialogs)
+                foreach (KeyValuePair<MonitoredItemHandle, MonitoredItemDlg> current in m_dialogs)
                 {
                     if (current.Value == sender)
                     {

--- a/Samples/Controls.Net4/Subscriptions/MonitoredItemDlg.cs
+++ b/Samples/Controls.Net4/Subscriptions/MonitoredItemDlg.cs
@@ -38,9 +38,14 @@ using System.Reflection;
 
 using Opc.Ua.Client;
 using Opc.Ua.Client.Controls;
+using Opc.Ua.Client.Subscriptions;
 
 namespace Opc.Ua.Sample.Controls
 {
+    // the V2 subscription engine reuses names the classic engine already has in the
+    // Opc.Ua.Client namespace this file imports, so the V2 types are pinned explicitly.
+    using SubscriptionState = Opc.Ua.Client.Subscriptions.SubscriptionState;
+
     public partial class MonitoredItemDlg : Form
     {
         #region Constructors
@@ -49,90 +54,98 @@ namespace Opc.Ua.Sample.Controls
             InitializeComponent();
             this.Icon = ClientUtils.GetAppIcon();
 
-            m_SubscriptionStateChanged = new SubscriptionStateChangedEventHandler(Subscription_StateChanged);
-            m_MonitoredItemNotification = new MonitoredItemNotificationEventHandler(MonitoredItem_NotificationAsync);
-            m_PublishStatusChanged = new PublishStateChangedEventHandler(Subscription_PublishStatusChanged);
+            m_DataChangeCallback = new Action<ISubscription, uint, DateTime, DataValueChange[], PublishState>(OnDataChangeNotification);
+            m_EventCallback = new Action<ISubscription, uint, DateTime, EventNotification[], PublishState>(OnEventNotification);
+            m_KeepAliveCallback = new Action<ISubscription, uint, DateTime, PublishState>(OnKeepAliveNotification);
+            m_StateChangedCallback = new Action<ISubscription, SubscriptionState, PublishState>(OnSubscriptionStateChanged);
+
+            FormClosing += new FormClosingEventHandler(MonitoredItemDlg_FormClosing);
         }
         #endregion
 
         #region Private Fields
-        private Subscription m_subscription;
-        private MonitoredItem m_monitoredItem;
-        private SubscriptionStateChangedEventHandler m_SubscriptionStateChanged;
-        private MonitoredItemNotificationEventHandler m_MonitoredItemNotification;
-        private PublishStateChangedEventHandler m_PublishStatusChanged;
+        private SubscriptionHandle m_subscription;
+        private MonitoredItemHandle m_monitoredItem;
+        private readonly Action<ISubscription, uint, DateTime, DataValueChange[], PublishState> m_DataChangeCallback;
+        private readonly Action<ISubscription, uint, DateTime, EventNotification[], PublishState> m_EventCallback;
+        private readonly Action<ISubscription, uint, DateTime, PublishState> m_KeepAliveCallback;
+        private readonly Action<ISubscription, SubscriptionState, PublishState> m_StateChangedCallback;
         private ITelemetryContext m_telemetry;
+        private uint m_lastSequenceNumber;
+        private DateTime m_lastPublishTime;
+        private bool m_publishingStopped;
         #endregion
 
         #region Public Interface
         /// <summary>
         /// Displays the dialog.
         /// </summary>
-        public void Show(MonitoredItem monitoredItem)
+        public void Show(SubscriptionHandle subscription, MonitoredItemHandle monitoredItem)
         {
+            if (subscription == null) throw new ArgumentNullException(nameof(subscription));
             if (monitoredItem == null) throw new ArgumentNullException(nameof(monitoredItem));
 
             Show();
             BringToFront();
 
-            // remove previous subscription.
-            if (m_monitoredItem != null)
-            {
-                monitoredItem.Subscription.StateChanged -= m_SubscriptionStateChanged;
-                monitoredItem.Subscription.PublishStatusChanged -= m_PublishStatusChanged;
-                monitoredItem.Notification -= m_MonitoredItemNotification;
-            }
+            // stop receiving notifications from the previous subscription.
+            Detach();
 
             // start receiving notifications from the new subscription.
+            m_subscription = subscription;
             m_monitoredItem = monitoredItem;
-            m_subscription = null;
+            m_telemetry = subscription.Session?.MessageContext?.Telemetry;
 
-            #pragma warning disable CA1508 // Justification: Sample code retains existing ownership/lifetime and behavior.
-            if (m_monitoredItem != null)
-            #pragma warning restore CA1508
-            {
-                m_subscription = monitoredItem.Subscription;
-                m_monitoredItem.Subscription.StateChanged += m_SubscriptionStateChanged;
-                m_monitoredItem.Subscription.PublishStatusChanged += m_PublishStatusChanged;
-                m_monitoredItem.Notification += m_MonitoredItemNotification;
-            }
-
-            m_telemetry = m_subscription?.Session?.MessageContext?.Telemetry;
+            subscription.Callbacks.DataChangeCallback += m_DataChangeCallback;
+            subscription.Callbacks.EventCallback += m_EventCallback;
+            subscription.Callbacks.KeepAliveCallback += m_KeepAliveCallback;
+            subscription.Callbacks.StateChangedCallback += m_StateChangedCallback;
 
             WindowMI_Click(WindowStatusMI, null);
             WindowMI_Click(WindowLatestValueMI, null);
 
-            MonitoredItemsCTRL.Initialize(m_monitoredItem);
+            MonitoredItemsCTRL.Initialize(m_subscription, m_monitoredItem);
             EventsCTRL.Initialize(m_subscription, m_monitoredItem);
-            DataChangesCTRL.InitializeAsync(m_subscription, m_monitoredItem);
+            DataChangesCTRL.Initialize(m_subscription, m_monitoredItem);
             LatestValueCTRL.Telemetry = m_telemetry;
-            LatestValueCTRL.ShowValueAsync(m_monitoredItem, false).GetAwaiter().GetResult();
+            UpdateStatus();
         }
         #endregion
 
         #region Private Methods
         /// <summary>
-        /// Updates the controls displaying the status of the subscription.
+        /// Stops receiving notifications from the current subscription.
+        /// </summary>
+        private void Detach()
+        {
+            if (m_subscription != null)
+            {
+                m_subscription.Callbacks.DataChangeCallback -= m_DataChangeCallback;
+                m_subscription.Callbacks.EventCallback -= m_EventCallback;
+                m_subscription.Callbacks.KeepAliveCallback -= m_KeepAliveCallback;
+                m_subscription.Callbacks.StateChangedCallback -= m_StateChangedCallback;
+            }
+        }
+
+        /// <summary>
+        /// Updates the controls displaying the status of the monitored item.
         /// </summary>
         private void UpdateStatus()
         {
-            NotificationMessage lastMessage = null;
-
-            if (m_monitoredItem != null)
-            {
-                lastMessage = m_monitoredItem.LastMessage;
-            }
-
             MonitoringModeTB.Text = String.Empty;
             MonitoringModeTB.ForeColor = Color.Empty;
             MonitoringModeTB.Font = new Font(MonitoringModeTB.Font, FontStyle.Regular);
 
             if (m_monitoredItem != null)
             {
-                MonitoringModeTB.Text = String.Format("{0}", m_monitoredItem.Status.MonitoringMode);
+                MonitoringMode monitoringMode = (m_monitoredItem.Item != null && m_monitoredItem.Item.Created)
+                    ? m_monitoredItem.Item.CurrentMonitoringMode
+                    : m_monitoredItem.Settings.MonitoringMode;
+
+                MonitoringModeTB.Text = String.Format("{0}", monitoringMode);
             }
 
-            if (m_subscription != null && m_subscription.PublishingStopped)
+            if (m_publishingStopped)
             {
                 MonitoringModeTB.Text = String.Format("BadNoCommunication");
                 MonitoringModeTB.ForeColor = Color.Red;
@@ -142,23 +155,45 @@ namespace Opc.Ua.Sample.Controls
             LastUpdateTimeTB.Text = String.Empty;
             LastMessageIdTB.Text = String.Empty;
 
-            if (lastMessage != null)
+            if (m_lastPublishTime != DateTime.MinValue)
             {
-                LastUpdateTimeTB.Text = String.Format("{0:HH:mm:ss}", lastMessage.PublishTime.ToLocalTime());
-                LastMessageIdTB.Text = String.Format("{0}", lastMessage.SequenceNumber);
+                LastUpdateTimeTB.Text = String.Format("{0:HH:mm:ss}", m_lastPublishTime.ToLocalTime());
+                LastMessageIdTB.Text = String.Format("{0}", m_lastSequenceNumber);
+            }
+        }
+
+        /// <summary>
+        /// Remembers the publish state the engine reported with a notification.
+        /// </summary>
+        private void UpdatePublishState(uint sequenceNumber, DateTime publishTime, PublishState publishStateMask)
+        {
+            m_lastSequenceNumber = sequenceNumber;
+            m_lastPublishTime = publishTime;
+
+            if ((publishStateMask & PublishState.Stopped) != 0)
+            {
+                m_publishingStopped = true;
+            }
+            else if ((publishStateMask & PublishState.Recovered) != 0)
+            {
+                m_publishingStopped = false;
+            }
+            else if (publishStateMask == PublishState.None)
+            {
+                m_publishingStopped = false;
             }
         }
         #endregion
 
         #region Event Handlers
         /// <summary>
-        /// Processes a Publish repsonse from the server.
+        /// Processes the data changes of a publish response from the server.
         /// </summary>
-        private async void MonitoredItem_NotificationAsync(MonitoredItem monitoredItem, MonitoredItemNotificationEventArgs e)
+        private async void OnDataChangeNotification(ISubscription subscription, uint sequenceNumber, DateTime publishTime, DataValueChange[] notifications, PublishState publishStateMask)
         {
             if (InvokeRequired)
             {
-                BeginInvoke(m_MonitoredItemNotification, monitoredItem, e);
+                BeginInvoke(m_DataChangeCallback, subscription, sequenceNumber, publishTime, notifications, publishStateMask);
                 return;
             }
             else if (!IsHandleCreated)
@@ -168,22 +203,99 @@ namespace Opc.Ua.Sample.Controls
 
             try
             {
-                // ignore notifications for other monitored items.
-                if (!Object.ReferenceEquals(m_monitoredItem, monitoredItem))
+                // ignore notifications for other subscriptions.
+                if (m_subscription == null || !Object.ReferenceEquals(m_subscription.Subscription, subscription))
                 {
                     return;
                 }
 
+                UpdatePublishState(sequenceNumber, publishTime, publishStateMask);
+
                 // notify controls of the change.
-                EventsCTRL.NotificationReceived(e);
-                await DataChangesCTRL.NotificationReceivedAsync(e);
-                if (e != null)
+                await DataChangesCTRL.NotificationReceivedAsync(notifications, publishStateMask);
+                MonitoredItemsCTRL.NotificationReceived(notifications);
+
+                // show the latest value of the item this dialog monitors.
+                foreach (DataValueChange change in notifications)
                 {
-                    MonitoredItemNotification notification = e.NotificationValue as MonitoredItemNotification;
-                    LatestValueCTRL.Telemetry = m_telemetry;
-                    await LatestValueCTRL.ShowValueAsync(notification, true);
+                    if (Object.ReferenceEquals(m_monitoredItem.Item, change.MonitoredItem))
+                    {
+                        LatestValueCTRL.Telemetry = m_telemetry;
+                        await LatestValueCTRL.ShowValueAsync(change.Value, true);
+                    }
                 }
+
                 // update item status.
+                UpdateStatus();
+            }
+            catch (Exception exception)
+            {
+                GuiUtils.HandleException(m_telemetry, this.Text, MethodBase.GetCurrentMethod(), exception);
+            }
+        }
+
+        /// <summary>
+        /// Processes the events of a publish response from the server.
+        /// </summary>
+        private void OnEventNotification(ISubscription subscription, uint sequenceNumber, DateTime publishTime, EventNotification[] notifications, PublishState publishStateMask)
+        {
+            if (InvokeRequired)
+            {
+                BeginInvoke(m_EventCallback, subscription, sequenceNumber, publishTime, notifications, publishStateMask);
+                return;
+            }
+            else if (!IsHandleCreated)
+            {
+                return;
+            }
+
+            try
+            {
+                // ignore notifications for other subscriptions.
+                if (m_subscription == null || !Object.ReferenceEquals(m_subscription.Subscription, subscription))
+                {
+                    return;
+                }
+
+                UpdatePublishState(sequenceNumber, publishTime, publishStateMask);
+
+                // notify controls of the change.
+                EventsCTRL.NotificationReceived(notifications);
+                MonitoredItemsCTRL.NotificationReceived(notifications);
+
+                // update item status.
+                UpdateStatus();
+            }
+            catch (Exception exception)
+            {
+                GuiUtils.HandleException(m_telemetry, this.Text, MethodBase.GetCurrentMethod(), exception);
+            }
+        }
+
+        /// <summary>
+        /// Processes a keep alive notification from the server.
+        /// </summary>
+        private void OnKeepAliveNotification(ISubscription subscription, uint sequenceNumber, DateTime publishTime, PublishState publishStateMask)
+        {
+            if (InvokeRequired)
+            {
+                BeginInvoke(m_KeepAliveCallback, subscription, sequenceNumber, publishTime, publishStateMask);
+                return;
+            }
+            else if (!IsHandleCreated)
+            {
+                return;
+            }
+
+            try
+            {
+                // ignore notifications for other subscriptions.
+                if (m_subscription == null || !Object.ReferenceEquals(m_subscription.Subscription, subscription))
+                {
+                    return;
+                }
+
+                UpdatePublishState(sequenceNumber, publishTime, publishStateMask);
                 UpdateStatus();
             }
             catch (Exception exception)
@@ -195,11 +307,11 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Handles a change to the state of the subscription.
         /// </summary>
-        private void Subscription_StateChanged(Subscription subscription, SubscriptionStateChangedEventArgs e)
+        private void OnSubscriptionStateChanged(ISubscription subscription, SubscriptionState state, PublishState publishStateMask)
         {
             if (InvokeRequired)
             {
-                BeginInvoke(m_SubscriptionStateChanged, subscription, e);
+                BeginInvoke(m_StateChangedCallback, subscription, state, publishStateMask);
                 return;
             }
             else if (!IsHandleCreated)
@@ -210,15 +322,15 @@ namespace Opc.Ua.Sample.Controls
             try
             {
                 // ignore notifications for other subscriptions.
-                if (m_monitoredItem == null || !Object.ReferenceEquals(m_monitoredItem.Subscription, subscription))
+                if (m_subscription == null || !Object.ReferenceEquals(m_subscription.Subscription, subscription))
                 {
                     return;
                 }
 
                 // notify controls of the change.
-                EventsCTRL.SubscriptionChanged(e);
-                DataChangesCTRL.SubscriptionChanged(e);
-                MonitoredItemsCTRL.SubscriptionChanged(e);
+                EventsCTRL.SubscriptionChanged();
+                DataChangesCTRL.SubscriptionChanged();
+                MonitoredItemsCTRL.SubscriptionChanged();
 
                 // update subscription status.
                 UpdateStatus();
@@ -229,31 +341,11 @@ namespace Opc.Ua.Sample.Controls
             }
         }
 
-        /// <summary>
-        /// Handles a change to the publish status for the subscription.
-        /// </summary>
-        private void Subscription_PublishStatusChanged(object subscription, PublishStateChangedEventArgs e)
+        private void MonitoredItemDlg_FormClosing(object sender, FormClosingEventArgs e)
         {
-            if (InvokeRequired)
-            {
-                BeginInvoke(m_PublishStatusChanged, subscription, e);
-                return;
-            }
-            else if (!IsHandleCreated)
-            {
-                return;
-            }
-
             try
             {
-                // ignore notifications for other subscriptions.
-                if (!Object.ReferenceEquals(m_subscription, subscription))
-                {
-                    return;
-                }
-
-                // update item status.
-                UpdateStatus();
+                Detach();
             }
             catch (Exception exception)
             {
@@ -307,7 +399,7 @@ namespace Opc.Ua.Sample.Controls
         {
             try
             {
-                MonitoringMode monitoringMode = m_monitoredItem.MonitoringMode;
+                MonitoringMode monitoringMode = m_monitoredItem.Settings.MonitoringMode;
 
                 if (sender == MonitoringModeReportingMI)
                 {
@@ -324,7 +416,12 @@ namespace Opc.Ua.Sample.Controls
                     monitoringMode = MonitoringMode.Disabled;
                 }
 
-                await m_monitoredItem.Subscription.SetMonitoringModeAsync(monitoringMode, new MonitoredItem[] { m_monitoredItem });
+                // reconfiguring the options is the request, the engine applies it on its own
+                // worker.
+                m_monitoredItem.Configure(options => options with { MonitoringMode = monitoringMode });
+                await m_subscription.WaitForPendingChangesAsync(TimeSpan.FromSeconds(10));
+
+                UpdateStatus();
             }
             catch (Exception exception)
             {
@@ -340,7 +437,11 @@ namespace Opc.Ua.Sample.Controls
                 MonitoringModeSamplingMI.Checked = false;
                 MonitoringModeDisabledMI.Checked = false;
 
-                switch (m_monitoredItem.MonitoringMode)
+                MonitoringMode monitoringMode = (m_monitoredItem.Item != null && m_monitoredItem.Item.Created)
+                    ? m_monitoredItem.Item.CurrentMonitoringMode
+                    : m_monitoredItem.Settings.MonitoringMode;
+
+                switch (monitoringMode)
                 {
                     case MonitoringMode.Reporting: { MonitoringModeReportingMI.Checked = true; break; }
                     case MonitoringMode.Sampling: { MonitoringModeSamplingMI.Checked = true; break; }

--- a/Samples/Controls.Net4/Subscriptions/MonitoredItemEditDlg.cs
+++ b/Samples/Controls.Net4/Subscriptions/MonitoredItemEditDlg.cs
@@ -42,6 +42,10 @@ using Opc.Ua.Client.Controls;
 
 namespace Opc.Ua.Sample.Controls
 {
+    // the V2 subscription engine reuses names the classic engine already has in the
+    // Opc.Ua.Client namespace this file imports, so the V2 types are pinned explicitly.
+    using MonitoredItemOptions = Opc.Ua.Client.Subscriptions.MonitoredItems.MonitoredItemOptions;
+
     public partial class MonitoredItemEditDlg : Form
     {
         public MonitoredItemEditDlg()
@@ -62,20 +66,25 @@ namespace Opc.Ua.Sample.Controls
             }
         }
 
-        private Session m_session;
+        private ISession m_session;
 
         /// <summary>
-        /// Prompts the user to specify the browse options.
+        /// Prompts the user to specify the settings for a monitored item.
         /// </summary>
-        public bool ShowDialog(Session session, MonitoredItem monitoredItem, ITelemetryContext telemetry)
+        public bool ShowDialog(ISession session, MonitoredItemHandle monitoredItem, ITelemetryContext telemetry)
         {
             return ShowDialog(session, monitoredItem, false, telemetry);
         }
 
         /// <summary>
-        /// Prompts the user to specify the browse options.
+        /// Prompts the user to specify the settings for a monitored item.
         /// </summary>
-        public bool ShowDialog(Session session, MonitoredItem monitoredItem, bool editMonitoredItem, ITelemetryContext telemetry)
+        /// <remarks>
+        /// Reconfiguring the options monitor of the handle is the modify request: for an item
+        /// which already exists the V2 engine applies the new settings on its own worker, and
+        /// for one which does not it uses them when it is created.
+        /// </remarks>
+        public bool ShowDialog(ISession session, MonitoredItemHandle monitoredItem, bool editMonitoredItem, ITelemetryContext telemetry)
         {
             if (monitoredItem == null) throw new ArgumentNullException(nameof(monitoredItem));
 
@@ -84,50 +93,39 @@ namespace Opc.Ua.Sample.Controls
             NodeIdCTRL.Telemetry = telemetry;
             NodeIdCTRL.Browser = new Browser(session);
 
+            // the V2 engine identifies the monitored node by its node id, relative paths are
+            // not part of the item options.
+            RelativePathTB.Enabled = false;
+
             if (editMonitoredItem)
             {
                 // Disable the not changeable values
                 NodeIdCTRL.Enabled = false;
-                RelativePathTB.Enabled = false;
                 NodeClassCB.Enabled = false;
                 AttributeIdCB.Enabled = false;
                 IndexRangeTB.Enabled = false;
                 EncodingCB.Enabled = false;
                 MonitoringModeCB.Enabled = false;
-
-                DisplayNameTB.Text = monitoredItem.DisplayName;
-            }
-            else
-            {
-                uint monitoredItemsCount = 0;
-
-                if (session != null && session.SubscriptionCount >= 1)
-                {
-                    foreach (Subscription subscription in session.Subscriptions)
-                    {
-                        monitoredItemsCount += subscription.MonitoredItemCount;
-                    }
-                }
-
-                DisplayNameTB.Text = String.Format("MonitoredItem {0}", monitoredItemsCount + 1);
             }
 
-            NodeIdCTRL.Identifier = monitoredItem.StartNodeId;
-            RelativePathTB.Text = monitoredItem.RelativePath;
+            MonitoredItemOptions settings = monitoredItem.Settings;
+
+            DisplayNameTB.Text = monitoredItem.DisplayName;
+            NodeIdCTRL.Identifier = settings.StartNodeId;
             NodeClassCB.SelectedItem = monitoredItem.NodeClass;
-            AttributeIdCB.SelectedItem = Attributes.GetBrowseName(monitoredItem.AttributeId);
-            IndexRangeTB.Text = monitoredItem.IndexRange;
-            EncodingCB.Text = (!monitoredItem.Encoding.IsNull) ? monitoredItem.Encoding.Name : null;
-            MonitoringModeCB.SelectedItem = monitoredItem.MonitoringMode;
+            AttributeIdCB.SelectedItem = Attributes.GetBrowseName(settings.AttributeId);
+            IndexRangeTB.Text = settings.IndexRange;
+            EncodingCB.Text = (settings.Encoding.HasValue && !settings.Encoding.Value.IsNull) ? settings.Encoding.Value.Name : null;
+            MonitoringModeCB.SelectedItem = settings.MonitoringMode;
             SamplingIntervalNC.Value = 1000;
-            DisableOldestCK.Checked = monitoredItem.DiscardOldest;
+            DisableOldestCK.Checked = settings.DiscardOldest;
 
-            if (monitoredItem.SamplingInterval >= 0)
+            if (settings.SamplingInterval >= TimeSpan.Zero)
             {
-                SamplingIntervalNC.Value = (decimal)monitoredItem.SamplingInterval;
+                SamplingIntervalNC.Value = (decimal)settings.SamplingInterval.TotalMilliseconds;
             }
 
-            QueueSizeNC.Value = monitoredItem.QueueSize;
+            QueueSizeNC.Value = settings.QueueSize;
 
             if (ShowDialog() != DialogResult.OK)
             {
@@ -136,19 +134,26 @@ namespace Opc.Ua.Sample.Controls
 
             monitoredItem.DisplayName = DisplayNameTB.Text;
             monitoredItem.NodeClass = (NodeClass)NodeClassCB.SelectedItem;
-            monitoredItem.StartNodeId = NodeIdCTRL.Identifier;
-            monitoredItem.RelativePath = RelativePathTB.Text;
-            monitoredItem.AttributeId = Attributes.GetIdentifier((string)AttributeIdCB.SelectedItem);
-            monitoredItem.IndexRange = IndexRangeTB.Text;
-            monitoredItem.MonitoringMode = (MonitoringMode)MonitoringModeCB.SelectedItem;
-            monitoredItem.SamplingInterval = (int)SamplingIntervalNC.Value;
-            monitoredItem.QueueSize = (uint)QueueSizeNC.Value;
-            monitoredItem.DiscardOldest = DisableOldestCK.Checked;
 
-            if (!String.IsNullOrEmpty(EncodingCB.Text))
-            {
-                monitoredItem.Encoding = new QualifiedName(EncodingCB.Text);
-            }
+            NodeId startNodeId = NodeIdCTRL.Identifier;
+            uint attributeId = Attributes.GetIdentifier((string)AttributeIdCB.SelectedItem);
+            string indexRange = IndexRangeTB.Text;
+            MonitoringMode monitoringMode = (MonitoringMode)MonitoringModeCB.SelectedItem;
+            TimeSpan samplingInterval = TimeSpan.FromMilliseconds((double)SamplingIntervalNC.Value);
+            uint queueSize = (uint)QueueSizeNC.Value;
+            bool discardOldest = DisableOldestCK.Checked;
+            QualifiedName? encoding = (!String.IsNullOrEmpty(EncodingCB.Text)) ? new QualifiedName(EncodingCB.Text) : null;
+
+            monitoredItem.Configure(options => options with {
+                StartNodeId = startNodeId,
+                AttributeId = attributeId,
+                IndexRange = indexRange,
+                MonitoringMode = monitoringMode,
+                SamplingInterval = samplingInterval,
+                QueueSize = queueSize,
+                DiscardOldest = discardOldest,
+                Encoding = encoding ?? options.Encoding,
+            });
 
             return true;
         }
@@ -162,18 +167,6 @@ namespace Opc.Ua.Sample.Controls
             catch (Exception)
             {
                 MessageBox.Show("Please enter a valid node id.", this.Text);
-            }
-
-            try
-            {
-                if (!String.IsNullOrEmpty(RelativePathTB.Text))
-                {
-                    RelativePath relativePath = RelativePath.Parse(RelativePathTB.Text, m_session.TypeTree);
-                }
-            }
-            catch (Exception)
-            {
-                MessageBox.Show("Please enter a valid relative path.", this.Text);
             }
 
             try

--- a/Samples/Controls.Net4/Subscriptions/MonitoredItemStatusCtrl.cs
+++ b/Samples/Controls.Net4/Subscriptions/MonitoredItemStatusCtrl.cs
@@ -39,6 +39,8 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using Opc.Ua.Client;
 using Opc.Ua.Client.Controls;
+using Opc.Ua.Client.Subscriptions;
+using Opc.Ua.Client.Subscriptions.MonitoredItems;
 
 namespace Opc.Ua.Sample.Controls
 {
@@ -56,8 +58,19 @@ namespace Opc.Ua.Sample.Controls
         #endregion
 
         #region Private Fields
-        private Subscription m_subscription;
-        private MonitoredItem m_monitoredItem;
+        private SubscriptionHandle m_subscription;
+        private MonitoredItemHandle m_monitoredItem;
+        private readonly Dictionary<MonitoredItemHandle, LastNotification> m_notifications = new Dictionary<MonitoredItemHandle, LastNotification>();
+
+        /// <summary>
+        /// The most recent notification of a monitored item. The V2 engine keeps no value
+        /// cache on the item, so the control remembers what it displayed last.
+        /// </summary>
+        private sealed class LastNotification
+        {
+            public string Value;
+            public DateTime Timestamp;
+        }
 
         /// <summary>
         /// The columns to display in the control.
@@ -82,48 +95,24 @@ namespace Opc.Ua.Sample.Controls
         public void Clear()
         {
             ItemsLV.Items.Clear();
+            m_notifications.Clear();
             AdjustColumns();
         }
 
         /// <summary>
-        /// Displays the items for the specified subscription in the control.
+        /// Displays the status of a single monitored item in the control.
         /// </summary>
-        public void Initialize(MonitoredItem monitoredItem)
+        public void Initialize(SubscriptionHandle subscription, MonitoredItemHandle monitoredItem)
         {
-            // do nothing if same subscription provided.
-            if (Object.ReferenceEquals(m_monitoredItem, monitoredItem))
+            // do nothing if same item provided.
+            if (Object.ReferenceEquals(m_subscription, subscription) && Object.ReferenceEquals(m_monitoredItem, monitoredItem))
             {
                 return;
             }
 
-            m_monitoredItem = monitoredItem;
-            m_subscription = null;
-            #pragma warning disable CA1508 // Justification: Sample code retains existing ownership/lifetime and behavior.
-            Telemetry = m_subscription?.Session?.MessageContext?.Telemetry;
-            #pragma warning restore CA1508
-
-            Clear();
-
-            if (m_monitoredItem != null)
-            {
-                m_subscription = monitoredItem.Subscription;
-                UpdateItems();
-            }
-        }
-
-        /// <summary>
-        /// Displays the items for the specified subscription in the control.
-        /// </summary>
-        public void Initialize(Subscription subscription)
-        {
-            // do nothing if same subscription provided.
-            if (Object.ReferenceEquals(m_subscription, subscription))
-            {
-                return;
-            }
-
-            m_monitoredItem = null;
             m_subscription = subscription;
+            m_monitoredItem = monitoredItem;
+            Telemetry = m_subscription?.Session?.MessageContext?.Telemetry;
 
             Clear();
 
@@ -134,11 +123,83 @@ namespace Opc.Ua.Sample.Controls
         }
 
         /// <summary>
-        /// Called when the subscription changes.
+        /// Displays the items for the specified subscription in the control.
         /// </summary>
-        public void SubscriptionChanged(SubscriptionStateChangedEventArgs e)
+        public void Initialize(SubscriptionHandle subscription)
+        {
+            Initialize(subscription, null);
+        }
+
+        /// <summary>
+        /// Called when the state of the subscription changes, which includes the engine
+        /// finishing to apply monitored item changes.
+        /// </summary>
+        public void SubscriptionChanged()
         {
             UpdateItems();
+        }
+
+        /// <summary>
+        /// Updates the value cells with the data changes of a notification.
+        /// </summary>
+        public void NotificationReceived(DataValueChange[] changes)
+        {
+            foreach (DataValueChange change in changes)
+            {
+                MonitoredItemHandle handle = m_subscription?.FindItem(change.MonitoredItem);
+
+                if (handle == null || (m_monitoredItem != null && !Object.ReferenceEquals(handle, m_monitoredItem)))
+                {
+                    continue;
+                }
+
+                m_notifications[handle] = new LastNotification {
+                    Value = String.Format("{0}", change.Value.WrappedValue),
+                    Timestamp = change.Value.SourceTimestamp.ToDateTime(),
+                };
+            }
+
+            UpdateItems();
+        }
+
+        /// <summary>
+        /// Updates the value cells with the events of a notification.
+        /// </summary>
+        public async void NotificationReceived(EventNotification[] notifications)
+        {
+            try
+            {
+                foreach (EventNotification notification in notifications)
+                {
+                    MonitoredItemHandle handle = m_subscription?.FindItem(notification.MonitoredItem);
+
+                    if (handle == null || (m_monitoredItem != null && !Object.ReferenceEquals(handle, m_monitoredItem)))
+                    {
+                        continue;
+                    }
+
+                    string value = null;
+
+                    if (SubscriptionHandle.GetEventFieldValue(handle, notification, new QualifiedName(Opc.Ua.BrowseNames.EventType)) is NodeId eventTypeId)
+                    {
+                        INode eventType = await m_subscription.Session.NodeCache.FindAsync(eventTypeId);
+                        value = String.Format("{0}", (object)eventType ?? eventTypeId);
+                    }
+
+                    DateTime timestamp = (SubscriptionHandle.GetEventFieldValue(handle, notification, new QualifiedName(Opc.Ua.BrowseNames.Time)) as DateTime?) ?? DateTime.MinValue;
+
+                    m_notifications[handle] = new LastNotification {
+                        Value = value,
+                        Timestamp = timestamp,
+                    };
+                }
+
+                UpdateItems();
+            }
+            catch (Exception exception)
+            {
+                GuiUtils.HandleException(Telemetry, this.Text, MethodBase.GetCurrentMethod(), exception);
+            }
         }
 
         /// <summary>
@@ -150,33 +211,15 @@ namespace Opc.Ua.Sample.Controls
             {
                 BeginUpdate();
 
-                foreach (MonitoredItem monitoredItem in m_subscription.MonitoredItems)
+                foreach (MonitoredItemHandle monitoredItem in m_subscription.Items)
                 {
-                    if (m_monitoredItem == null || monitoredItem.ClientHandle == m_monitoredItem.ClientHandle)
+                    if (m_monitoredItem == null || Object.ReferenceEquals(monitoredItem, m_monitoredItem))
                     {
                         AddItem(monitoredItem);
                     }
                 }
 
                 EndUpdate();
-
-                AdjustColumns();
-            }
-        }
-
-        /// <summary>
-        /// Apply any changes to the set of items.
-        /// </summary>
-        public async Task ApplyChangesAsync(CancellationToken ct = default)
-        {
-            if (m_subscription != null)
-            {
-                await m_subscription.ApplyChangesAsync(ct);
-
-                foreach (ListViewItem listItem in ItemsLV.Items)
-                {
-                    await UpdateItemAsync(listItem, listItem.Tag, ct);
-                }
 
                 AdjustColumns();
             }
@@ -193,45 +236,32 @@ namespace Opc.Ua.Sample.Controls
         /// <see cref="BaseListCtrl.UpdateItemAsync" />
         protected override async Task UpdateItemAsync(ListViewItem listItem, object item, CancellationToken ct = default)
         {
-            MonitoredItem monitoredItem = item as MonitoredItem;
+            MonitoredItemHandle handle = item as MonitoredItemHandle;
 
-            if (monitoredItem == null)
+            if (handle == null)
             {
                 await base.UpdateItemAsync(listItem, item, ct);
                 return;
             }
 
-            listItem.SubItems[0].Text = String.Format("{0}", monitoredItem.Status.Id);
-            listItem.SubItems[1].Text = String.Format("{0}", monitoredItem.DisplayName);
-            listItem.SubItems[2].Text = String.Format("{0}", monitoredItem.NodeClass);
-            listItem.SubItems[3].Text = String.Format("{0}", monitoredItem.Status.SamplingInterval);
-            listItem.SubItems[4].Text = String.Format("{0}", monitoredItem.Status.QueueSize);
+            IMonitoredItem monitoredItem = handle.Item;
+
+            listItem.SubItems[0].Text = String.Format("{0}", (monitoredItem != null) ? monitoredItem.ServerId : 0);
+            listItem.SubItems[1].Text = String.Format("{0}", handle.DisplayName);
+            listItem.SubItems[2].Text = String.Format("{0}", handle.NodeClass);
+            listItem.SubItems[3].Text = String.Format("{0}", (monitoredItem != null) ? monitoredItem.CurrentSamplingInterval.TotalMilliseconds : handle.Settings.SamplingInterval.TotalMilliseconds);
+            listItem.SubItems[4].Text = String.Format("{0}", (monitoredItem != null) ? monitoredItem.CurrentQueueSize : handle.Settings.QueueSize);
             listItem.SubItems[5].Text = String.Empty;
-            listItem.SubItems[6].Text = String.Format("{0}", monitoredItem.Status.Error);
+            listItem.SubItems[6].Text = String.Format("{0}", monitoredItem?.Error);
             listItem.SubItems[7].Text = String.Empty;
 
-            IEncodeable value = monitoredItem.LastValue;
-
-            if (value != null)
+            if (m_notifications.TryGetValue(handle, out LastNotification notification))
             {
-                MonitoredItemNotification datachange = value as MonitoredItemNotification;
+                listItem.SubItems[5].Text = notification.Value;
 
-                if (datachange != null)
+                if (notification.Timestamp != DateTime.MinValue)
                 {
-                    listItem.SubItems[5].Text = String.Format("{0}", datachange.Value);
-
-                    if (datachange.Value.SourceTimestamp != DateTime.MinValue)
-                    {
-                        listItem.SubItems[7].Text = String.Format("{0:HH:mm:ss.fff}", datachange.Value.SourceTimestamp.ToLocalTime());
-                    }
-                }
-
-                EventFieldList eventFields = value as EventFieldList;
-
-                if (eventFields != null)
-                {
-                    listItem.SubItems[5].Text = String.Format("{0}", await monitoredItem.GetEventTypeAsync(eventFields, ct));
-                    listItem.SubItems[7].Text = String.Format("{0:HH:mm:ss.fff}", monitoredItem.GetEventTime(eventFields).ToLocalTime());
+                    listItem.SubItems[7].Text = String.Format("{0:HH:mm:ss.fff}", notification.Timestamp.ToLocalTime());
                 }
             }
 

--- a/Samples/Controls.Net4/Subscriptions/NotificationMessageListCtrl.cs
+++ b/Samples/Controls.Net4/Subscriptions/NotificationMessageListCtrl.cs
@@ -39,6 +39,7 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using Opc.Ua.Client;
 using Opc.Ua.Client.Controls;
+using Opc.Ua.Client.Subscriptions;
 
 namespace Opc.Ua.Sample.Controls
 {
@@ -56,14 +57,20 @@ namespace Opc.Ua.Sample.Controls
             SetColumns(m_ColumnNames);
 
             ItemsLV.Sorting = SortOrder.Descending;
-            m_SessionNotification = new NotificationEventHandler(Session_Notification);
+
+            m_DataChangeCallback = new Action<ISubscription, uint, DateTime, DataValueChange[], PublishState>(OnDataChangeNotification);
+            m_EventCallback = new Action<ISubscription, uint, DateTime, EventNotification[], PublishState>(OnEventNotification);
+            m_KeepAliveCallback = new Action<ISubscription, uint, DateTime, PublishState>(OnKeepAliveNotification);
         }
         #endregion
 
         #region Private Fields
-        private Session m_session;
-        private Subscription m_subscription;
-        private NotificationEventHandler m_SessionNotification;
+        private ISession m_session;
+        private SubscriptionHandle m_subscription;
+        private readonly List<SubscriptionHandle> m_attached = new List<SubscriptionHandle>();
+        private readonly Action<ISubscription, uint, DateTime, DataValueChange[], PublishState> m_DataChangeCallback;
+        private readonly Action<ISubscription, uint, DateTime, EventNotification[], PublishState> m_EventCallback;
+        private readonly Action<ISubscription, uint, DateTime, PublishState> m_KeepAliveCallback;
         private int m_maxMessageCount;
 
         /// <summary>
@@ -74,7 +81,6 @@ namespace Opc.Ua.Sample.Controls
             new object[] { "Subscription",  HorizontalAlignment.Left,   null   },
             new object[] { "Message ID",    HorizontalAlignment.Center, null   },
             new object[] { "Publish Time",  HorizontalAlignment.Center, null   },
-            new object[] { "Notifications", HorizontalAlignment.Center, null   },
             new object[] { "Data Changes",  HorizontalAlignment.Center, null   },
             new object[] { "EventTypes",    HorizontalAlignment.Center, null   }
         };
@@ -103,33 +109,32 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Initializes the control with the session/subscription indicated.
         /// </summary>
-        public void Initialize(Session session, Subscription subscription)
+        /// <remarks>
+        /// The V2 engine delivers its notifications through the handler a subscription was
+        /// created with, so the control combines its delegates into the callbacks of the
+        /// subscriptions it reports on instead of the session-wide notification event the
+        /// classic engine raised.
+        /// </remarks>
+        public void Initialize(ISession session, IList<SubscriptionHandle> subscriptions, SubscriptionHandle subscription)
         {
-            // do nothing if nothing has changed.
-            if (Object.ReferenceEquals(session, m_session) && Object.ReferenceEquals(subscription, m_subscription))
+            // do nothing if nothing has changed. Unlike the session-wide notification event of
+            // the classic engine the callbacks are per subscription, so a subscription created
+            // since the last call also forces a re-attach.
+            if (Object.ReferenceEquals(session, m_session) &&
+                Object.ReferenceEquals(subscription, m_subscription) &&
+                (subscription != null || subscriptions == null || m_attached.Count == subscriptions.Count))
             {
                 return;
             }
 
-            // subscription to event notifications.
-            if (!Object.ReferenceEquals(session, m_session))
-            {
-                if (m_session != null)
-                {
-                    m_session.Notification -= m_SessionNotification;
-                }
-
-                if (session != null)
-                {
-                    session.Notification += m_SessionNotification;
-                }
-            }
+            // stop receiving notifications from the previous subscriptions.
+            Detach();
 
             Clear();
 
             m_session = session;
             m_subscription = subscription;
-            Telemetry = m_subscription?.Session?.MessageContext?.Telemetry;
+            Telemetry = session?.MessageContext?.Telemetry;
 
             // nothing to do if no session provided.
             if (m_session == null)
@@ -137,31 +142,18 @@ namespace Opc.Ua.Sample.Controls
                 return;
             }
 
-            List<ItemData> tags = new List<ItemData>();
-
-            // display only items for current subscription.
+            // display only messages for the current subscription, or for all of them.
             if (subscription != null)
             {
-                foreach (NotificationMessage item in subscription.Notifications)
-                {
-                    tags.Insert(0, new ItemData(subscription, item));
-                }
+                Attach(subscription);
             }
-
-            // display all notifications for all subscriptions.
-            else
+            else if (subscriptions != null)
             {
-                foreach (Subscription item1 in m_session.Subscriptions)
+                foreach (SubscriptionHandle handle in subscriptions)
                 {
-                    foreach (NotificationMessage item2 in item1.Notifications)
-                    {
-                        tags.Insert(0, new ItemData(item1, item2));
-                    }
+                    Attach(handle);
                 }
             }
-
-            // update control.
-            Update(tags);
         }
         #endregion
 
@@ -173,16 +165,28 @@ namespace Opc.Ua.Sample.Controls
         public class ItemData
         {
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1051:Do not declare visible instance fields", Justification = "Sample code preserves existing public API and behavior.")]
-            public Subscription Subscription;
+            public SubscriptionHandle Subscription;
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1051:Do not declare visible instance fields", Justification = "Sample code preserves existing public API and behavior.")]
-            public NotificationMessage NotificationMessage;
+            public uint SequenceNumber;
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1051:Do not declare visible instance fields", Justification = "Sample code preserves existing public API and behavior.")]
+            public DateTime PublishTime;
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1051:Do not declare visible instance fields", Justification = "Sample code preserves existing public API and behavior.")]
+            public int DataChanges;
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1051:Do not declare visible instance fields", Justification = "Sample code preserves existing public API and behavior.")]
+            public int Events;
 
             public ItemData(
-                Subscription subscription,
-                NotificationMessage notificationMessage)
+                SubscriptionHandle subscription,
+                uint sequenceNumber,
+                DateTime publishTime,
+                int dataChanges,
+                int events)
             {
                 Subscription = subscription;
-                NotificationMessage = notificationMessage;
+                SequenceNumber = sequenceNumber;
+                PublishTime = publishTime;
+                DataChanges = dataChanges;
+                Events = events;
             }
         }
         #endregion
@@ -195,7 +199,9 @@ namespace Opc.Ua.Sample.Controls
             {
                 OptionsMI.Enabled = true;
                 ClearMI.Enabled = true;
-                RepublishMI.Enabled = m_subscription != null;
+
+                // the V2 engine republishes missed messages on its own.
+                RepublishMI.Enabled = false;
 
                 if (clickedItem != null)
                 {
@@ -222,92 +228,94 @@ namespace Opc.Ua.Sample.Controls
             }
 
             listItem.SubItems[0].Text = String.Format("{0}", itemData.Subscription.DisplayName);
-            listItem.SubItems[1].Text = String.Format("{0}", itemData.NotificationMessage.SequenceNumber);
-            listItem.SubItems[2].Text = String.Format("{0:HH:mm:ss.fff}", itemData.NotificationMessage.PublishTime.ToLocalTime());
-
-            int events = 0;
-            int datachanges = 0;
-            int notifications = 0;
-
-            foreach (ExtensionObject notification in itemData.NotificationMessage.NotificationData)
-            {
-                notifications++;
-
-                if ((notification).IsNull)
-                {
-                    continue;
-                }
-
-                DataChangeNotification datachangeNotification = notification.TryGetValue<DataChangeNotification>(out var dataChangeValue, ServiceMessageContext.CreateEmpty(null)) ? dataChangeValue : null;
-
-                if (datachangeNotification != null)
-                {
-                    datachanges += datachangeNotification.MonitoredItems.Count;
-                }
-
-                EventNotificationList EventNotification = notification.TryGetValue<EventNotificationList>(out var eventValue, ServiceMessageContext.CreateEmpty(null)) ? eventValue : null;
-
-                if (EventNotification != null)
-                {
-                    events += EventNotification.Events.Count;
-                }
-            }
-
-            listItem.SubItems[3].Text = String.Format("{0}", notifications);
-            listItem.SubItems[4].Text = String.Format("{0}", datachanges);
-            listItem.SubItems[5].Text = String.Format("{0}", events);
+            listItem.SubItems[1].Text = String.Format("{0}", itemData.SequenceNumber);
+            listItem.SubItems[2].Text = String.Format("{0:HH:mm:ss.fff}", itemData.PublishTime.ToLocalTime());
+            listItem.SubItems[3].Text = String.Format("{0}", itemData.DataChanges);
+            listItem.SubItems[4].Text = String.Format("{0}", itemData.Events);
 
             listItem.Tag = item;
         }
         #endregion
 
-        private void Update(List<ItemData> tags)
+        #region Private Methods
+        /// <summary>
+        /// Starts receiving the notifications of a subscription.
+        /// </summary>
+        private void Attach(SubscriptionHandle subscription)
         {
-            if (tags.Count > MaxMessageCount)
-            {
-                tags.RemoveRange(MaxMessageCount, tags.Count - MaxMessageCount);
-            }
-
-            BeginUpdate();
-
-            foreach (ItemData tag in tags)
-            {
-                AddItem(tag);
-            }
-
-            EndUpdate();
+            subscription.Callbacks.DataChangeCallback += m_DataChangeCallback;
+            subscription.Callbacks.EventCallback += m_EventCallback;
+            subscription.Callbacks.KeepAliveCallback += m_KeepAliveCallback;
+            m_attached.Add(subscription);
         }
 
-        private void Session_Notification(ISession sender, NotificationEventArgs e)
+        /// <summary>
+        /// Stops receiving the notifications of the attached subscriptions.
+        /// </summary>
+        private void Detach()
+        {
+            foreach (SubscriptionHandle subscription in m_attached)
+            {
+                subscription.Callbacks.DataChangeCallback -= m_DataChangeCallback;
+                subscription.Callbacks.EventCallback -= m_EventCallback;
+                subscription.Callbacks.KeepAliveCallback -= m_KeepAliveCallback;
+            }
+
+            m_attached.Clear();
+        }
+
+        /// <summary>
+        /// Adds a message to the list and trims it to the maximum count.
+        /// </summary>
+        private void AddMessage(ItemData itemData)
+        {
+            if (!IsHandleCreated)
+            {
+                return;
+            }
+
+            AddItem(itemData);
+
+            if (ItemsLV.Items.Count > MaxMessageCount)
+            {
+                for (int i = 0; i < (ItemsLV.Items.Count - MaxMessageCount); i++)
+                {
+                    ItemsLV.Items.RemoveAt(i);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Finds the handle for a subscription of the V2 engine.
+        /// </summary>
+        private SubscriptionHandle FindSubscription(ISubscription subscription)
+        {
+            foreach (SubscriptionHandle handle in m_attached)
+            {
+                if (Object.ReferenceEquals(handle.Subscription, subscription))
+                {
+                    return handle;
+                }
+            }
+
+            return null;
+        }
+
+        private void OnDataChangeNotification(ISubscription subscription, uint sequenceNumber, DateTime publishTime, DataValueChange[] notifications, PublishState publishStateMask)
         {
             if (InvokeRequired)
             {
-                BeginInvoke(m_SessionNotification, sender, e);
-                return;
-            }
-            else if (!IsHandleCreated)
-            {
+                BeginInvoke(m_DataChangeCallback, subscription, sequenceNumber, publishTime, notifications, publishStateMask);
                 return;
             }
 
             try
             {
-                if (m_subscription != null)
-                {
-                    if (!Object.ReferenceEquals(m_subscription, e.Subscription))
-                    {
-                        return;
-                    }
-                }
+                SubscriptionHandle handle = FindSubscription(subscription);
 
-                AddItem(new ItemData(e.Subscription, e.NotificationMessage));
-
-                if (ItemsLV.Items.Count > MaxMessageCount)
+                if (handle != null)
                 {
-                    for (int i = 0; i < (ItemsLV.Items.Count - MaxMessageCount); i++)
-                    {
-                        ItemsLV.Items.RemoveAt(i);
-                    }
+                    AddMessage(new ItemData(handle, sequenceNumber, publishTime, notifications.Length, 0));
                 }
             }
             catch (Exception exception)
@@ -315,6 +323,53 @@ namespace Opc.Ua.Sample.Controls
                 GuiUtils.HandleException(Telemetry, this.Text, MethodBase.GetCurrentMethod(), exception);
             }
         }
+
+        private void OnEventNotification(ISubscription subscription, uint sequenceNumber, DateTime publishTime, EventNotification[] notifications, PublishState publishStateMask)
+        {
+            if (InvokeRequired)
+            {
+                BeginInvoke(m_EventCallback, subscription, sequenceNumber, publishTime, notifications, publishStateMask);
+                return;
+            }
+
+            try
+            {
+                SubscriptionHandle handle = FindSubscription(subscription);
+
+                if (handle != null)
+                {
+                    AddMessage(new ItemData(handle, sequenceNumber, publishTime, 0, notifications.Length));
+                }
+            }
+            catch (Exception exception)
+            {
+                GuiUtils.HandleException(Telemetry, this.Text, MethodBase.GetCurrentMethod(), exception);
+            }
+        }
+
+        private void OnKeepAliveNotification(ISubscription subscription, uint sequenceNumber, DateTime publishTime, PublishState publishStateMask)
+        {
+            if (InvokeRequired)
+            {
+                BeginInvoke(m_KeepAliveCallback, subscription, sequenceNumber, publishTime, publishStateMask);
+                return;
+            }
+
+            try
+            {
+                SubscriptionHandle handle = FindSubscription(subscription);
+
+                if (handle != null)
+                {
+                    AddMessage(new ItemData(handle, sequenceNumber, publishTime, 0, 0));
+                }
+            }
+            catch (Exception exception)
+            {
+                GuiUtils.HandleException(Telemetry, this.Text, MethodBase.GetCurrentMethod(), exception);
+            }
+        }
+        #endregion
 
         private void ViewMI_Click(object sender, EventArgs e)
         {
@@ -356,27 +411,8 @@ namespace Opc.Ua.Sample.Controls
 
         private void RepublishMI_Click(object sender, EventArgs e)
         {
-            try
-            {
-                if (m_subscription == null)
-                {
-                    return;
-                }
-
-                #pragma warning disable CA2000 // Justification: Sample code retains existing ownership/lifetime and behavior.
-                NotificationMessage message = new RepublishNotificationMessageDlg().ShowDialog(m_subscription);
-                #pragma warning restore CA2000
-
-                if (message != null)
-                {
-                    ListViewItem listItem = AddItem(new ItemData(m_subscription, message));
-                    listItem.ForeColor = Color.Red;
-                }
-            }
-            catch (Exception exception)
-            {
-                GuiUtils.HandleException(Telemetry, this.Text, MethodBase.GetCurrentMethod(), exception);
-            }
+            // the V2 engine republishes missed messages on its own, so there is nothing left
+            // to trigger by hand.
         }
     }
 }

--- a/Samples/Controls.Net4/Subscriptions/ReadDlg.cs
+++ b/Samples/Controls.Net4/Subscriptions/ReadDlg.cs
@@ -55,14 +55,14 @@ namespace Opc.Ua.Sample.Controls
         #endregion
 
         #region Private Fields
-        private Session m_session;
+        private ISession m_session;
         #endregion
 
         #region Public Interface
         /// <summary>
         /// Displays the dialog.
         /// </summary>
-        public async Task ShowAsync(Session session, IList<ReadValueId> valueIds, ITelemetryContext telemetry, CancellationToken ct = default)
+        public async Task ShowAsync(ISession session, IList<ReadValueId> valueIds, ITelemetryContext telemetry, CancellationToken ct = default)
         {
             if (session == null) throw new ArgumentNullException(nameof(session));
 

--- a/Samples/Controls.Net4/Subscriptions/ReadValueEditDlg.cs
+++ b/Samples/Controls.Net4/Subscriptions/ReadValueEditDlg.cs
@@ -56,7 +56,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Prompts the user to specify the browse options.
         /// </summary>
-        public async Task<bool> ShowDialogAsync(Session session, ReadValueId valueId, ITelemetryContext telemetry, CancellationToken ct = default)
+        public async Task<bool> ShowDialogAsync(ISession session, ReadValueId valueId, ITelemetryContext telemetry, CancellationToken ct = default)
         {
             if (session == null) throw new ArgumentNullException(nameof(session));
             if (valueId == null) throw new ArgumentNullException(nameof(valueId));

--- a/Samples/Controls.Net4/Subscriptions/ReadValueListCtrl.cs
+++ b/Samples/Controls.Net4/Subscriptions/ReadValueListCtrl.cs
@@ -51,7 +51,7 @@ namespace Opc.Ua.Sample.Controls
         }
 
         #region Private Fields
-        private Session m_session;
+        private ISession m_session;
 
         /// <summary>
 		/// The columns to display in the control.
@@ -79,7 +79,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Sets the nodes in the control.
         /// </summary>
-        public void Initialize(Session session, IList<ReadValueId> valueIds, ITelemetryContext telemetry)
+        public void Initialize(ISession session, IList<ReadValueId> valueIds, ITelemetryContext telemetry)
         {
             if (session == null) throw new ArgumentNullException(nameof(session));
 

--- a/Samples/Controls.Net4/Subscriptions/SelectClauseListCtrl.cs
+++ b/Samples/Controls.Net4/Subscriptions/SelectClauseListCtrl.cs
@@ -51,7 +51,7 @@ namespace Opc.Ua.Sample.Controls
         }
 
         #region Private Fields
-        private Session m_session;
+        private ISession m_session;
         private IList<SimpleAttributeOperand> m_selectClauses;
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Sets the nodes in the control.
         /// </summary>
-        public void Initialize(Session session, IList<SimpleAttributeOperand> selectClauses)
+        public void Initialize(ISession session, IList<SimpleAttributeOperand> selectClauses)
         {
             if (session == null) throw new ArgumentNullException(nameof(session));
 

--- a/Samples/Controls.Net4/Subscriptions/SubscriptionDlg.cs
+++ b/Samples/Controls.Net4/Subscriptions/SubscriptionDlg.cs
@@ -38,80 +38,77 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-using Microsoft.Extensions.Logging;
 using Opc.Ua.Client;
 using Opc.Ua.Client.Controls;
+using Opc.Ua.Client.Subscriptions;
 
 namespace Opc.Ua.Sample.Controls
 {
+    // the V2 subscription engine reuses names the classic engine already has in the
+    // Opc.Ua.Client namespace this file imports, so the V2 types are pinned explicitly.
+    using SubscriptionState = Opc.Ua.Client.Subscriptions.SubscriptionState;
+
     public partial class SubscriptionDlg : Form
     {
+        /// <summary>
+        /// How long the dialog waits for the subscription engine to apply changes.
+        /// </summary>
+        private static readonly TimeSpan kApplyTimeout = TimeSpan.FromSeconds(10);
+
         #region Constructors
         public SubscriptionDlg()
         {
             InitializeComponent();
             this.Icon = ClientUtils.GetAppIcon();
 
-            m_SessionNotification = new NotificationEventHandler(Session_NotificationAsync);
-            m_SubscriptionStateChanged = new SubscriptionStateChangedEventHandler(Subscription_StateChanged);
-            m_PublishStatusChanged = new PublishStateChangedEventHandler(Subscription_PublishStatusChangedAsync);
+            m_DataChangeCallback = new Action<ISubscription, uint, DateTime, DataValueChange[], PublishState>(OnDataChangeNotification);
+            m_EventCallback = new Action<ISubscription, uint, DateTime, EventNotification[], PublishState>(OnEventNotification);
+            m_KeepAliveCallback = new Action<ISubscription, uint, DateTime, PublishState>(OnKeepAliveNotification);
+            m_StateChangedCallback = new Action<ISubscription, SubscriptionState, PublishState>(OnSubscriptionStateChanged);
         }
         #endregion
 
         #region Private Fields
         private ITelemetryContext m_telemetry;
-        private ILogger m_logger;
-        private Subscription m_subscription;
-        private NotificationEventHandler m_SessionNotification;
-        private SubscriptionStateChangedEventHandler m_SubscriptionStateChanged;
+        private SubscriptionHandle m_subscription;
+        private readonly Action<ISubscription, uint, DateTime, DataValueChange[], PublishState> m_DataChangeCallback;
+        private readonly Action<ISubscription, uint, DateTime, EventNotification[], PublishState> m_EventCallback;
+        private readonly Action<ISubscription, uint, DateTime, PublishState> m_KeepAliveCallback;
+        private readonly Action<ISubscription, SubscriptionState, PublishState> m_StateChangedCallback;
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA2213:Disposable fields should be disposed", Justification = "Sample code preserves existing public API and behavior.")]
         private CreateMonitoredItemsDlg m_createDialog;
-        private PublishStateChangedEventHandler m_PublishStatusChanged;
+        private uint m_lastSequenceNumber;
+        private DateTime m_lastPublishTime;
+        private static uint m_Counter = 0;
         #endregion
 
         #region Public Interface
         /// <summary>
-        /// Creates a new subscription.
+        /// Creates a new subscription with the V2 subscription engine of the session.
         /// </summary>
-        public async Task<Subscription> NewAsync(Session session, ITelemetryContext telemetry, CancellationToken ct = default)
+        public SubscriptionHandle New(ISession session, ITelemetryContext telemetry)
         {
             if (session == null) throw new ArgumentNullException(nameof(session));
 
             m_telemetry = telemetry;
-            m_logger = telemetry.CreateLogger<SubscriptionDlg>();
+
+            SubscriptionHandle subscription = new SubscriptionHandle(
+                session,
+                Utils.Format("Subscription {0}", Utils.IncrementIdentifier(ref m_Counter)),
+                ClientUtils.DefaultSubscriptionOptions);
 
             #pragma warning disable CA2000 // Justification: Sample code retains existing ownership/lifetime and behavior.
-            Subscription subscription = new Subscription(session.DefaultSubscription);
-            #pragma warning restore CA2000
-
-            #pragma warning disable CA2000 // Justification: Sample code retains existing ownership/lifetime and behavior.
-            if (!await new SubscriptionEditDlg().ShowDialogAsync(subscription, ct))
+            if (!new SubscriptionEditDlg().ShowDialog(subscription))
             #pragma warning restore CA2000
             {
                 return null;
             }
 
-            session.AddSubscription(subscription);
-            await subscription.CreateAsync(ct);
+            // registering the subscription is the request, the engine creates it on the
+            // server from its own worker.
+            subscription.Create();
 
-            Subscription duplicateSubscription = session.Subscriptions.FirstOrDefault(s => s.Id != 0 && s.Id.Equals(subscription.Id) && s != subscription);
-            if (duplicateSubscription != null)
-            {
-                m_logger.LogWarning("Duplicate subscription was created with the id: {SubscriptionId}", duplicateSubscription.Id);
-
-                DialogResult result = MessageBox.Show("Duplicate subscription was created with the id: " + duplicateSubscription.Id + ". Do you want to keep it?", "Warning", MessageBoxButtons.YesNo);
-                if (result == System.Windows.Forms.DialogResult.No)
-                {
-                    await duplicateSubscription.DeleteAsync(false, ct);
-                    await session.RemoveSubscriptionAsync(subscription, ct);
-
-                    return null;
-                }
-            }
-
-            #pragma warning disable CA1849 // Justification: Sample code retains existing ownership/lifetime and behavior.
             Show(subscription);
-            #pragma warning restore CA1849
 
             return subscription;
         }
@@ -119,36 +116,32 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Displays the dialog.
         /// </summary>
-        public void Show(Subscription subscription)
+        public void Show(SubscriptionHandle subscription)
         {
             if (subscription == null) throw new ArgumentNullException(nameof(subscription));
+
+            if (m_telemetry == null)
+            {
+                m_telemetry = subscription.Session?.MessageContext?.Telemetry;
+            }
 
             Show();
             BringToFront();
 
-            // remove previous subscription.
-            if (m_subscription != null)
-            {
-                m_subscription.StateChanged -= m_SubscriptionStateChanged;
-                m_subscription.PublishStatusChanged -= m_PublishStatusChanged;
-                m_subscription.Session.Notification -= m_SessionNotification;
-            }
+            // stop receiving notifications from the previous subscription.
+            Detach();
 
             // start receiving notifications from the new subscription.
             m_subscription = subscription;
 
-            #pragma warning disable CA1508 // Justification: Sample code retains existing ownership/lifetime and behavior.
-            if (subscription != null)
-            #pragma warning restore CA1508
-            {
-                m_subscription.StateChanged += m_SubscriptionStateChanged;
-                m_subscription.PublishStatusChanged += m_PublishStatusChanged;
-                m_subscription.Session.Notification += m_SessionNotification;
-            }
+            subscription.Callbacks.DataChangeCallback += m_DataChangeCallback;
+            subscription.Callbacks.EventCallback += m_EventCallback;
+            subscription.Callbacks.KeepAliveCallback += m_KeepAliveCallback;
+            subscription.Callbacks.StateChangedCallback += m_StateChangedCallback;
 
             MonitoredItemsCTRL.Initialize(subscription, m_telemetry);
             EventsCTRL.Initialize(subscription, null);
-            DataChangesCTRL.InitializeAsync(subscription, null);
+            DataChangesCTRL.Initialize(subscription, null);
 
             WindowMI_Click(WindowDataChangesMI, null);
 
@@ -158,52 +151,61 @@ namespace Opc.Ua.Sample.Controls
 
         #region Private Methods
         /// <summary>
+        /// Stops receiving notifications from the current subscription.
+        /// </summary>
+        private void Detach()
+        {
+            if (m_subscription != null)
+            {
+                m_subscription.Callbacks.DataChangeCallback -= m_DataChangeCallback;
+                m_subscription.Callbacks.EventCallback -= m_EventCallback;
+                m_subscription.Callbacks.KeepAliveCallback -= m_KeepAliveCallback;
+                m_subscription.Callbacks.StateChangedCallback -= m_StateChangedCallback;
+            }
+        }
+
+        /// <summary>
         /// Updates the controls displaying the status of the subscription.
         /// </summary>
         private void UpdateStatus()
         {
-            NotificationMessage message = null;
-
-            if (m_subscription != null)
-            {
-                message = m_subscription.LastNotification;
-            }
-
             PublishingEnabledTB.Text = String.Empty;
 
             if (m_subscription != null)
             {
-                PublishingEnabledTB.Text = (m_subscription.CurrentPublishingEnabled) ? "Enabled" : "Disabled";
+                bool publishingEnabled = (m_subscription.Subscription != null)
+                    ? m_subscription.Subscription.CurrentPublishingEnabled
+                    : m_subscription.Settings.PublishingEnabled;
+
+                PublishingEnabledTB.Text = (publishingEnabled) ? "Enabled" : "Disabled";
             }
 
             LastUpdateTimeTB.Text = String.Empty;
-
-            if (message != null)
-            {
-                LastUpdateTimeTB.Text = String.Format("{0:HH:mm:ss}", message.PublishTime.ToLocalTime());
-            }
-
             LastMessageIdTB.Text = String.Empty;
 
-            if (message != null)
+            if (m_lastPublishTime != DateTime.MinValue)
             {
-                LastMessageIdTB.Text = String.Format("{0}", message.SequenceNumber);
+                LastUpdateTimeTB.Text = String.Format("{0:HH:mm:ss}", m_lastPublishTime.ToLocalTime());
+                LastMessageIdTB.Text = String.Format("{0}", m_lastSequenceNumber);
             }
 
             // determine what window to show.
             bool hasEvents = false;
             bool hasDatachanges = false;
 
-            foreach (MonitoredItem monitoredItem in m_subscription.MonitoredItems)
+            if (m_subscription != null)
             {
-                if (monitoredItem.Filter is EventFilter)
+                foreach (MonitoredItemHandle monitoredItem in m_subscription.Items)
                 {
-                    hasEvents = true;
-                }
+                    if (monitoredItem.Settings.Filter is EventFilter)
+                    {
+                        hasEvents = true;
+                    }
 
-                if (monitoredItem.NodeClass == NodeClass.Variable)
-                {
-                    hasDatachanges = true;
+                    if (monitoredItem.NodeClass == NodeClass.Variable)
+                    {
+                        hasDatachanges = true;
+                    }
                 }
             }
 
@@ -227,13 +229,13 @@ namespace Opc.Ua.Sample.Controls
 
         #region Event Handlers
         /// <summary>
-        /// Processes a Publish repsonse from the server.
+        /// Processes the data changes of a publish response from the server.
         /// </summary>
-        private async void Session_NotificationAsync(ISession session, NotificationEventArgs e)
+        private async void OnDataChangeNotification(ISubscription subscription, uint sequenceNumber, DateTime publishTime, DataValueChange[] notifications, PublishState publishStateMask)
         {
             if (InvokeRequired)
             {
-                BeginInvoke(m_SessionNotification, session, e);
+                BeginInvoke(m_DataChangeCallback, subscription, sequenceNumber, publishTime, notifications, publishStateMask);
                 return;
             }
             else if (!IsHandleCreated)
@@ -244,14 +246,16 @@ namespace Opc.Ua.Sample.Controls
             try
             {
                 // ignore notifications for other subscriptions.
-                if (!Object.ReferenceEquals(m_subscription, e.Subscription))
+                if (m_subscription == null || !Object.ReferenceEquals(m_subscription.Subscription, subscription))
                 {
                     return;
                 }
 
+                m_lastSequenceNumber = sequenceNumber;
+                m_lastPublishTime = publishTime;
+
                 // notify controls of the change.
-                EventsCTRL.NotificationReceived(e);
-                await DataChangesCTRL.NotificationReceivedAsync(e);
+                await DataChangesCTRL.NotificationReceivedAsync(notifications, publishStateMask);
 
                 // update subscription status.
                 UpdateStatus();
@@ -263,13 +267,13 @@ namespace Opc.Ua.Sample.Controls
         }
 
         /// <summary>
-        /// Handles a change to the state of the subscription.
+        /// Processes the events of a publish response from the server.
         /// </summary>
-        private void Subscription_StateChanged(Subscription subscription, SubscriptionStateChangedEventArgs e)
+        private void OnEventNotification(ISubscription subscription, uint sequenceNumber, DateTime publishTime, EventNotification[] notifications, PublishState publishStateMask)
         {
             if (InvokeRequired)
             {
-                BeginInvoke(m_SubscriptionStateChanged, subscription, e);
+                BeginInvoke(m_EventCallback, subscription, sequenceNumber, publishTime, notifications, publishStateMask);
                 return;
             }
             else if (!IsHandleCreated)
@@ -280,15 +284,16 @@ namespace Opc.Ua.Sample.Controls
             try
             {
                 // ignore notifications for other subscriptions.
-                if (!Object.ReferenceEquals(m_subscription, subscription))
+                if (m_subscription == null || !Object.ReferenceEquals(m_subscription.Subscription, subscription))
                 {
                     return;
                 }
 
+                m_lastSequenceNumber = sequenceNumber;
+                m_lastPublishTime = publishTime;
+
                 // notify controls of the change.
-                EventsCTRL.SubscriptionChanged(e);
-                DataChangesCTRL.SubscriptionChanged(e);
-                MonitoredItemsCTRL.SubscriptionChanged(e);
+                EventsCTRL.NotificationReceived(notifications);
 
                 // update subscription status.
                 UpdateStatus();
@@ -300,13 +305,13 @@ namespace Opc.Ua.Sample.Controls
         }
 
         /// <summary>
-        /// Handles a change to the publish status for the subscription.
+        /// Processes a keep alive notification from the server.
         /// </summary>
-        private async void Subscription_PublishStatusChangedAsync(object subscription, EventArgs e)
+        private void OnKeepAliveNotification(ISubscription subscription, uint sequenceNumber, DateTime publishTime, PublishState publishStateMask)
         {
             if (InvokeRequired)
             {
-                BeginInvoke(m_PublishStatusChanged, subscription, e);
+                BeginInvoke(m_KeepAliveCallback, subscription, sequenceNumber, publishTime, publishStateMask);
                 return;
             }
             else if (!IsHandleCreated)
@@ -317,13 +322,53 @@ namespace Opc.Ua.Sample.Controls
             try
             {
                 // ignore notifications for other subscriptions.
-                if (!Object.ReferenceEquals(m_subscription, subscription))
+                if (m_subscription == null || !Object.ReferenceEquals(m_subscription.Subscription, subscription))
+                {
+                    return;
+                }
+
+                m_lastSequenceNumber = sequenceNumber;
+                m_lastPublishTime = publishTime;
+
+                UpdateStatus();
+            }
+            catch (Exception exception)
+            {
+                GuiUtils.HandleException(m_telemetry, this.Text, MethodBase.GetCurrentMethod(), exception);
+            }
+        }
+
+        /// <summary>
+        /// Handles a change to the state of the subscription, which is also what reports that
+        /// the engine finished applying changes.
+        /// </summary>
+        private void OnSubscriptionStateChanged(ISubscription subscription, SubscriptionState state, PublishState publishStateMask)
+        {
+            if (InvokeRequired)
+            {
+                BeginInvoke(m_StateChangedCallback, subscription, state, publishStateMask);
+                return;
+            }
+            else if (!IsHandleCreated)
+            {
+                return;
+            }
+
+            try
+            {
+                // ignore notifications for other subscriptions.
+                if (m_subscription == null || !Object.ReferenceEquals(m_subscription.Subscription, subscription))
                 {
                     return;
                 }
 
                 // notify controls of the change.
-                await DataChangesCTRL.PublishStatusChangedAsync();
+                EventsCTRL.SubscriptionChanged();
+                DataChangesCTRL.SubscriptionChanged();
+                MonitoredItemsCTRL.SubscriptionChanged();
+
+                // update subscription status.
+                UpdateStatus();
             }
             catch (Exception exception)
             {
@@ -335,7 +380,9 @@ namespace Opc.Ua.Sample.Controls
         {
             try
             {
-                SubscriptionEnablePublishingMI.Checked = m_subscription.CurrentPublishingEnabled;
+                SubscriptionEnablePublishingMI.Checked = (m_subscription.Subscription != null)
+                    ? m_subscription.Subscription.CurrentPublishingEnabled
+                    : m_subscription.Settings.PublishingEnabled;
             }
             catch (Exception exception)
             {
@@ -387,7 +434,12 @@ namespace Opc.Ua.Sample.Controls
         {
             try
             {
-                await m_subscription.SetPublishingModeAsync(SubscriptionEnablePublishingMI.Checked);
+                // reconfiguring the options is the request, the engine applies it on its own
+                // worker.
+                bool enabled = SubscriptionEnablePublishingMI.Checked;
+                m_subscription.Configure(options => options with { PublishingEnabled = enabled });
+                await m_subscription.WaitForPendingChangesAsync(kApplyTimeout);
+                UpdateStatus();
             }
             catch (Exception exception)
             {
@@ -405,6 +457,8 @@ namespace Opc.Ua.Sample.Controls
                 }
 
                 MonitoredItemsCTRL.FormClosing();
+
+                Detach();
             }
             catch (Exception exception)
             {
@@ -417,13 +471,16 @@ namespace Opc.Ua.Sample.Controls
             try
             {
                 #pragma warning disable CA2000 // Justification: Sample code retains existing ownership/lifetime and behavior.
-                if (!await new SubscriptionEditDlg().ShowDialogAsync(m_subscription))
+                if (!new SubscriptionEditDlg().ShowDialog(m_subscription))
                 #pragma warning restore CA2000
                 {
                     return;
                 }
 
-                await m_subscription.ModifyAsync();
+                // the engine applies the new options on its own worker, the state changed
+                // callback refreshes the display once it did.
+                await m_subscription.WaitForPendingChangesAsync(kApplyTimeout);
+                UpdateStatus();
             }
             catch (Exception exception)
             {
@@ -486,7 +543,10 @@ namespace Opc.Ua.Sample.Controls
         {
             try
             {
-                await m_subscription.ConditionRefreshAsync();
+                if (m_subscription.Subscription != null)
+                {
+                    await m_subscription.Subscription.ConditionRefreshAsync(CancellationToken.None);
+                }
             }
             catch (Exception exception)
             {

--- a/Samples/Controls.Net4/Subscriptions/SubscriptionEditDlg.cs
+++ b/Samples/Controls.Net4/Subscriptions/SubscriptionEditDlg.cs
@@ -38,9 +38,14 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using Opc.Ua.Client;
+using Opc.Ua.Client.Subscriptions;
 
 namespace Opc.Ua.Sample.Controls
 {
+    // the V2 subscription engine reuses names the classic engine already has in the
+    // Opc.Ua.Client namespace this file imports, so the V2 types are pinned explicitly.
+    using SubscriptionOptions = Opc.Ua.Client.Subscriptions.SubscriptionOptions;
+
     public partial class SubscriptionEditDlg : Form
     {
         public SubscriptionEditDlg()
@@ -49,19 +54,27 @@ namespace Opc.Ua.Sample.Controls
         }
 
         /// <summary>
-        /// Prompts the user to specify the browse options.
+        /// Prompts the user to specify the subscription parameters.
         /// </summary>
-        public async Task<bool> ShowDialogAsync(Subscription subscription, CancellationToken ct = default)
+        /// <remarks>
+        /// Reconfiguring the options monitor of the handle is the modify request: for a
+        /// subscription which already exists the V2 engine applies the new settings on its own
+        /// worker, and for one which does not it uses them when it is created.
+        /// </remarks>
+        public bool ShowDialog(SubscriptionHandle subscription)
         {
             if (subscription == null) throw new ArgumentNullException(nameof(subscription));
 
+            ISubscription created = subscription.Created ? subscription.Subscription : null;
+            SubscriptionOptions options = subscription.Settings;
+
             DisplayNameTB.Text = subscription.DisplayName;
-            PublishingIntervalNC.Value = subscription.Created ? (decimal)subscription.CurrentPublishingInterval : (decimal)subscription.PublishingInterval;
-            KeepAliveCountNC.Value = subscription.Created ? subscription.CurrentKeepAliveCount : subscription.KeepAliveCount;
-            LifetimeCountCTRL.Value = subscription.Created ? subscription.CurrentLifetimeCount : subscription.LifetimeCount;
-            MaxNotificationsCTRL.Value = subscription.MaxNotificationsPerPublish;
-            PriorityNC.Value = subscription.Created ? subscription.CurrentPriority : subscription.Priority;
-            PublishingEnabledCK.Checked = subscription.Created ? subscription.CurrentPublishingEnabled : subscription.PublishingEnabled;
+            PublishingIntervalNC.Value = (decimal)((created != null) ? created.CurrentPublishingInterval : options.PublishingInterval).TotalMilliseconds;
+            KeepAliveCountNC.Value = (created != null) ? created.CurrentKeepAliveCount : options.KeepAliveCount;
+            LifetimeCountCTRL.Value = (created != null) ? created.CurrentLifetimeCount : options.LifetimeCount;
+            MaxNotificationsCTRL.Value = (created != null) ? created.CurrentMaxNotificationsPerPublish : options.MaxNotificationsPerPublish;
+            PriorityNC.Value = (created != null) ? created.CurrentPriority : options.Priority;
+            PublishingEnabledCK.Checked = (created != null) ? created.CurrentPublishingEnabled : options.PublishingEnabled;
 
             if (ShowDialog() != DialogResult.OK)
             {
@@ -69,19 +82,23 @@ namespace Opc.Ua.Sample.Controls
             }
 
             subscription.DisplayName = DisplayNameTB.Text;
-            subscription.PublishingInterval = (int)PublishingIntervalNC.Value;
-            subscription.KeepAliveCount = (uint)KeepAliveCountNC.Value;
-            subscription.LifetimeCount = (uint)LifetimeCountCTRL.Value;
-            subscription.MaxNotificationsPerPublish = (uint)MaxNotificationsCTRL.Value;
-            subscription.Priority = (byte)PriorityNC.Value;
-            if (subscription.Created)
-            {
-                await subscription.SetPublishingModeAsync(PublishingEnabledCK.Checked, ct);
-            }
-            else
-            {
-                subscription.PublishingEnabled = PublishingEnabledCK.Checked;
-            }
+
+            TimeSpan publishingInterval = TimeSpan.FromMilliseconds((double)PublishingIntervalNC.Value);
+            uint keepAliveCount = (uint)KeepAliveCountNC.Value;
+            uint lifetimeCount = (uint)LifetimeCountCTRL.Value;
+            uint maxNotifications = (uint)MaxNotificationsCTRL.Value;
+            byte priority = (byte)PriorityNC.Value;
+            bool publishingEnabled = PublishingEnabledCK.Checked;
+
+            subscription.Configure(current => current with {
+                PublishingInterval = publishingInterval,
+                KeepAliveCount = keepAliveCount,
+                LifetimeCount = lifetimeCount,
+                MaxNotificationsPerPublish = maxNotifications,
+                Priority = priority,
+                PublishingEnabled = publishingEnabled,
+            });
+
             return true;
         }
     }

--- a/Samples/Controls.Net4/Subscriptions/SubscriptionHandle.cs
+++ b/Samples/Controls.Net4/Subscriptions/SubscriptionHandle.cs
@@ -1,0 +1,364 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Opc.Ua.Client;
+using Opc.Ua.Client.Controls;
+using Opc.Ua.Client.Subscriptions;
+using Opc.Ua.Client.Subscriptions.MonitoredItems;
+
+namespace Opc.Ua.Sample.Controls
+{
+    // the V2 subscription engine reuses names the classic engine already has in the
+    // Opc.Ua.Client namespace this file imports, so the V2 types are pinned explicitly.
+    using MonitoredItemOptions = Opc.Ua.Client.Subscriptions.MonitoredItems.MonitoredItemOptions;
+    using SubscriptionOptions = Opc.Ua.Client.Subscriptions.SubscriptionOptions;
+
+    /// <summary>
+    /// Everything the sample controls keep about one subscription of the V2 engine.
+    /// </summary>
+    /// <remarks>
+    /// A V2 subscription does not point back at its session, carries no display name and takes
+    /// its notification handler when it is created, so the tree and the dialogs share this
+    /// handle instead of the subscription itself: it pairs the subscription with the session it
+    /// was created on, the options monitor which reconfigures it, the
+    /// <see cref="SubscriptionCallbacks"/> every interested control attaches its delegates to
+    /// and the <see cref="MonitoredItemHandle"/> bookkeeping of the items the controls added.
+    /// </remarks>
+    public sealed class SubscriptionHandle
+    {
+        private int m_nextItemId;
+
+        /// <summary>
+        /// Creates a handle for a subscription which has not been created on the server yet.
+        /// </summary>
+        /// <param name="session">The session the subscription belongs to.</param>
+        /// <param name="displayName">The name the controls display for the subscription.</param>
+        /// <param name="options">The options the subscription is created with.</param>
+        public SubscriptionHandle(ISession session, string displayName, SubscriptionOptions options)
+        {
+            Session = session ?? throw new ArgumentNullException(nameof(session));
+            DisplayName = displayName;
+            Options = new OptionsMonitor<SubscriptionOptions>(options ?? ClientUtils.DefaultSubscriptionOptions);
+            Callbacks = new SubscriptionCallbacks();
+            Items = new List<MonitoredItemHandle>();
+        }
+
+        /// <summary>
+        /// The session the subscription belongs to.
+        /// </summary>
+        public ISession Session { get; }
+
+        /// <summary>
+        /// The name the controls display for the subscription.
+        /// </summary>
+        public string DisplayName { get; set; }
+
+        /// <summary>
+        /// The settings of the subscription. Reconfiguring the monitor is what modifies the
+        /// subscription on the server.
+        /// </summary>
+        public OptionsMonitor<SubscriptionOptions> Options { get; }
+
+        /// <summary>
+        /// The current settings of the subscription.
+        /// </summary>
+        public SubscriptionOptions Settings => Options.CurrentValue;
+
+        /// <summary>
+        /// The handler the subscription is created with. Controls interested in the
+        /// notifications combine their delegates into its callbacks.
+        /// </summary>
+        public SubscriptionCallbacks Callbacks { get; }
+
+        /// <summary>
+        /// The subscription once it has been created, null before that.
+        /// </summary>
+        public ISubscription Subscription { get; private set; }
+
+        /// <summary>
+        /// The monitored items of the subscription the controls keep track of.
+        /// </summary>
+        public IList<MonitoredItemHandle> Items { get; }
+
+        /// <summary>
+        /// Whether the subscription exists on the server.
+        /// </summary>
+        public bool Created => Subscription != null && Subscription.Created;
+
+        /// <summary>
+        /// Creates the subscription on the session with the V2 subscription engine.
+        /// </summary>
+        public ISubscription Create()
+        {
+            if (Subscription == null)
+            {
+                Subscription = ClientUtils.AddSubscription(Session, Callbacks, Options);
+            }
+
+            return Subscription;
+        }
+
+        /// <summary>
+        /// Adopts a subscription which already runs in the engine, e.g. one restored from a
+        /// file. The engine holds the options of such a subscription and its items, so the
+        /// synthesized item handles only support display and removal, not reconfiguration.
+        /// </summary>
+        public void Attach(ISubscription subscription)
+        {
+            Subscription = subscription ?? throw new ArgumentNullException(nameof(subscription));
+
+            foreach (IMonitoredItem monitoredItem in subscription.MonitoredItems.Items)
+            {
+                Items.Add(new MonitoredItemHandle(monitoredItem.Name, new MonitoredItemOptions()) {
+                    DisplayName = monitoredItem.Name,
+                    Item = monitoredItem,
+                });
+            }
+        }
+
+        /// <summary>
+        /// Applies a change to the settings of the subscription.
+        /// </summary>
+        public void Configure(Func<SubscriptionOptions, SubscriptionOptions> configure)
+        {
+            Options.Configure(configure);
+        }
+
+        /// <summary>
+        /// Adds a monitored item to the subscription.
+        /// </summary>
+        /// <remarks>
+        /// Adding the item is the request: the engine creates it on the server from its own
+        /// worker, and <see cref="WaitForPendingChangesAsync"/> or the state changed callback
+        /// report when the revised values are available.
+        /// </remarks>
+        /// <param name="displayName">The name the controls display for the item.</param>
+        /// <param name="nodeClass">The node class of the monitored node.</param>
+        /// <param name="options">The settings the item is created with.</param>
+        public MonitoredItemHandle AddItem(string displayName, NodeClass nodeClass, MonitoredItemOptions options)
+        {
+            MonitoredItemHandle handle = StageItem(displayName, nodeClass, options);
+            Push(handle);
+            return handle;
+        }
+
+        /// <summary>
+        /// Registers a monitored item without handing it to the engine yet, so a wizard can
+        /// collect several items and add them in one step with <see cref="ApplyChanges"/>.
+        /// </summary>
+        public MonitoredItemHandle StageItem(string displayName, NodeClass nodeClass, MonitoredItemOptions options)
+        {
+            // the name has to be unique within the subscription, and an item which was just
+            // removed may not have been reaped yet, so every item gets its own name.
+            MonitoredItemHandle handle = new MonitoredItemHandle(Utils.Format("Item{0}", ++m_nextItemId), options) {
+                DisplayName = displayName,
+                NodeClass = nodeClass,
+            };
+
+            Items.Add(handle);
+            return handle;
+        }
+
+        /// <summary>
+        /// Hands the staged monitored items to the engine, which creates them on the server
+        /// from its own worker.
+        /// </summary>
+        public void ApplyChanges()
+        {
+            foreach (MonitoredItemHandle handle in Items)
+            {
+                Push(handle);
+            }
+        }
+
+        /// <summary>
+        /// Hands one monitored item to the engine unless it already has been.
+        /// </summary>
+        private void Push(MonitoredItemHandle handle)
+        {
+            if (Subscription != null && handle.Item == null)
+            {
+                Subscription.MonitoredItems.TryAdd(handle.Name, handle.Options, out IMonitoredItem item);
+                handle.Item = item;
+            }
+        }
+
+        /// <summary>
+        /// Removes a monitored item from the subscription.
+        /// </summary>
+        public bool RemoveItem(MonitoredItemHandle handle)
+        {
+            if (handle == null)
+            {
+                return false;
+            }
+
+            if (handle.Item != null && Subscription != null)
+            {
+                Subscription.MonitoredItems.TryRemove(handle.Item.ClientHandle);
+            }
+
+            return Items.Remove(handle);
+        }
+
+        /// <summary>
+        /// Finds the handle which owns the monitored item a notification came from.
+        /// </summary>
+        public MonitoredItemHandle FindItem(IMonitoredItem monitoredItem)
+        {
+            if (monitoredItem == null)
+            {
+                return null;
+            }
+
+            foreach (MonitoredItemHandle handle in Items)
+            {
+                if (Object.ReferenceEquals(handle.Item, monitoredItem))
+                {
+                    return handle;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Waits until the engine has applied the pending monitored item changes.
+        /// </summary>
+        public Task WaitForPendingChangesAsync(TimeSpan timeout, CancellationToken ct = default)
+        {
+            if (Subscription == null)
+            {
+                return Task.CompletedTask;
+            }
+
+            return ClientUtils.WaitForPendingChangesAsync(Subscription, timeout, ct);
+        }
+
+        /// <summary>
+        /// Deletes the subscription on the server and drops it from the subscription manager
+        /// of the session.
+        /// </summary>
+        public async Task DeleteAsync()
+        {
+            if (Subscription != null)
+            {
+                await Subscription.DisposeAsync();
+                Subscription = null;
+            }
+
+            Items.Clear();
+        }
+
+        /// <summary>
+        /// The event filter the sample subscribes event notifiers with, selecting the fields
+        /// of the base event type the dialogs display.
+        /// </summary>
+        /// <remarks>
+        /// The classic engine composed a default filter inside its MonitoredItem; the V2
+        /// engine takes the filter through the options the item is created with, so the
+        /// controls build it themselves. The first clause selects the node id of the event
+        /// source, matching the layout the <see cref="Opc.Ua.Client.Controls.FilterDeclaration"/>
+        /// helper produces.
+        /// </remarks>
+        public static EventFilter CreateDefaultEventFilter()
+        {
+            List<SimpleAttributeOperand> selectClauses = new List<SimpleAttributeOperand> {
+                new SimpleAttributeOperand {
+                    TypeDefinitionId = ObjectTypeIds.BaseEventType,
+                    AttributeId = Attributes.NodeId,
+                }
+            };
+
+            foreach (string browseName in new string[] {
+                Opc.Ua.BrowseNames.EventId,
+                Opc.Ua.BrowseNames.EventType,
+                Opc.Ua.BrowseNames.SourceNode,
+                Opc.Ua.BrowseNames.SourceName,
+                Opc.Ua.BrowseNames.Time,
+                Opc.Ua.BrowseNames.ReceiveTime,
+                Opc.Ua.BrowseNames.Message,
+                Opc.Ua.BrowseNames.Severity })
+            {
+                selectClauses.Add(new SimpleAttributeOperand {
+                    TypeDefinitionId = ObjectTypeIds.BaseEventType,
+                    AttributeId = Attributes.Value,
+                    BrowsePath = new QualifiedName[] { new QualifiedName(browseName) }.ToArrayOf(),
+                });
+            }
+
+            ContentFilter whereClause = new ContentFilter();
+            whereClause.Push(FilterOperator.OfType, ObjectTypeIds.BaseEventType);
+
+            return new EventFilter {
+                SelectClauses = selectClauses.ToArrayOf(),
+                WhereClause = whereClause,
+            };
+        }
+
+        /// <summary>
+        /// Returns the value of an event field selected by the filter the item was created
+        /// with, or null if the filter does not select the field.
+        /// </summary>
+        /// <remarks>
+        /// The fields of a V2 <see cref="EventNotification"/> align one to one with the select
+        /// clauses of the event filter, which replaces the field lookup the classic
+        /// MonitoredItem provided.
+        /// </remarks>
+        public static object GetEventFieldValue(MonitoredItemHandle handle, EventNotification notification, QualifiedName browseName)
+        {
+            if (handle?.Settings?.Filter is not EventFilter filter)
+            {
+                return null;
+            }
+
+            for (int ii = 0; ii < filter.SelectClauses.Count && ii < notification.Fields.Count; ii++)
+            {
+                SimpleAttributeOperand clause = filter.SelectClauses[ii];
+
+                if (clause.BrowsePath.Count == 1 && clause.BrowsePath[0] == browseName)
+                {
+                    return notification.Fields[ii].AsBoxedObject();
+                }
+            }
+
+            return null;
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return DisplayName;
+        }
+    }
+}

--- a/Samples/Controls.Net4/Subscriptions/WriteDlg.cs
+++ b/Samples/Controls.Net4/Subscriptions/WriteDlg.cs
@@ -55,14 +55,14 @@ namespace Opc.Ua.Sample.Controls
         #endregion
 
         #region Private Fields
-        private Session m_session;
+        private ISession m_session;
         #endregion
 
         #region Public Interface
         /// <summary>
         /// Displays the dialog.
         /// </summary>
-        public async Task ShowAsync(Session session, IList<WriteValue> values, ITelemetryContext telemetry, CancellationToken ct = default)
+        public async Task ShowAsync(ISession session, IList<WriteValue> values, ITelemetryContext telemetry, CancellationToken ct = default)
         {
             if (session == null) throw new ArgumentNullException(nameof(session));
 

--- a/Samples/Controls.Net4/Subscriptions/WriteValueEditDlg.cs
+++ b/Samples/Controls.Net4/Subscriptions/WriteValueEditDlg.cs
@@ -55,7 +55,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Prompts the user to specify the browse options.
         /// </summary>
-        public async Task<bool> ShowDialogAsync(Session session, WriteValue value, ITelemetryContext telemetry, CancellationToken ct = default)
+        public async Task<bool> ShowDialogAsync(ISession session, WriteValue value, ITelemetryContext telemetry, CancellationToken ct = default)
         {
             if (session == null) throw new ArgumentNullException(nameof(session));
             if (value == null) throw new ArgumentNullException(nameof(value));

--- a/Samples/Controls.Net4/Subscriptions/WriteValueListCtrl.cs
+++ b/Samples/Controls.Net4/Subscriptions/WriteValueListCtrl.cs
@@ -52,7 +52,7 @@ namespace Opc.Ua.Sample.Controls
         }
 
         #region Private Fields
-        private Session m_session;
+        private ISession m_session;
 
         /// <summary>
 		/// The columns to display in the control.
@@ -82,7 +82,7 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Sets the nodes in the control.
         /// </summary>
-        public void Initialize(Session session, IList<WriteValue> values, ITelemetryContext telemetry)
+        public void Initialize(ISession session, IList<WriteValue> values, ITelemetryContext telemetry)
         {
             if (session == null) throw new ArgumentNullException(nameof(session));
 

--- a/Tests/SampleClients.Tests/SampleClients.Tests.csproj
+++ b/Tests/SampleClients.Tests/SampleClients.Tests.csproj
@@ -37,6 +37,7 @@
     <ProjectReference Include="..\..\Workshop\UserAuthentication\Client\UserAuthentication Client.csproj" />
     <ProjectReference Include="..\..\Workshop\Views\Client\Views Client.csproj" />
     <ProjectReference Include="..\..\Samples\ReferenceClient\Reference Client.csproj" />
+    <ProjectReference Include="..\..\Samples\Controls.Net4\UA Sample Controls.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Tests/SampleClients.Tests/SampleControlsSubscribeTests.cs
+++ b/Tests/SampleClients.Tests/SampleControlsSubscribeTests.cs
@@ -1,0 +1,190 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using NUnit.Framework;
+using Opc.Ua.Client;
+using Opc.Ua.Client.Controls;
+using Opc.Ua.Configuration;
+using Opc.Ua.Sample.Controls;
+
+namespace Opc.Ua.Samples.Tests
+{
+    /// <summary>
+    /// Tier 2: the UA Sample Client controls have to connect with a managed session and receive
+    /// data changes through the V2 subscription engine.
+    /// </summary>
+    /// <remarks>
+    /// The client smoke tests only prove that a sample connects. This drives the subscription
+    /// dialog of the sample controls the same way a user would - create the subscription, add
+    /// an item through the config grid and apply - so a notification which never arrives at the
+    /// data change grid fails a test instead of showing up as an empty window.
+    /// </remarks>
+    [TestFixture]
+    [Category("ClientSmoke")]
+    [Category("RequiresDesktop")]
+    [NonParallelizable]
+    public class SampleControlsSubscribeTests
+    {
+        private const int kTimeout = 90_000;
+
+        /// <summary>
+        /// The sample whose server this drives the controls against.
+        /// </summary>
+        private const string kSample = "Reference";
+
+        [Test]
+        [CancelAfter(kTimeout)]
+        public async Task SampleControlsSubscribeAndReceiveDataChanges(CancellationToken ct)
+        {
+            SampleDefinition sample = SampleCatalog.All.Single(entry => entry.Name == kSample);
+            SampleServerUnderTest server = SampleServerFactories.All.Single(entry => entry.Sample.Name == kSample);
+
+            await using SampleServerHost host = await SampleServerHost
+                .StartAsync(kSample, server.Sample.ServerConfig, server.CreateServer, ct)
+                .ConfigureAwait(false);
+
+            await WinFormsHarness.RunAsync(
+                async _ => await DriveSubscriptionAsync(sample, host.EndpointUrl, ct).ConfigureAwait(true),
+                TimeSpan.FromMilliseconds(kTimeout) - TimeSpan.FromSeconds(15))
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Runs on the STA thread of the harness, with a message loop pumping.
+        /// </summary>
+        private static async Task DriveSubscriptionAsync(SampleDefinition sample, string endpointUrl, CancellationToken ct)
+        {
+            using var pki = new TemporaryPki("client-sample-controls");
+
+            ApplicationConfiguration configuration = await SampleConfigurationLoader
+                .LoadAsync(sample.ClientConfig, pki, ct)
+                .ConfigureAwait(true);
+
+            await using var application = new ApplicationInstance(configuration, NullTelemetry.Instance);
+
+            bool certificateOk = await application
+                .CheckApplicationInstanceCertificatesAsync(true, null, ct)
+                .ConfigureAwait(true);
+
+            Assert.That(certificateOk, Is.True, "The client certificate of the sample could not be created.");
+
+            // create the managed session the way SessionOpenDlg does, without the dialog.
+            EndpointDescription endpointDescription = await CoreClientUtils
+                .SelectEndpointAsync(configuration, endpointUrl, false, 15_000, NullTelemetry.Instance, ct)
+                .ConfigureAwait(true);
+
+            ConfiguredEndpoint endpoint = new ConfiguredEndpoint(null, endpointDescription, EndpointConfiguration.Create(configuration));
+
+            ISession session = await new ManagedSessionFactory(NullTelemetry.Instance)
+                .CreateAsync(configuration, endpoint, false, false, "SampleControlsTest", 60_000, null, (string[])null, ct)
+                .ConfigureAwait(true);
+
+            using var dialog = new SubscriptionDlg();
+
+            try
+            {
+                Assert.That(
+                    session,
+                    Is.InstanceOf<ManagedSession>(),
+                    "The session open dialog path no longer creates a managed session, so the " +
+                    "sample controls are back to the classic client surface.");
+
+                // create the subscription the way SubscriptionDlg.New does, without the modal
+                // edit dialog.
+                var subscription = new SubscriptionHandle(session, "Test Subscription", ClientUtils.DefaultSubscriptionOptions);
+
+                Assert.That(subscription.Create(), Is.Not.Null, "The subscription was not registered with the V2 engine.");
+
+                // showing the dialog wires the monitored item grid and the notification lists
+                // to the callbacks of the subscription.
+                #pragma warning disable CA1849 // Justification: Show displays a modeless window, there is nothing to await.
+                dialog.Show(subscription);
+                #pragma warning restore CA1849
+
+                var monitoredItems = (MonitoredItemConfigCtrl)WinFormsHarness.FindControl(dialog, "MonitoredItemsCTRL");
+
+                Assert.That(monitoredItems, Is.Not.Null, "The dialog no longer has a 'MonitoredItemsCTRL' grid.");
+
+                await monitoredItems.AddItemAsync(
+                    new ReferenceDescription {
+                        NodeId = VariableIds.Server_ServerStatus_CurrentTime,
+                        NodeClass = NodeClass.Variable,
+                        BrowseName = new QualifiedName(Opc.Ua.BrowseNames.CurrentTime),
+                        DisplayName = new LocalizedText("CurrentTime"),
+                        ReferenceTypeId = ReferenceTypeIds.HasComponent,
+                        IsForward = true,
+                    },
+                    ct).ConfigureAwait(true);
+
+                await monitoredItems.ApplyChangesAsync(true, ct).ConfigureAwait(true);
+
+                MonitoredItemHandle handle = subscription.Items.SingleOrDefault();
+
+                Assert.That(handle, Is.Not.Null, "The control did not add a monitored item.");
+                Assert.That(handle.Item, Is.Not.Null, "The control did not hand the monitored item to the engine.");
+                Assert.That(
+                    ServiceResult.IsGood(handle.Item.Error),
+                    Is.True,
+                    $"The server refused the monitored item: {handle.Item.Error}");
+
+                // a data change has to reach the grid of the dialog through the notification
+                // handler the subscription was created with.
+                ListView dataChanges = await WaitForDataChangeAsync(dialog, ct).ConfigureAwait(true);
+
+                Assert.That(
+                    dataChanges,
+                    Is.Not.Null,
+                    "No data change reached the grid, so the notification handler of the dialog " +
+                    "is not wired up to the subscription engine.");
+            }
+            finally
+            {
+                dialog.Close();
+                await session.CloseAsync(ct).ConfigureAwait(true);
+            }
+        }
+
+        /// <summary>
+        /// Waits until a data change has been written into the grid of the dialog.
+        /// </summary>
+        /// <remarks>
+        /// The designer fields are private, and reflection is used rather than widening the
+        /// controls just for this test.
+        /// </remarks>
+        private static async Task<ListView> WaitForDataChangeAsync(SubscriptionDlg dialog, CancellationToken ct)
+        {
+            var dataChangesCtrl = (DataChangeNotificationListCtrl)WinFormsHarness.FindControl(dialog, "DataChangesCTRL");
+
+            Assert.That(dataChangesCtrl, Is.Not.Null, "The dialog no longer has a 'DataChangesCTRL' list.");
+
+            var listView = (ListView)WinFormsHarness.FindControl(dataChangesCtrl, "ItemsLV");
+
+            Assert.That(listView, Is.Not.Null, "The list control no longer has an 'ItemsLV' view.");
+
+            DateTime deadline = DateTime.UtcNow.AddSeconds(30);
+
+            while (DateTime.UtcNow < deadline)
+            {
+                if (listView.Items.Count > 0)
+                {
+                    return listView;
+                }
+
+                await Task.Delay(100, ct).ConfigureAwait(true);
+            }
+
+            return null;
+        }
+    }
+}

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -383,8 +383,14 @@ wizard of the shared `SubscribeDataListViewCtrl` against the Reference server th
 would - create the subscription, add `Server_ServerStatus_CurrentTime`, step to apply and then
 to view - and waits for a data change to land in the grid. It asserts the connect control
 handed out a `ManagedSession`, so a silent fall back to the raw session and its hand rolled
-reconnect fails a test, and it is the only case which proves that the V2 notification handler
-of a control actually reaches the user interface.
+reconnect fails a test, and it proves that the V2 notification handler of a control actually
+reaches the user interface.
+
+`SampleControlsSubscribeTests` does the same for the UA Sample Client controls in
+`Controls.Net4`: it opens a managed session the way `SessionOpenDlg` does, creates a
+`SubscriptionHandle` on the V2 engine, shows the (modeless) `SubscriptionDlg`, adds
+`Server_ServerStatus_CurrentTime` through the `MonitoredItemConfigCtrl` grid, applies, and
+waits for a data change to land in the `DataChangeNotificationListCtrl` of the dialog.
 
 The **dialog watchdog** is what makes this safe: the sample clients report errors through a
 modal `ExceptionDlg`, which in an unattended run would wait forever for a click. A timer on


### PR DESCRIPTION
## Proposed changes

`Samples/Controls.Net4` — the session tree, browse tree, subscription and monitored-item dialogs used by the UA Sample Client — moves off the raw `Session` and the classic `Subscription`/`MonitoredItem` engine onto the 2.0 client surface, following the pattern #805 established for `ClientControls.Net4`.

**Managed Session**
- `SessionOpenDlg` now creates the session with `ManagedSessionFactory` (discover + secure channel + open in one step) and loads the complex type system; the identity/session-name UX is unchanged. On failure the dialog stays open for a retry instead of closing as if it had succeeded.
- `SessionTreeCtrl.ConnectAsync` no longer builds a channel by hand; the channel-based overload is removed.
- `ClientForm` reports reconnects from `ManagedSession.ConnectionStateChanged` instead of driving them with a `SessionReconnectHandler`. The managed session keeps the same `ISession` and its subscriptions across a reconnect, so reconnect handling reduces to refreshing the display.

**New Subscription Engine**
- A new `SubscriptionHandle` carries what a V2 subscription does not: the session it belongs to, a display name, the options monitor that reconfigures it, the `SubscriptionCallbacks` the subscription is created with, and the `MonitoredItemHandle` bookkeeping of the items the controls added. The tree, `SubscriptionDlg`, `MonitoredItemDlg`, `CreateMonitoredItemsDlg` and the notification list controls all combine their delegates into that one handler and detach on close.
- Item add/edit/monitoring-mode/filter changes go through `MonitoredItems.TryAdd` and options-record reconfiguration; wizard-style flows stage items and hand them to the engine on Apply, then wait for the engine worker to settle before showing revised values (there is no ApplyChanges in V2).
- Session save/load switches to `ManagedSessionExtensions.SaveSubscriptionsAsync`/`LoadSubscriptionsAsync`.
- Event items get an explicit default `BaseEventType` filter (the V2 engine no longer composes one); event fields come back aligned 1:1 with the filter's select clauses, which replaces the classic `GetFieldValue`.

**ISession everywhere**
- `ManagedSession` does not derive from `Session`, so every concrete `Session` parameter and `as Session` cast across ~40 dialogs/controls was converted to `ISession` — including the casts off `Browser.Session`, which still compile but return null for a managed session.
- `MonitoredItemHandle` (shared, from #805) gained `DisplayName` and `NodeClass`, which the Controls.Net4 dialogs display; `GuiUtils.EditValue` and `NodeIdValueEditDlg` widened `Session` → `ISession`.

**Breaking changes**
- `SessionTreeCtrl`, `SubscriptionDlg`, `CreateMonitoredItemsDlg`, `MonitoredItemDlg` and the list controls now hand out `ISession` / `SubscriptionHandle` / `MonitoredItemHandle` instead of `Session` / `Subscription` / `MonitoredItem`; `MethodCalledEventArgs.Session` is `ISession`.
- The channel-based `SessionTreeCtrl.ConnectAsync(endpoint, channel, …)` overload is removed (no equivalent in the factory path; nothing in the repo called it).
- The monitored-item grid lost its relative-path column: V2 items are identified by node id, so the type-model flow subscribes the picked node directly.
- The republish menu is disabled — the V2 engine republishes missed messages on its own.
- Subscriptions restored from a file display and can be deleted, but their items cannot be reconfigured (the engine holds their options monitors).

**Verification**
- All four solutions build with 0 errors / 0 warnings.
- New tier 2 test `SampleControlsSubscribeTests` opens a managed session the way `SessionOpenDlg` does, creates a subscription on the V2 engine, shows the (modeless) `SubscriptionDlg`, adds `Server_ServerStatus_CurrentTime` through the `MonitoredItemConfigCtrl` grid, applies, and waits for a data change to land in the dialog's data-change grid.
- Full `SampleClients.Tests` suite passes 18/18, including the pre-existing `SubscribeControlTests` that guards the #805 surface this PR builds on.

## Related Issues

- Fixes #770 (sub-issue of #755)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [x] Test enhancement (non-breaking change to increase test coverage)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines.
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

The `SubscriptionHandle` + `MonitoredItemHandle` pair is the Controls.Net4 counterpart of the `SubscriptionCallbacks`/`MonitoredItemHandle` helpers #805 introduced: the V2 engine takes its notification handler at creation time, identifies items by unique name, and reports only revised values, while these dialogs juggle several windows per subscription — so a shared client-side handle is what preserves the tree/dialog UX (display names, pending vs. revised settings, per-window callback wiring) on top of the new engine. The alternative — attaching state to the engine objects via lookups per window — was tried first and dropped because loaded/restored subscriptions have no client-side state to look up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
