### PR TITLE
Modernize the ReferenceClient and UA Sample Client for the managed session

### DIFF
--- a/Samples/Client.Net4/SampleClientForm.cs
+++ b/Samples/Client.Net4/SampleClientForm.cs
@@ -35,6 +35,16 @@ using Opc.Ua.Configuration;
 
 namespace Opc.Ua.Sample
 {
+    /// <summary>
+    /// The main form of the UA Sample Client.
+    /// </summary>
+    /// <remarks>
+    /// Everything about the connection lives in <see cref="ClientForm"/>: it opens a
+    /// <c>ManagedSession</c> through the session dialog of the sample controls, so the reconnect
+    /// is driven by the connection state machine of that session, and its subscription dialogs
+    /// run on the V2 subscription engine. This form only adds what is specific to the sample -
+    /// the certificate prompt for a configuration which does not accept untrusted peers.
+    /// </remarks>
     public partial class SampleClientForm : ClientForm
     {
         public SampleClientForm()

--- a/Samples/ReferenceClient/MainForm.Designer.cs
+++ b/Samples/ReferenceClient/MainForm.Designer.cs
@@ -132,7 +132,7 @@ namespace Quickstarts.ReferenceClient
             this.Server_DisconnectMI.Name = "Server_DisconnectMI";
             this.Server_DisconnectMI.Size = new System.Drawing.Size(127, 22);
             this.Server_DisconnectMI.Text = "Disconnect";
-            this.Server_DisconnectMI.Click += new System.EventHandler(this.Server_DisconnectMI_Click);
+            this.Server_DisconnectMI.Click += new System.EventHandler(this.Server_DisconnectMI_ClickAsync);
             // 
             // HelpMI
             // 
@@ -174,8 +174,6 @@ namespace Quickstarts.ReferenceClient
             this.ConnectServerCTRL.UserIdentity = null;
             this.ConnectServerCTRL.UseSecurity = true;
             this.ConnectServerCTRL.ConnectComplete += new System.EventHandler(this.Server_ConnectCompleteAsync);
-            this.ConnectServerCTRL.ReconnectStarting += new System.EventHandler(this.Server_ReconnectStartingAsync);
-            this.ConnectServerCTRL.ReconnectComplete += new System.EventHandler(this.Server_ReconnectCompleteAsync);
             // 
             // BrowseCTRL
             // 

--- a/Samples/ReferenceClient/MainForm.cs
+++ b/Samples/ReferenceClient/MainForm.cs
@@ -42,6 +42,12 @@ namespace Quickstarts.ReferenceClient
     /// <summary>
     /// The main form for a simple Quickstart Client application.
     /// </summary>
+    /// <remarks>
+    /// The connect control creates a <see cref="ManagedSession"/>, so the reconnect is driven
+    /// by the connection state machine of the session rather than by this form. The session the
+    /// form holds stays the same instance across a reconnect, which is why nothing here swaps
+    /// it out or rebuilds the browse tree when the connection drops.
+    /// </remarks>
     public partial class MainForm : Form
     {
         #region Constructors
@@ -70,11 +76,7 @@ namespace Quickstarts.ReferenceClient
         #region Private Fields
         private ApplicationConfiguration m_configuration;
         private ISession m_session;
-        private bool m_connectedOnce;
         private ITelemetryContext m_telemetry;
-        #endregion
-
-        #region Private Methods
         #endregion
 
         #region Event Handlers
@@ -96,11 +98,11 @@ namespace Quickstarts.ReferenceClient
         /// <summary>
         /// Disconnects from the current session.
         /// </summary>
-        private void Server_DisconnectMI_Click(object sender, EventArgs e)
+        private async void Server_DisconnectMI_ClickAsync(object sender, EventArgs e)
         {
             try
             {
-                ConnectServerCTRL.Disconnect();
+                await ConnectServerCTRL.DisconnectAsync();
             }
             catch (Exception exception)
             {
@@ -126,17 +128,15 @@ namespace Quickstarts.ReferenceClient
         /// <summary>
         /// Updates the application after connecting to or disconnecting from the server.
         /// </summary>
+        /// <remarks>
+        /// This also runs after a disconnect, where the connect control reports a null session
+        /// and the browse tree empties itself.
+        /// </remarks>
         private async void Server_ConnectCompleteAsync(object sender, EventArgs e)
         {
             try
             {
                 m_session = ConnectServerCTRL.Session;
-
-                // set a suitable initial state.
-                if (m_session != null && !m_connectedOnce)
-                {
-                    m_connectedOnce = true;
-                }
 
                 // browse the instances in the server.
                 await BrowseCTRL.InitializeAsync(m_session, ObjectIds.ObjectsFolder, m_telemetry, default, ReferenceTypeIds.Organizes, ReferenceTypeIds.Aggregates);
@@ -148,39 +148,12 @@ namespace Quickstarts.ReferenceClient
         }
 
         /// <summary>
-        /// Updates the application after a communicate error was detected.
-        /// </summary>
-        private async void Server_ReconnectStartingAsync(object sender, EventArgs e)
-        {
-            try
-            {
-                await BrowseCTRL.ChangeSessionAsync(null);
-            }
-            catch (Exception exception)
-            {
-                ClientUtils.HandleException(m_telemetry, this.Text, exception);
-            }
-        }
-
-        /// <summary>
-        /// Updates the application after reconnecting to the server.
-        /// </summary>
-        private async void Server_ReconnectCompleteAsync(object sender, EventArgs e)
-        {
-            try
-            {
-                m_session = ConnectServerCTRL.Session;
-                await BrowseCTRL.ChangeSessionAsync(m_session);
-            }
-            catch (Exception exception)
-            {
-                ClientUtils.HandleException(m_telemetry, this.Text, exception);
-            }
-        }
-
-        /// <summary>
         /// Cleans up when the main form closes.
         /// </summary>
+        /// <remarks>
+        /// The form is on its way out and there is nothing left to await on, so this closes the
+        /// session synchronously rather than starting work which would outlive the window.
+        /// </remarks>
         private void MainForm_FormClosing(object sender, FormClosingEventArgs e)
         {
             ConnectServerCTRL.Disconnect();

--- a/Tests/SampleClients.Tests/ClientReconnectTests.cs
+++ b/Tests/SampleClients.Tests/ClientReconnectTests.cs
@@ -1,0 +1,395 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using NUnit.Framework;
+using Opc.Ua.Client;
+using Opc.Ua.Client.Controls;
+using Opc.Ua.Client.Subscriptions;
+using Opc.Ua.Configuration;
+
+// the V2 engine reuses names the classic engine already has in Opc.Ua.Client
+using MonitoredItemOptions = Opc.Ua.Client.Subscriptions.MonitoredItems.MonitoredItemOptions;
+using SubscriptionOptions = Opc.Ua.Client.Subscriptions.SubscriptionOptions;
+
+namespace Opc.Ua.Samples.Tests
+{
+    /// <summary>
+    /// Tier 2: the Reference Client has to survive its server going away and coming back,
+    /// without doing anything about it itself.
+    /// </summary>
+    /// <remarks>
+    /// The client smoke tests prove that a sample connects, and the subscribe tests prove that
+    /// notifications arrive. Neither drops the server, which is the one thing the move to the
+    /// managed session changed: the reconnect is no longer driven by the sample or by the
+    /// shared connect control, and the session the sample holds is the same instance before and
+    /// after. This test is what would notice if that stopped being true - either because the
+    /// reconnect does not happen at all, or because it happens by handing the sample a new
+    /// session it never picks up.
+    /// </remarks>
+    [TestFixture]
+    [Category("ClientSmoke")]
+    [Category("RequiresDesktop")]
+    [NonParallelizable]
+    public class ClientReconnectTests
+    {
+        /// <summary>
+        /// How long the whole test may take. A reconnect is a wait for a keep alive to fail,
+        /// a backoff and a session recreate, so this is well above the client smoke tests.
+        /// </summary>
+        private const int kTimeout = 180_000;
+
+        /// <summary>
+        /// How long a single service call of the sample may take.
+        /// </summary>
+        private const int kOperationTimeout = 30_000;
+
+        /// <summary>
+        /// The sample this drives. Its client is the one #771 modernized, and its server is
+        /// the Quickstart Reference Server the issue asks the samples to be verified against.
+        /// </summary>
+        private const string kSample = "Reference";
+
+        [Test]
+        [CancelAfter(kTimeout)]
+        public async Task ReferenceClientReconnectsAfterAServerRestart(CancellationToken ct)
+        {
+            SampleClientUnderTest client = SampleClientFactories.All.Single(entry => entry.Sample.Name == kSample);
+            SampleServerUnderTest server = SampleServerFactories.All.Single(entry => entry.Sample.Name == kSample);
+
+            await using SampleServerHost host = await SampleServerHost
+                .StartAsync(kSample, server.Sample.ServerConfig, server.CreateServer, ct)
+                .ConfigureAwait(false);
+
+            var phase = new ClientPhase();
+
+            try
+            {
+                await WinFormsHarness.RunAsync(
+                    async _ => await DriveReconnectAsync(client, host, phase, ct).ConfigureAwait(true),
+                    TimeSpan.FromMilliseconds(kTimeout) - TimeSpan.FromSeconds(20))
+                    .ConfigureAwait(false);
+            }
+            catch (TimeoutException expired)
+            {
+                throw phase.Explain(expired);
+            }
+        }
+
+        /// <summary>
+        /// Runs on the STA thread of the harness, with a message loop pumping.
+        /// </summary>
+        private static async Task DriveReconnectAsync(
+            SampleClientUnderTest client,
+            SampleServerHost host,
+            ClientPhase phase,
+            CancellationToken ct)
+        {
+            phase.Enter("loading the configuration of the sample");
+
+            using var pki = new TemporaryPki("client-reconnect");
+
+            ApplicationConfiguration configuration = await SampleConfigurationLoader
+                .LoadAsync(client.Sample.ClientConfig, pki, ct)
+                .ConfigureAwait(true);
+
+            configuration.TransportQuotas.OperationTimeout = kOperationTimeout;
+
+            await using var application = new ApplicationInstance(configuration, NullTelemetry.Instance);
+
+            bool certificateOk = await application
+                .CheckApplicationInstanceCertificatesAsync(true, null, ct)
+                .ConfigureAwait(true);
+
+            Assert.That(certificateOk, Is.True, "The client certificate of the sample could not be created.");
+
+            using Form form = client.CreateMainForm(configuration, NullTelemetry.Instance);
+
+            // create the window handle without ever showing the form: the sample marshals its
+            // connect callbacks back to the UI thread and needs a handle to do so
+            _ = form.Handle;
+
+            ConnectServerCtrl connect = WinFormsHarness.GetConnectControl(form);
+
+            phase.Enter($"connecting to {host.EndpointUrl}");
+
+            ISession session = await connect
+                .ConnectAsync(NullTelemetry.Instance, host.EndpointUrl, false, 30_000, ct)
+                .ConfigureAwait(true);
+
+            try
+            {
+                Assert.That(
+                    session,
+                    Is.InstanceOf<ManagedSession>(),
+                    "The sample no longer connects with a managed session, so nothing drives its reconnect.");
+
+                using var states = new ConnectionStateLog((ManagedSession)session);
+                var changes = new DataChangeCounter();
+
+                phase.Enter("subscribing through the V2 engine");
+
+                ISubscription subscription = Subscribe(session, changes);
+
+                Assert.That(
+                    await changes.WaitForMoreAsync(0, TimeSpan.FromSeconds(30), ct).ConfigureAwait(true),
+                    Is.True,
+                    "No data change arrived before the server was restarted, so the test could not " +
+                    "have told a broken reconnect from a subscription which never worked.");
+
+                // drop the server the sample is talking to, and wait until the session has
+                // noticed. Restarting it right away would let the client reconnect over a
+                // channel which never broke, which proves nothing.
+                phase.Enter("stopping the server");
+
+                // off the message loop: the server counts its shutdown down and closes its
+                // channels while the client is still on them, and doing that on the thread
+                // which also pumps the callbacks of the client deadlocks the two
+                await Task.Run(() => host.StopAsync(), ct).ConfigureAwait(true);
+
+                phase.Enter("waiting for the session to notice that the server is gone");
+
+                await states
+                    .WaitForAsync(
+                        state => state is ConnectionState.Reconnecting or ConnectionState.Disconnected
+                            or ConnectionState.Failover,
+                        "the managed session to notice that the server is gone",
+                        TimeSpan.FromSeconds(45),
+                        ct)
+                    .ConfigureAwait(true);
+
+                phase.Enter("starting the server again");
+
+                await Task.Run(() => host.StartAgainAsync(ct), ct).ConfigureAwait(true);
+
+                phase.Enter("waiting for the session to reconnect");
+
+                await states
+                    .WaitForAsync(
+                        state => state == ConnectionState.Connected,
+                        "the managed session to reconnect to the restarted server",
+                        TimeSpan.FromSeconds(60),
+                        ct)
+                    .ConfigureAwait(true);
+
+                phase.Enter("checking the reconnected session");
+
+                Assert.That(
+                    connect.Session,
+                    Is.SameAs(session),
+                    "The reconnect replaced the session of the connect control. The sample relies on " +
+                    "the managed session keeping the same instance and no longer rebinds its browse tree.");
+
+                Assert.That(session.Connected, Is.True, "The session did not come back connected.");
+
+                // the session works again, which is what the browse and read paths of the
+                // sample do with it
+                DataValue serverState = await SessionOps
+                    .ReadValueAsync(session, VariableIds.Server_ServerStatus_State, ct)
+                    .ConfigureAwait(true);
+
+                Assert.That(
+                    ServiceResult.IsGood(serverState.StatusCode),
+                    Is.True,
+                    $"Reading over the reconnected session failed: {serverState.StatusCode}");
+
+                // and the V2 subscription is serving the sample again
+                phase.Enter("waiting for the subscription to deliver again");
+
+                int seen = changes.Count;
+
+                Assert.That(
+                    await changes.WaitForMoreAsync(seen, TimeSpan.FromSeconds(45), ct).ConfigureAwait(true),
+                    Is.True,
+                    "No data change arrived after the reconnect, so the V2 subscription was not " +
+                    $"restored. The subscription reports Created={subscription.Created}.");
+            }
+            finally
+            {
+                phase.Enter("disconnecting");
+
+                await connect.DisconnectAsync(CancellationToken.None).ConfigureAwait(true);
+            }
+        }
+
+        /// <summary>
+        /// Adds a V2 subscription with one fast changing item, the way the shared controls do.
+        /// </summary>
+        private static ISubscription Subscribe(ISession session, DataChangeCounter changes)
+        {
+            ISubscription subscription = ClientUtils.AddSubscription(
+                session,
+                changes.Handler,
+                new OptionsMonitor<SubscriptionOptions>(ClientUtils.DefaultSubscriptionOptions));
+
+            bool added = subscription.MonitoredItems.TryAdd(
+                "CurrentTime",
+                new OptionsMonitor<MonitoredItemOptions>(new MonitoredItemOptions {
+                    StartNodeId = VariableIds.Server_ServerStatus_CurrentTime,
+                    AttributeId = Attributes.Value,
+                    SamplingInterval = TimeSpan.FromMilliseconds(250),
+                }),
+                out _);
+
+            Assert.That(added, Is.True, "The V2 engine refused the monitored item.");
+
+            return subscription;
+        }
+
+        /// <summary>
+        /// Counts the data changes the V2 engine delivers.
+        /// </summary>
+        /// <remarks>
+        /// The callbacks run on a publish worker, not on the message loop the test body runs
+        /// on, so the count is read across threads and the waits are interlocked rather than
+        /// plain field reads.
+        /// </remarks>
+        private sealed class DataChangeCounter
+        {
+            private int m_count;
+
+            public DataChangeCounter()
+            {
+                Handler = new SubscriptionCallbacks {
+                    DataChangeCallback = (_, _, _, notifications, _) =>
+                        Interlocked.Add(ref m_count, notifications.Length),
+                };
+            }
+
+            /// <summary>
+            /// The handler to create the subscription with.
+            /// </summary>
+            public SubscriptionCallbacks Handler { get; }
+
+            /// <summary>
+            /// How many data changes have arrived so far.
+            /// </summary>
+            public int Count => Volatile.Read(ref m_count);
+
+            /// <summary>
+            /// Waits until more data changes than <paramref name="seen"/> have arrived.
+            /// </summary>
+            public async Task<bool> WaitForMoreAsync(int seen, TimeSpan timeout, CancellationToken ct)
+            {
+                DateTime deadline = DateTime.UtcNow.Add(timeout);
+
+                while (DateTime.UtcNow < deadline)
+                {
+                    if (Count > seen)
+                    {
+                        return true;
+                    }
+
+                    await Task.Delay(100, ct).ConfigureAwait(true);
+                }
+
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Records the connection state transitions of a managed session.
+        /// </summary>
+        /// <remarks>
+        /// Polling <c>StateMachine.State</c> would miss a transition which is over before the
+        /// next poll, and a reconnect which is fast enough would then look like a session that
+        /// never noticed anything. The states are collected from the event instead, and the
+        /// waits below consume them in order.
+        /// </remarks>
+        private sealed class ConnectionStateLog : IDisposable
+        {
+            private readonly ManagedSession m_session;
+            private readonly List<ConnectionState> m_states = [];
+            private readonly Lock m_lock = new();
+            private int m_consumed;
+
+            public ConnectionStateLog(ManagedSession session)
+            {
+                m_session = session;
+                m_session.ConnectionStateChanged += OnStateChanged;
+            }
+
+            /// <inheritdoc/>
+            public void Dispose()
+            {
+                m_session.ConnectionStateChanged -= OnStateChanged;
+            }
+
+            /// <summary>
+            /// Waits until a state the test has not consumed yet is accepted, and consumes
+            /// everything up to and including it.
+            /// </summary>
+            public async Task WaitForAsync(
+                Func<ConnectionState, bool> accept,
+                string because,
+                TimeSpan timeout,
+                CancellationToken ct)
+            {
+                DateTime deadline = DateTime.UtcNow.Add(timeout);
+
+                while (true)
+                {
+                    if (TryConsume(accept))
+                    {
+                        return;
+                    }
+
+                    if (DateTime.UtcNow >= deadline)
+                    {
+                        Assert.Fail(
+                            $"Timed out after {timeout.TotalSeconds:F0} s waiting for {because}. " +
+                            $"The states seen so far were: {Describe()}.");
+                    }
+
+                    await Task.Delay(200, ct).ConfigureAwait(true);
+                }
+            }
+
+            private bool TryConsume(Func<ConnectionState, bool> accept)
+            {
+                lock (m_lock)
+                {
+                    for (int index = m_consumed; index < m_states.Count; index++)
+                    {
+                        if (accept(m_states[index]))
+                        {
+                            m_consumed = index + 1;
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }
+            }
+
+            private string Describe()
+            {
+                lock (m_lock)
+                {
+                    return m_states.Count == 0
+                        ? "none, the session never reported a state change"
+                        : string.Join(" -> ", m_states);
+                }
+            }
+
+            private void OnStateChanged(object sender, ConnectionStateChangedEventArgs e)
+            {
+                lock (m_lock)
+                {
+                    m_states.Add(e.NewState);
+                }
+            }
+        }
+    }
+}

--- a/Tests/SampleClients.Tests/SampleClientFormTests.cs
+++ b/Tests/SampleClients.Tests/SampleClientFormTests.cs
@@ -1,0 +1,179 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using NUnit.Framework;
+using Opc.Ua.Client;
+using Opc.Ua.Client.Subscriptions;
+using Opc.Ua.Configuration;
+using Opc.Ua.Sample;
+using Opc.Ua.Sample.Controls;
+
+namespace Opc.Ua.Samples.Tests
+{
+    /// <summary>
+    /// Tier 2: the UA Sample Client has to open its session with a managed session running the
+    /// V2 subscription engine, and fill its browse tree from it.
+    /// </summary>
+    /// <remarks>
+    /// The sample is the one client the generic smoke test cannot drive: it does not host the
+    /// shared connect control, and it opens its session through a modal dialog rather than from
+    /// a url in a toolbar. That is why "Sample" is a declared gap in <see cref="SampleClientTests"/>.
+    /// This fixture drives it the way a user would instead - pick an endpoint, let the session
+    /// dialog come up and click OK - with the watchdog answering the dialog.
+    /// </remarks>
+    [TestFixture]
+    [Category("ClientSmoke")]
+    [Category("RequiresDesktop")]
+    [NonParallelizable]
+    public class SampleClientFormTests
+    {
+        private const int kTimeout = 120_000;
+
+        /// <summary>
+        /// The sample. Its client is the UA Sample Client and its server the UA Sample Server.
+        /// </summary>
+        private const string kSample = "Sample";
+
+        [Test]
+        [CancelAfter(kTimeout)]
+        public async Task SampleClientConnectsWithAManagedSessionAndBrowses(CancellationToken ct)
+        {
+            SampleDefinition sample = SampleCatalog.All.Single(entry => entry.Name == kSample);
+            SampleServerUnderTest server = SampleServerFactories.All.Single(entry => entry.Sample.Name == kSample);
+
+            await using SampleServerHost host = await SampleServerHost
+                .StartAsync(kSample, server.Sample.ServerConfig, server.CreateServer, ct)
+                .ConfigureAwait(false);
+
+            var phase = new ClientPhase();
+
+            try
+            {
+                await WinFormsHarness.RunAsync(
+                    async watchdog => await DriveClientAsync(sample, host.EndpointUrl, watchdog, phase, ct)
+                        .ConfigureAwait(true),
+                    TimeSpan.FromMilliseconds(kTimeout) - TimeSpan.FromSeconds(20))
+                    .ConfigureAwait(false);
+            }
+            catch (TimeoutException expired)
+            {
+                throw phase.Explain(expired);
+            }
+        }
+
+        /// <summary>
+        /// Runs on the STA thread of the harness, with a message loop pumping.
+        /// </summary>
+        private static async Task DriveClientAsync(
+            SampleDefinition sample,
+            string endpointUrl,
+            DialogWatchdog watchdog,
+            ClientPhase phase,
+            CancellationToken ct)
+        {
+            phase.Enter("loading the configuration of the sample");
+
+            using var pki = new TemporaryPki("client-sample-form");
+
+            ApplicationConfiguration configuration = await SampleConfigurationLoader
+                .LoadAsync(sample.ClientConfig, pki, ct)
+                .ConfigureAwait(true);
+
+            await using var application = new ApplicationInstance(configuration, NullTelemetry.Instance);
+
+            phase.Enter("creating its client certificate");
+
+            bool certificateOk = await application
+                .CheckApplicationInstanceCertificatesAsync(true, null, ct)
+                .ConfigureAwait(true);
+
+            Assert.That(certificateOk, Is.True, "The client certificate of the sample could not be created.");
+
+            phase.Enter("building its main form");
+
+            using var form = new SampleClientForm(application, masterForm: null, configuration, NullTelemetry.Instance);
+
+            // create the window handle without ever showing the form: the sample marshals its
+            // connect callbacks back to the UI thread and needs a handle to do so
+            _ = form.Handle;
+
+            phase.Enter("selecting the endpoint");
+
+            EndpointDescription description = await CoreClientUtils
+                .SelectEndpointAsync(configuration, endpointUrl, false, 15_000, NullTelemetry.Instance, ct)
+                .ConfigureAwait(true);
+
+            var endpoint = new ConfiguredEndpoint(null, description, EndpointConfiguration.Create(configuration)) {
+                // the sample would otherwise open its endpoint configuration dialog first,
+                // which is a step the user has already done when they pick a cached endpoint
+                UpdateBeforeConnect = false,
+            };
+
+            // the sample opens its session through a modal dialog, and the harness would
+            // otherwise cancel it and report it as an error dialog the sample opened
+            watchdog.Accept<SessionOpenDlg>("OkBTN");
+
+            phase.Enter($"connecting to {endpointUrl}");
+
+            await form.ConnectAsync(endpoint, NullTelemetry.Instance, ct).ConfigureAwait(true);
+
+            try
+            {
+                phase.Enter("checking the session it opened");
+
+                var session = WinFormsHarness.FindField<ISession>(form, "m_session");
+
+                Assert.That(
+                    session,
+                    Is.Not.Null,
+                    "The sample did not keep the session its session dialog opened.");
+
+                Assert.That(
+                    session,
+                    Is.InstanceOf<ManagedSession>(),
+                    "The sample no longer opens a managed session, so nothing drives its reconnect.");
+
+                Assert.That(session.Connected, Is.True, "The session of the sample is not connected.");
+
+                Assert.That(
+                    session.TryGetSubscriptionManager(out ISubscriptionManager manager),
+                    Is.True,
+                    "The session of the sample does not run the V2 subscription engine, so its " +
+                    "subscription dialogs have nothing to add monitored items to.");
+
+                Assert.That(manager, Is.Not.Null, "The session reported a V2 engine without a manager.");
+
+                phase.Enter("checking its browse tree");
+
+                var nodes = (TreeView)WinFormsHarness.FindControl(
+                    WinFormsHarness.FindControl(form, "BrowseCTRL"),
+                    "NodesTV");
+
+                Assert.That(nodes, Is.Not.Null, "The browse control of the sample has no 'NodesTV' tree.");
+
+                Assert.That(
+                    nodes.Nodes.Count,
+                    Is.GreaterThan(0),
+                    "The sample connected but its browse tree stayed empty, so the post connect " +
+                    "logic did not read the address space of the server.");
+            }
+            finally
+            {
+                phase.Enter("disconnecting");
+
+                await form.DisconnectAsync(CancellationToken.None).ConfigureAwait(true);
+            }
+        }
+    }
+}

--- a/Tests/SampleClients.Tests/SampleClientTests.cs
+++ b/Tests/SampleClients.Tests/SampleClientTests.cs
@@ -9,7 +9,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Runtime.ExceptionServices;
 using System.Threading;
@@ -121,9 +120,10 @@ namespace Opc.Ua.Samples.Tests
         [Test]
         public void UncoveredClientSamplesAreDeclared()
         {
-            // the sample client discovers its server instead of connecting to a fixed
-            // endpoint, and the GDS and aggregation clients need more than one server;
-            // both follow in phase 4 of docs/TESTING.md
+            // the UA Sample Client has no shared connect control and opens its session
+            // through a modal dialog, so it cannot be driven by the loop above - it has its
+            // own fixture in SampleClientFormTests instead. The GDS and aggregation clients
+            // need more than one server and follow in phase 4 of docs/TESTING.md
             string[] expectedGaps = ["Aggregation", "Gds", "Sample"];
 
             IEnumerable<string> uncovered = SampleCatalog.Clients
@@ -201,12 +201,7 @@ namespace Opc.Ua.Samples.Tests
             }
             catch (TimeoutException expired)
             {
-                // the bare message says only that the clock ran out, which is the same for
-                // every way a sample can hang. The step it was in is what tells them apart.
-                throw new TimeoutException(
-                    $"{expired.Message} It was {phase.Current}, " +
-                    $"and had been for {phase.Elapsed.TotalSeconds:F0} of those seconds.",
-                    expired);
+                throw phase.Explain(expired);
             }
 
             if (watchdog?.DuringTeardown.Count > 0)
@@ -296,40 +291,6 @@ namespace Opc.Ua.Samples.Tests
             Assert.That(connect.Session, Is.Null, "The sample client did not release its session on disconnect.");
 
             phase.Enter("shutting down");
-        }
-
-        /// <summary>
-        /// The step a sample client is in, so that a harness timeout says where it hung.
-        /// </summary>
-        /// <remarks>
-        /// Written on the message loop thread and read by the test thread once the clock has
-        /// run out. Neither the reference nor the reading of the stopwatch tears, and a
-        /// message which names the step before last would still be enough to go on, so the
-        /// two are left unsynchronized rather than locked on every step.
-        /// </remarks>
-        private sealed class ClientPhase
-        {
-            private readonly Stopwatch m_since = Stopwatch.StartNew();
-            private volatile string m_current = "starting up";
-
-            /// <summary>
-            /// What the client is doing, phrased to follow "It was ".
-            /// </summary>
-            public string Current => m_current;
-
-            /// <summary>
-            /// How long it has been in that step.
-            /// </summary>
-            public TimeSpan Elapsed => m_since.Elapsed;
-
-            /// <summary>
-            /// Records that the client moved on to the next step.
-            /// </summary>
-            public void Enter(string what)
-            {
-                m_current = what;
-                m_since.Restart();
-            }
         }
     }
 }

--- a/Tests/SampleClients.Tests/SampleClients.Tests.csproj
+++ b/Tests/SampleClients.Tests/SampleClients.Tests.csproj
@@ -37,6 +37,7 @@
     <ProjectReference Include="..\..\Workshop\UserAuthentication\Client\UserAuthentication Client.csproj" />
     <ProjectReference Include="..\..\Workshop\Views\Client\Views Client.csproj" />
     <ProjectReference Include="..\..\Samples\ReferenceClient\Reference Client.csproj" />
+    <ProjectReference Include="..\..\Samples\Client.Net4\UA Sample Client.csproj" />
     <ProjectReference Include="..\..\Samples\Controls.Net4\UA Sample Controls.csproj" />
   </ItemGroup>
 

--- a/Tests/Samples.Tests.Common/SampleServerHost.cs
+++ b/Tests/Samples.Tests.Common/SampleServerHost.cs
@@ -28,37 +28,47 @@ namespace Opc.Ua.Samples.Tests
     /// </remarks>
     public sealed class SampleServerHost : IAsyncDisposable
     {
-        private readonly ApplicationInstance m_application;
+        private readonly string m_name;
+        private readonly string m_configPath;
+        private readonly Func<ITelemetryContext, StandardServer> m_serverFactory;
+        private readonly Action<ApplicationConfiguration> m_configure;
         private readonly TemporaryPki m_pki;
-        private readonly StandardServer m_server;
-        private bool m_stopped;
+        private ApplicationInstance m_application;
+        private StandardServer m_server;
 
         private SampleServerHost(
-            ApplicationInstance application,
-            StandardServer server,
-            TemporaryPki pki,
-            string endpointUrl)
+            string name,
+            string configPath,
+            Func<ITelemetryContext, StandardServer> serverFactory,
+            Action<ApplicationConfiguration> configure,
+            TemporaryPki pki)
         {
-            m_application = application;
-            m_server = server;
+            m_name = name;
+            m_configPath = configPath;
+            m_serverFactory = serverFactory;
+            m_configure = configure;
             m_pki = pki;
-            EndpointUrl = endpointUrl;
         }
 
         /// <summary>
         /// The opc.tcp endpoint the server listens on.
         /// </summary>
-        public string EndpointUrl { get; }
+        public string EndpointUrl { get; private set; }
 
         /// <summary>
         /// The configuration the server was started with.
         /// </summary>
-        public ApplicationConfiguration Configuration => m_application.ApplicationConfiguration;
+        public ApplicationConfiguration Configuration => m_application?.ApplicationConfiguration;
 
         /// <summary>
-        /// The running server instance.
+        /// The running server instance, or null while the host is stopped.
         /// </summary>
         public StandardServer Server => m_server;
+
+        /// <summary>
+        /// Whether the server is currently listening.
+        /// </summary>
+        public bool IsRunning => m_application != null;
 
         /// <summary>
         /// Loads the configuration of a sample, creates its server and starts it.
@@ -85,18 +95,97 @@ namespace Opc.Ua.Samples.Tests
             }
 
             var pki = new TemporaryPki(name);
+            var host = new SampleServerHost(name, configPath, serverFactory, configure, pki);
+
+            try
+            {
+                await host.StartServerAsync(ct).ConfigureAwait(false);
+
+                return host;
+            }
+            catch
+            {
+                pki.Dispose();
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Stops the server and frees its endpoint, leaving the host able to start again.
+        /// </summary>
+        public async Task StopAsync()
+        {
+            ApplicationInstance application = m_application;
+            StandardServer server = m_server;
+
+            m_application = null;
+            m_server = null;
+
+            if (application == null)
+            {
+                return;
+            }
+
+            try
+            {
+                await application.StopAsync().ConfigureAwait(false);
+            }
+            catch (ServiceResultException)
+            {
+                // a server which is already down must not fail the test
+            }
+
+            server?.Dispose();
+
+            await application.DisposeAsync().ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Starts a new instance of the server on the same endpoint after <see cref="StopAsync"/>.
+        /// </summary>
+        /// <remarks>
+        /// The temporary PKI is kept, so the server comes back with the certificate a client
+        /// already knows. What the client sees is the server it was talking to going away and
+        /// returning, which is what a reconnect has to survive - not a different server which
+        /// happens to answer on the same port.
+        /// </remarks>
+        public Task StartAgainAsync(CancellationToken ct = default)
+        {
+            if (IsRunning)
+            {
+                throw new InvalidOperationException(
+                    $"{m_name}: the server is still running. Stop it before starting it again.");
+            }
+
+            return StartServerAsync(ct);
+        }
+
+        /// <inheritdoc/>
+        public async ValueTask DisposeAsync()
+        {
+            await StopAsync().ConfigureAwait(false);
+
+            m_pki.Dispose();
+        }
+
+        /// <summary>
+        /// Loads the configuration and starts one instance of the server from it.
+        /// </summary>
+        private async Task StartServerAsync(CancellationToken ct)
+        {
+            ApplicationInstance application = null;
             StandardServer server = null;
 
             try
             {
                 ApplicationConfiguration configuration =
-                    await SampleConfigurationLoader.LoadAsync(configPath, pki, ct).ConfigureAwait(false);
+                    await SampleConfigurationLoader.LoadAsync(m_configPath, m_pki, ct).ConfigureAwait(false);
 
-                string endpointUrl = KeepOpcTcpEndpointsOnly(configuration);
+                EndpointUrl = KeepOpcTcpEndpointsOnly(configuration);
 
-                configure?.Invoke(configuration);
+                m_configure?.Invoke(configuration);
 
-                var application = new ApplicationInstance(configuration, NullTelemetry.Instance);
+                application = new ApplicationInstance(configuration, NullTelemetry.Instance);
 
                 bool certificateOk = await application
                     .CheckApplicationInstanceCertificatesAsync(true, null, ct)
@@ -105,45 +194,29 @@ namespace Opc.Ua.Samples.Tests
                 if (!certificateOk)
                 {
                     throw new InvalidOperationException(
-                        $"{name}: the application instance certificate could not be created.");
+                        $"{m_name}: the application instance certificate could not be created.");
                 }
 
-                server = serverFactory(NullTelemetry.Instance);
+                server = m_serverFactory(NullTelemetry.Instance);
 
                 await application.StartAsync(server, ct).ConfigureAwait(false);
 
-                return new SampleServerHost(application, server, pki, endpointUrl);
+                m_application = application;
+                m_server = server;
             }
             catch
             {
+                // a half started server holds its listener, and a second attempt on the same
+                // port would fail for a reason which has nothing to do with the first failure
                 server?.Dispose();
-                pki.Dispose();
+
+                if (application != null)
+                {
+                    await application.DisposeAsync().ConfigureAwait(false);
+                }
+
                 throw;
             }
-        }
-
-        /// <inheritdoc/>
-        public async ValueTask DisposeAsync()
-        {
-            if (!m_stopped)
-            {
-                m_stopped = true;
-
-                try
-                {
-                    await m_application.StopAsync().ConfigureAwait(false);
-                }
-                catch (ServiceResultException)
-                {
-                    // a server which is already down must not fail the test
-                }
-            }
-
-            m_server?.Dispose();
-
-            await m_application.DisposeAsync().ConfigureAwait(false);
-
-            m_pki.Dispose();
         }
 
         /// <summary>

--- a/Tests/Samples.Tests.WinForms/ClientPhase.cs
+++ b/Tests/Samples.Tests.WinForms/ClientPhase.cs
@@ -1,0 +1,63 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Diagnostics;
+
+namespace Opc.Ua.Samples.Tests
+{
+    /// <summary>
+    /// The step a sample client is in, so that a harness timeout says where it hung.
+    /// </summary>
+    /// <remarks>
+    /// Written on the message loop thread and read by the test thread once the clock has
+    /// run out. Neither the reference nor the reading of the stopwatch tears, and a
+    /// message which names the step before last would still be enough to go on, so the
+    /// two are left unsynchronized rather than locked on every step.
+    /// </remarks>
+    public sealed class ClientPhase
+    {
+        private readonly Stopwatch m_since = Stopwatch.StartNew();
+        private volatile string m_current = "starting up";
+
+        /// <summary>
+        /// What the client is doing, phrased to follow "It was ".
+        /// </summary>
+        public string Current => m_current;
+
+        /// <summary>
+        /// How long it has been in that step.
+        /// </summary>
+        public TimeSpan Elapsed => m_since.Elapsed;
+
+        /// <summary>
+        /// Records that the client moved on to the next step.
+        /// </summary>
+        public void Enter(string what)
+        {
+            m_current = what;
+            m_since.Restart();
+        }
+
+        /// <summary>
+        /// Turns a harness timeout into one which names the step the client hung in.
+        /// </summary>
+        public TimeoutException Explain(TimeoutException expired)
+        {
+            ArgumentNullException.ThrowIfNull(expired);
+
+            // the bare message says only that the clock ran out, which is the same for
+            // every way a sample can hang. The step it was in is what tells them apart.
+            return new TimeoutException(
+                $"{expired.Message} It was {Current}, " +
+                $"and had been for {Elapsed.TotalSeconds:F0} of those seconds.",
+                expired);
+        }
+    }
+}

--- a/Tests/Samples.Tests.WinForms/DialogWatchdog.cs
+++ b/Tests/Samples.Tests.WinForms/DialogWatchdog.cs
@@ -32,6 +32,7 @@ namespace Opc.Ua.Samples.Tests
     {
         private readonly List<string> m_captured = [];
         private readonly List<string> m_duringTeardown = [];
+        private readonly Dictionary<Type, string> m_accepted = [];
         private readonly Timer m_timer;
         private bool m_disposed;
 
@@ -48,6 +49,24 @@ namespace Opc.Ua.Samples.Tests
         /// What the dialogs said, in the order they appeared.
         /// </summary>
         public IReadOnlyList<string> Captured => m_captured;
+
+        /// <summary>
+        /// Clicks a button of a dialog the sample opens on purpose, instead of cancelling it
+        /// and reporting it as a complaint.
+        /// </summary>
+        /// <remarks>
+        /// Not every modal dialog of a sample is an error. The UA Sample Client opens its
+        /// session through a modal dialog, and a test which drives that sample has to answer
+        /// it the way a user would - otherwise the only two outcomes are a cancelled connect
+        /// or a hang. Registering the dialog here keeps everything else the sample opens a
+        /// failure, so this cannot silently swallow the next complaint.
+        /// </remarks>
+        /// <typeparam name="TDialog">The dialog to answer.</typeparam>
+        /// <param name="buttonName">The designer name of the button to click.</param>
+        public void Accept<TDialog>(string buttonName) where TDialog : Form
+        {
+            m_accepted[typeof(TDialog)] = buttonName;
+        }
 
         /// <summary>
         /// Starts watching.
@@ -135,6 +154,12 @@ namespace Opc.Ua.Samples.Tests
                 .Where(form => form.Modal && BelongsToThisThread(form))
                 .ToArray())
             {
+                if (m_accepted.TryGetValue(form.GetType(), out string buttonName))
+                {
+                    ClickAccepted(form, buttonName);
+                    continue;
+                }
+
                 m_captured.Add(Describe(form));
 
                 try
@@ -151,6 +176,60 @@ namespace Opc.Ua.Samples.Tests
                     // nor one whose window is already gone
                 }
             }
+        }
+
+        /// <summary>
+        /// Clicks the button of a dialog the test registered with <see cref="Accept{TDialog}"/>.
+        /// </summary>
+        /// <remarks>
+        /// The button of a dialog which is already working on the previous click is disabled,
+        /// and clicking it again would start the operation twice. Skipping a disabled button
+        /// is what lets the watchdog keep ticking while the dialog does its work.
+        /// </remarks>
+        private void ClickAccepted(Form form, string buttonName)
+        {
+            try
+            {
+                if (FindButton(form, buttonName) is not Button button)
+                {
+                    m_captured.Add($"{Describe(form)} <no button '{buttonName}' to click>");
+                    form.DialogResult = DialogResult.Cancel;
+                    form.Close();
+                    return;
+                }
+
+                if (button.Enabled)
+                {
+                    button.PerformClick();
+                }
+            }
+            catch (Exception e) when (e is InvalidOperationException or COMException or ObjectDisposedException)
+            {
+                // a dialog which closed itself between the scan and the click is not a failure
+            }
+        }
+
+        /// <summary>
+        /// Finds a button of a dialog by its designer name.
+        /// </summary>
+        private static Control FindButton(Control parent, string name)
+        {
+            foreach (Control child in parent.Controls)
+            {
+                if (child is Button && string.Equals(child.Name, name, StringComparison.Ordinal))
+                {
+                    return child;
+                }
+
+                Control found = FindButton(child, name);
+
+                if (found != null)
+                {
+                    return found;
+                }
+            }
+
+            return null;
         }
 
         /// <summary>

--- a/Tests/Samples.Tests.WinForms/WinFormsHarness.cs
+++ b/Tests/Samples.Tests.WinForms/WinFormsHarness.cs
@@ -110,18 +110,31 @@ namespace Opc.Ua.Samples.Tests
         /// </summary>
         public static Control FindControl(Control parent, string name)
         {
-            if (parent == null)
+            return FindField<Control>(parent, name);
+        }
+
+        /// <summary>
+        /// Reads a private field of a form or control by name.
+        /// </summary>
+        /// <remarks>
+        /// The samples keep what they connected with in private fields, and a test which has
+        /// to check that - the session of the UA Sample Client, for instance - reads it here
+        /// rather than widening the sample just to be observable.
+        /// </remarks>
+        public static T FindField<T>(object instance, string name) where T : class
+        {
+            if (instance == null)
             {
-                throw new ArgumentNullException(nameof(parent));
+                throw new ArgumentNullException(nameof(instance));
             }
 
-            for (Type type = parent.GetType(); type != null; type = type.BaseType)
+            for (Type type = instance.GetType(); type != null; type = type.BaseType)
             {
                 FieldInfo field = type.GetField(name, BindingFlags.Instance | BindingFlags.NonPublic);
 
-                if (field?.GetValue(parent) is Control control)
+                if (field?.GetValue(instance) is T value)
                 {
-                    return control;
+                    return value;
                 }
             }
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -365,7 +365,7 @@ since the server started.
 
 ## What Tier 2 checks today
 
-17 test cases, about a minute, Windows only. For each WinForms sample client the test
+20 test cases, about a minute, Windows only. For each WinForms sample client the test
 starts its sample server in process, then on a dedicated STA thread with a running message
 loop - but without ever showing a window:
 
@@ -392,10 +392,37 @@ reaches the user interface.
 `Server_ServerStatus_CurrentTime` through the `MonitoredItemConfigCtrl` grid, applies, and
 waits for a data change to land in the `DataChangeNotificationListCtrl` of the dialog.
 
+`ClientReconnectTests` is the only test which takes the server away. A connect proves that the
+sample talks to a `ManagedSession`; it does not prove that the managed session does the one
+thing it was brought in for. The test connects the Reference Client, subscribes through the V2
+engine and waits for a data change, then **stops the sample server**, waits for the session to
+report `Reconnecting`, **starts the server again on the same endpoint and with the same
+certificate**, and then asserts three things: the session came back `Connected` on its own, the
+connect control is still holding the *same* `ISession` instance, and data changes are arriving
+again. The middle one matters most - the samples no longer rebuild their browse tree around a
+reconnect because the managed session keeps its identity, and this is what would catch that
+assumption breaking. `SampleServerHost.StopAsync`/`StartAgainAsync` are what let a test do
+this; they keep the temporary PKI, so the client sees its server come back rather than a
+different one on the same port.
+
+> The server has to be stopped and started off the message loop (`Task.Run`). It counts its
+> shutdown down and closes the channels the client is still on, and doing that on the thread
+> which also pumps the client's callbacks deadlocks the two.
+
+`SampleClientFormTests` covers the one client the loop above cannot: the **UA Sample Client**
+has no shared connect control and opens its session through the modal `SessionOpenDlg`, so it
+is a declared gap in `SampleClientFactories`. Its own fixture builds `SampleClientForm`, picks
+an endpoint, calls the form's `ConnectAsync` and lets the watchdog click OK on the session
+dialog, then asserts the sample opened a `ManagedSession` running the V2 subscription engine
+and filled its browse tree.
+
 The **dialog watchdog** is what makes this safe: the sample clients report errors through a
 modal `ExceptionDlg`, which in an unattended run would wait forever for a click. A timer on
 the UI thread closes any modal form, keeps its text, and the harness fails the test with it.
-`WatchdogTurnsAModalDialogIntoAFailure` proves the watchdog itself works.
+`WatchdogTurnsAModalDialogIntoAFailure` proves the watchdog itself works. A dialog a sample
+opens *on purpose* is registered with `watchdog.Accept<TDialog>(buttonName)` and answered by
+clicking that button instead - everything else stays a failure, so this cannot quietly swallow
+the next complaint.
 
 The fixture is `[Category("RequiresDesktop")]` because it needs a window station. CI runs it:
 the `Test Samples` job is on a Windows agent and filters nothing out. The category is there so


### PR DESCRIPTION
Closes #771.

Both foundation issues have landed — #805 for `ClientControls.Net4`, #809 for `Controls.Net4` — so the two headline desktop clients already run on a `ManagedSession` and the V2 subscription engine through their shared controls. What was left in the apps themselves was the bookkeeping which only made sense while a reconnect handed out a *new* session, and the verification the issue asks for.

## The samples

**ReferenceClient** — `MainForm` no longer blanks its browse tree on `ReconnectStarting` and rebinds it on `ReconnectComplete`. The managed session keeps the same `ISession` instance across a reconnect, so that dance only cost the user their tree and their expansion state on every transient blip; the status strip of the connect control already reports the reconnect. The dead `m_connectedOnce` flag is gone, and the Disconnect menu item no longer blocks the UI thread on a synchronous close.

**UA Sample Client** — nothing to migrate. `SampleClientForm` is a shell over `ClientForm`, which #809 moved to `ManagedSession` and the V2 engine. That is now written down on the class rather than left to be rediscovered.

## The verification

This is the part of #771 which had nothing behind it. Two new tier 2 fixtures:

**`ClientReconnectTests`** is the first test in the suite which takes the server away. It connects the Reference Client, subscribes through the V2 engine and waits for a data change, then **stops the sample server**, waits for the session to report `Reconnecting`, **starts it again on the same endpoint and with the same certificate**, and asserts three things:

- the session came back `Connected` on its own,
- the connect control is still holding the **same** `ISession` instance,
- data changes are arriving again.

The middle one is what guards the change above: it is the assumption the sample now relies on, and this is what would catch it breaking.

**`SampleClientFormTests`** closes the `"Sample"` gap in tier 2. The UA Sample Client has no shared connect control and opens its session through the modal `SessionOpenDlg`, which is why the generic smoke test cannot drive it. This drives it the way a user would — pick an endpoint, let the dialog come up, click OK — and asserts the sample opened a `ManagedSession` running the V2 subscription engine and filled its browse tree.

## Harness changes these needed

- `SampleServerHost` gains `StopAsync`/`StartAgainAsync`. The temporary PKI is kept, so the client sees *its own* server come back rather than a stranger answering on the same port. A half started server now also disposes its `ApplicationInstance`, which the previous shape leaked.
- `DialogWatchdog` gains `Accept<TDialog>(button)` for a modal dialog a sample opens *on purpose*. Everything else it finds is still a failure, so this cannot quietly swallow the next complaint.
- `ClientPhase` moves out of `SampleClientTests` into the harness project so both fixtures report which step they hung in.

> One trap worth recording for anyone writing a similar test: the server has to be stopped and started **off the message loop**. It counts its shutdown down and closes the channels the client is still on, and doing that on the thread which also pumps the client's callbacks deadlocks the two — the first version of this test sat in "stopping the server" for 157 seconds.

## Verified

Clean rebuild of `UA Samples.slnx`: 0 errors, and the only warnings are the eight which were already there before this branch. Full suite on Windows:

| Suite | Result |
|---|---|
| SampleConfiguration.Tests | 143 passed |
| SampleServers.Tests | 88 passed |
| SampleNodeManagers.Tests | 91 passed, 1 skipped |
| SampleClients.Tests | 20 passed |

Both new tests were mutation checked: dropping the watchdog registration makes `SampleClientFormTests` fail on the null session, and the reconnect test failed loudly (naming the step) while the deadlock above was still in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
