### PR TITLE
Replace Variant.AsBoxedObject() with the type safe TryGet pattern

### DIFF
--- a/Samples/ClientControls.Net4/Browse/AttributeListCtrl.cs
+++ b/Samples/ClientControls.Net4/Browse/AttributeListCtrl.cs
@@ -201,15 +201,15 @@ namespace Opc.Ua.Client.Controls
         /// <summary>
         /// Formats the value of an attribute.
         /// </summary>
-        private async Task<string> FormatAttributeValueAsync(uint attributeId, object value, CancellationToken ct = default)
+        private async Task<string> FormatAttributeValueAsync(uint attributeId, Variant value, CancellationToken ct = default)
         {
             switch (attributeId)
             {
                 case Attributes.NodeClass:
                 {
-                    if (value != null)
+                    if (value.TryGetValue(out int nodeClass))
                     {
-                        return String.Format("{0}", Enum.ToObject(typeof(NodeClass), value));
+                        return String.Format("{0}", (NodeClass)nodeClass);
                     }
 
                     return "(null)";
@@ -217,7 +217,7 @@ namespace Opc.Ua.Client.Controls
 
                 case Attributes.DataType:
                 {
-                    NodeId datatypeId = value is NodeId dt ? dt : NodeId.Null;
+                    NodeId datatypeId = value.TryGetValue(out NodeId dt) ? dt : NodeId.Null;
 
                     if (!datatypeId.IsNull)
                     {
@@ -238,11 +238,9 @@ namespace Opc.Ua.Client.Controls
 
                 case Attributes.ValueRank:
                 {
-                    int? valueRank = value as int?;
-
-                    if (valueRank != null)
+                    if (value.TryGetValue(out int valueRank))
                     {
-                        switch (valueRank.Value)
+                        switch (valueRank)
                         {
                             case ValueRanks.Scalar: return "Scalar";
                             case ValueRanks.OneDimension: return "OneDimension";
@@ -251,7 +249,7 @@ namespace Opc.Ua.Client.Controls
 
                             default:
                             {
-                                return String.Format("{0}", valueRank.Value);
+                                return String.Format("{0}", valueRank);
                             }
                         }
                     }
@@ -261,21 +259,19 @@ namespace Opc.Ua.Client.Controls
 
                 case Attributes.MinimumSamplingInterval:
                 {
-                    double? minimumSamplingInterval = value as double?;
-
-                    if (minimumSamplingInterval != null)
+                    if (value.TryGetValue(out double minimumSamplingInterval))
                     {
-                        if (minimumSamplingInterval.Value == MinimumSamplingIntervals.Indeterminate)
+                        if (minimumSamplingInterval == MinimumSamplingIntervals.Indeterminate)
                         {
                             return "Indeterminate";
                         }
 
-                        else if (minimumSamplingInterval.Value == MinimumSamplingIntervals.Continuous)
+                        else if (minimumSamplingInterval == MinimumSamplingIntervals.Continuous)
                         {
                             return "Continuous";
                         }
 
-                        return String.Format("{0}", minimumSamplingInterval.Value);
+                        return String.Format("{0}", minimumSamplingInterval);
                     }
 
                     return String.Format("{0}", value);
@@ -284,7 +280,7 @@ namespace Opc.Ua.Client.Controls
                 case Attributes.AccessLevel:
                 case Attributes.UserAccessLevel:
                 {
-                    byte accessLevel = Convert.ToByte(value);
+                    value.TryGetValue(out byte accessLevel);
 
                     StringBuilder bits = new StringBuilder();
 
@@ -333,7 +329,7 @@ namespace Opc.Ua.Client.Controls
 
                 case Attributes.EventNotifier:
                 {
-                    byte notifier = Convert.ToByte(value);
+                    value.TryGetValue(out byte notifier);
 
                     StringBuilder bits = new StringBuilder();
 
@@ -399,7 +395,7 @@ namespace Opc.Ua.Client.Controls
                 }
                 else
                 {
-                    listItem.SubItems[1].Text = await FormatAttributeValueAsync(info.AttributeId, info.Value.WrappedValue.AsBoxedObject(), ct);
+                    listItem.SubItems[1].Text = await FormatAttributeValueAsync(info.AttributeId, info.Value.WrappedValue, ct);
                 }
 
                 if (info.AttributeId != Attributes.Value)

--- a/Samples/ClientControls.Net4/ClientUtils.cs
+++ b/Samples/ClientControls.Net4/ClientUtils.cs
@@ -227,11 +227,9 @@ namespace Opc.Ua.Client.Controls
                 case Attributes.AccessLevel:
                 case Attributes.UserAccessLevel:
                 {
-                    byte? field = value.AsBoxedObject() as byte?;
-
-                    if (field != null)
+                    if (value.TryGetValue(out byte accessLevel))
                     {
-                        return GetAccessLevelDisplayText(field.Value);
+                        return GetAccessLevelDisplayText(accessLevel);
                     }
 
                     break;
@@ -239,11 +237,9 @@ namespace Opc.Ua.Client.Controls
 
                 case Attributes.EventNotifier:
                 {
-                    byte? field = value.AsBoxedObject() as byte?;
-
-                    if (field != null)
+                    if (value.TryGetValue(out byte eventNotifier))
                     {
-                        return GetEventNotifierDisplayText(field.Value);
+                        return GetEventNotifierDisplayText(eventNotifier);
                     }
 
                     break;
@@ -251,17 +247,15 @@ namespace Opc.Ua.Client.Controls
 
                 case Attributes.DataType:
                 {
-                    NodeId dataTypeId = value.AsBoxedObject() is NodeId dt ? dt : NodeId.Null;
+                    NodeId dataTypeId = value.TryGetValue(out NodeId dt) ? dt : NodeId.Null;
                     return await session.NodeCache.GetDisplayTextAsync(dataTypeId, ct);
                 }
 
                 case Attributes.ValueRank:
                 {
-                    int? field = value.AsBoxedObject() as int?;
-
-                    if (field != null)
+                    if (value.TryGetValue(out int valueRank))
                     {
-                        return GetValueRankDisplayText(field.Value);
+                        return GetValueRankDisplayText(valueRank);
                     }
 
                     break;
@@ -269,11 +263,9 @@ namespace Opc.Ua.Client.Controls
 
                 case Attributes.NodeClass:
                 {
-                    int? field = value.AsBoxedObject() as int?;
-
-                    if (field != null)
+                    if (value.TryGetValue(out int nodeClass))
                     {
-                        return ((NodeClass)field.Value).ToString();
+                        return ((NodeClass)nodeClass).ToString();
                     }
 
                     break;
@@ -281,7 +273,7 @@ namespace Opc.Ua.Client.Controls
 
                 case Attributes.NodeId:
                 {
-                    if (value.AsBoxedObject() is NodeId field && !field.IsNull)
+                    if (value.TryGetValue(out NodeId field) && !field.IsNull)
                     {
                         return field.ToString();
                     }
@@ -291,7 +283,7 @@ namespace Opc.Ua.Client.Controls
 
                 case Attributes.DataTypeDefinition:
                 {
-                    if (value.AsBoxedObject() is ExtensionObject field)
+                    if (value.TryGetValue(out ExtensionObject field))
                     {
                         return field.ToString();
                     }
@@ -300,9 +292,9 @@ namespace Opc.Ua.Client.Controls
             }
 
             // check for byte strings.
-            if (value.AsBoxedObject() is byte[])
+            if (value.TryGetValue(out ByteString byteString))
             {
-                return Utils.ToHexString(value.AsBoxedObject() as byte[]);
+                return Utils.ToHexString(byteString.Span);
             }
 
             // use default format.
@@ -654,7 +646,7 @@ namespace Opc.Ua.Client.Controls
 
                     if (clause.BrowsePath.Count == 1 && clause.BrowsePath[0] == BrowseNames.EventType)
                     {
-                        return notification.EventFields[ii].AsBoxedObject() is NodeId nodeId ? nodeId : NodeId.Null;
+                        return notification.EventFields[ii].TryGetValue(out NodeId nodeId) ? nodeId : NodeId.Null;
                     }
                 }
             }

--- a/Samples/ClientControls.Net4/Common/Client/AttrributesListViewCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/AttrributesListViewCtrl.cs
@@ -177,7 +177,7 @@ namespace Opc.Ua.Client.Controls
                 }
 
                 item.Tag = new AttributeInfo() { NodeToRead = nodesToRead[ii], Value = results[ii] };
-                item.ImageIndex = ClientUtils.GetImageIndex(nodesToRead[ii].AttributeId, results[ii].WrappedValue.AsBoxedObject());
+                item.ImageIndex = ClientUtils.GetImageIndex(nodesToRead[ii].AttributeId, results[ii].WrappedValue);
 
                 // display in list.
                 AttributesLV.Items.Add(item);
@@ -274,7 +274,7 @@ namespace Opc.Ua.Client.Controls
             {
                 ReferenceDescription reference = (ReferenceDescription)nodesToRead[ii].Handle;
 
-                TypeInfo typeInfo = TypeInfo.Construct(results[ii].WrappedValue.AsBoxedObject());
+                TypeInfo typeInfo = results[ii].WrappedValue.TypeInfo;
 
                 // add the metadata for the attribute.
                 ListViewItem item = new ListViewItem(reference.ToString());
@@ -328,7 +328,7 @@ namespace Opc.Ua.Client.Controls
                     info.NodeToRead.NodeId,
                     info.NodeToRead.AttributeId,
                     null,
-                    info.Value.WrappedValue.AsBoxedObject(),
+                    info.Value.WrappedValue,
                     true,
                     "View Attribute Value");
             }

--- a/Samples/ClientControls.Net4/Common/Client/BrowseTreeViewCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/BrowseTreeViewCtrl.cs
@@ -446,11 +446,10 @@ namespace Opc.Ua.Client.Controls
                                 if (nodeIds.Count > 0 && !nodeIds[0].IsNull)
                                 {
                                     DataValue value = await m_session.ReadValueAsync(nodeIds[0]);
-                                    byte[] bytes = value.WrappedValue.AsBoxedObject() as byte[];
 
-                                    if (bytes != null)
+                                    if (value.WrappedValue.TryGetValue(out ByteString bytes))
                                     {
-                                        System.IO.MemoryStream istrm = new System.IO.MemoryStream(bytes);
+                                        System.IO.MemoryStream istrm = new System.IO.MemoryStream(bytes.ToArray());
                                         Image icon = Image.FromStream(istrm);
                                         BrowseTV.ImageList.Images.Add(icon);
                                         m_typeImageMapping[(NodeId)reference.TypeDefinition] = BrowseTV.ImageList.Images.Count - 1;

--- a/Samples/ClientControls.Net4/Common/Client/CallRequestListViewCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/CallRequestListViewCtrl.cs
@@ -133,7 +133,7 @@ namespace Opc.Ua.Client.Controls
             {
                 Argument argument = (Argument)row[0];
                 Variant value = (Variant)row[4];
-                argument.Value = value.AsBoxedObject();
+                argument.Value = value;
                 inputArguments.Add(value);
             }
 
@@ -255,7 +255,7 @@ namespace Opc.Ua.Client.Controls
             }
 
             row[0] = argument;
-            row[1] = ImageList.Images[ClientUtils.GetImageIndex(isOutputArgument, value.AsBoxedObject())];
+            row[1] = ImageList.Images[ClientUtils.GetImageIndex(isOutputArgument, value)];
             row[2] = argument.Name;
             row[3] = dataType;
             row[4] = value;
@@ -380,7 +380,7 @@ namespace Opc.Ua.Client.Controls
                     #pragma warning restore CA2000
                         new TypeInfo(builtInType, argument.ValueRank),
                         argument.Name,
-                        argument.Value,
+                        ClientUtils.ToVariant(argument.Value),
                         "Edit Input Argument");
 
                     if (result != null)

--- a/Samples/ClientControls.Net4/Common/Client/EditComplexValue2Dlg.cs
+++ b/Samples/ClientControls.Net4/Common/Client/EditComplexValue2Dlg.cs
@@ -111,12 +111,7 @@ namespace Opc.Ua.Client.Controls
             // get the source type.
             TypeInfo sourceType = value.TypeInfo;
 
-            if (sourceType.IsUnknown)
-            {
-                sourceType = TypeInfo.Construct(value.AsBoxedObject());
-            }
-
-            m_value = ClientUtils.ToVariant(value.AsBoxedObject());
+            m_value = value;
 
             // display value as text.
             StringBuilder buffer = new StringBuilder();
@@ -140,17 +135,12 @@ namespace Opc.Ua.Client.Controls
 
                 if (sourceType.ValueRank == ValueRanks.Scalar)
                 {
-                    extension = (ExtensionObject)m_value.AsBoxedObject();
+                    m_value.TryGetValue(out extension);
                 }
-                else
+                else if (m_value.TryGetValue(out ArrayOf<ExtensionObject> list) && list.Count > 0)
                 {
                     // only use the first item in the list for arrays.
-                    ExtensionObject[] list = (ExtensionObject[])m_value.AsBoxedObject();
-
-                    if (list.Length > 0)
-                    {
-                        extension = list[0];
-                    }
+                    extension = list[0];
                 }
 
                 encodingId = extension.TypeId;

--- a/Samples/ClientControls.Net4/Common/Client/EditComplexValueCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/EditComplexValueCtrl.cs
@@ -250,23 +250,7 @@ namespace Opc.Ua.Client.Controls.Common
             AccessInfo info = NavigationMENU.Items[NavigationMENU.Items.Count - 1].Tag as AccessInfo;
 
             TypeInfo currentType = info.TypeInfo;
-            object currentValue = info.Value;
-
-            if (info.Value is Variant)
-            {
-                Variant variant = (Variant)info.Value;
-                currentValue = variant.AsBoxedObject();
-
-                if (currentValue != null)
-                {
-                    currentType = variant.TypeInfo;
-
-                    if (currentType.IsUnknown)
-                    {
-                        currentType = TypeInfo.Construct(currentValue);
-                    }
-                }
-            }
+            object currentValue = Unwrap(info.Value, ref currentType);
 
             int[] dimensions = null;
 
@@ -403,21 +387,7 @@ namespace Opc.Ua.Client.Controls.Common
                 currentValue = TypeInfo.GetDefaultValue(currentType.BuiltInType);
             }
 
-            if (info.Value is Variant)
-            {
-                Variant variant = (Variant)info.Value;
-                currentValue = variant.AsBoxedObject();
-
-                if (currentValue != null)
-                {
-                    currentType = variant.TypeInfo;
-
-                    if (currentType.IsUnknown)
-                    {
-                        currentType = TypeInfo.Construct(currentValue);
-                    }
-                }
-            }
+            currentValue = Unwrap(info.Value, ref currentType);
 
             TypeInfo targetType = new TypeInfo(builtInType, currentType.ValueRank);
             object newValue = Convert(currentValue, currentType, targetType, true);
@@ -713,23 +683,8 @@ namespace Opc.Ua.Client.Controls.Common
             item.Tag = parent;
 
             TypeInfo typeInfo = parent.TypeInfo;
-            object value = parent.Value;
-
-            if (value is Variant)
-            {
-                Variant variant = (Variant)value;
-                value = variant.AsBoxedObject();
-
-                if (value != null)
-                {
-                    parent.TypeInfo = typeInfo = variant.TypeInfo;
-
-                    if (typeInfo.IsUnknown)
-                    {
-                        parent.TypeInfo = typeInfo = TypeInfo.Construct(value);
-                    }
-                }
-            }
+            object value = Unwrap(parent.Value, ref typeInfo);
+            parent.TypeInfo = typeInfo;
 
             if (typeInfo.ValueRank >= 0)
             {
@@ -943,6 +898,25 @@ namespace Opc.Ua.Client.Controls.Common
 
         #region Private Methods
         /// <summary>
+        /// Unwraps a Variant into the boxed value that this reflection based editor
+        /// navigates, and reports the type information carried by the Variant.
+        /// </summary>
+        private static object Unwrap(object value, ref TypeInfo typeInfo)
+        {
+            if (value is Variant variant)
+            {
+                if (!variant.IsNull)
+                {
+                    typeInfo = variant.TypeInfo;
+                }
+
+                return variant.AsBoxedObject();
+            }
+
+            return value;
+        }
+
+        /// <summary>
         /// Returns the index based on the current count.
         /// </summary>
         private int[] GetIndexFromCount(int count, int[] dimensions)
@@ -988,7 +962,7 @@ namespace Opc.Ua.Client.Controls.Common
             row[1] = info.Name;
             row[2] = GetDataTypeString(info);
             row[3] = ValueToString(info.Value, info.TypeInfo);
-            row[4] = ImageList.Images[ClientUtils.GetImageIndex(Attributes.Value, info.Value)];
+            row[4] = ImageList.Images[ClientUtils.GetImageIndex(Attributes.Value, ClientUtils.ToVariant(info.Value))];
 
             m_dataset.Tables[0].Rows.Add(row);
         }
@@ -1104,7 +1078,7 @@ namespace Opc.Ua.Client.Controls.Common
             row[1] = (info.Name != null) ? info.Name : "unknown";
             row[2] = GetDataTypeString(info);
             row[3] = ValueToString(info.Value, info.TypeInfo);
-            row[4] = ImageList.Images[ClientUtils.GetImageIndex(Attributes.Value, info.Value)];
+            row[4] = ImageList.Images[ClientUtils.GetImageIndex(Attributes.Value, ClientUtils.ToVariant(info.Value))];
 
             m_dataset.Tables[0].Rows.Add(row);
         }
@@ -1232,21 +1206,7 @@ namespace Opc.Ua.Client.Controls.Common
                 return String.Empty;
             }
 
-            if (value is Variant)
-            {
-                Variant variant = (Variant)value;
-                value = variant.AsBoxedObject();
-
-                if (value != null)
-                {
-                    typeInfo = variant.TypeInfo;
-
-                    if (typeInfo.IsUnknown)
-                    {
-                        typeInfo = TypeInfo.Construct(value);
-                    }
-                }
-            }
+            value = Unwrap(value, ref typeInfo);
 
             if (typeInfo.ValueRank >= 0)
             {
@@ -1362,7 +1322,7 @@ namespace Opc.Ua.Client.Controls.Common
                 }
             }
 
-            return (string)ClientUtils.ToVariant(value).ConvertTo(BuiltInType.String).AsBoxedObject();
+            return ClientUtils.ToVariant(value).ConvertTo(BuiltInType.String).TryGetValue(out string valueText) ? valueText : String.Empty;
         }
 
         /// <summary>
@@ -1376,19 +1336,7 @@ namespace Opc.Ua.Client.Controls.Common
             }
 
             TypeInfo typeInfo = info.TypeInfo;
-            object value = info.Value;
-
-            if (value is Variant)
-            {
-                Variant variant = (Variant)info.Value;
-                typeInfo = variant.TypeInfo;
-                value = variant.AsBoxedObject();
-
-                if (typeInfo.IsUnknown)
-                {
-                    typeInfo = TypeInfo.Construct(value);
-                }
-            }
+            object value = Unwrap(info.Value, ref typeInfo);
 
             if (typeInfo.ValueRank >= 0)
             {

--- a/Samples/ClientControls.Net4/Common/Client/EditComplexValueDlg.cs
+++ b/Samples/ClientControls.Net4/Common/Client/EditComplexValueDlg.cs
@@ -74,7 +74,7 @@ namespace Opc.Ua.Client.Controls
             NodeId nodeId,
             uint attributeId,
             string name,
-            object value,
+            Variant value,
             bool readOnly,
             string caption,
             CancellationToken ct = default)
@@ -87,7 +87,9 @@ namespace Opc.Ua.Client.Controls
             OkBTN.Visible = !readOnly;
 
             ValueCTRL.ChangeSession(session);
-            await ValueCTRL.ShowValueAsync(nodeId, attributeId, name, value, readOnly, ct);
+
+            // the editor navigates boxed CLR values, so the Variant is unwrapped for it.
+            await ValueCTRL.ShowValueAsync(nodeId, attributeId, name, value.AsBoxedObject(), readOnly, ct);
 
             if (base.ShowDialog() != DialogResult.OK)
             {
@@ -105,7 +107,7 @@ namespace Opc.Ua.Client.Controls
             string name,
             NodeId dataType,
             int valueRank,
-            object value,
+            Variant value,
             string caption)
         {
             m_telemetry = session?.MessageContext?.Telemetry;
@@ -117,7 +119,9 @@ namespace Opc.Ua.Client.Controls
             OkBTN.Visible = true;
 
             ValueCTRL.ChangeSession(session);
-            ValueCTRL.ShowValue(name, dataType, valueRank, value);
+
+            // the editor navigates boxed CLR values, so the Variant is unwrapped for it.
+            ValueCTRL.ShowValue(name, dataType, valueRank, value.AsBoxedObject());
 
             if (base.ShowDialog() != DialogResult.OK)
             {
@@ -133,7 +137,7 @@ namespace Opc.Ua.Client.Controls
         public object ShowDialog(
             TypeInfo expectedType,
             string name,
-            object value,
+            Variant value,
             string caption)
         {
             if (!String.IsNullOrEmpty(caption))
@@ -144,7 +148,9 @@ namespace Opc.Ua.Client.Controls
             OkBTN.Visible = true;
 
             ValueCTRL.ChangeSession(null);
-            ValueCTRL.ShowValue(expectedType, name, value);
+
+            // the editor navigates boxed CLR values, so the Variant is unwrapped for it.
+            ValueCTRL.ShowValue(expectedType, name, value.AsBoxedObject());
 
             if (base.ShowDialog() != DialogResult.OK)
             {
@@ -169,10 +175,11 @@ namespace Opc.Ua.Client.Controls
             NodeId nodeId,
             uint attributeId,
             string name,
-            object value,
+            Variant value,
             CancellationToken ct = default)
         {
-            return ValueCTRL.ShowValueAsync(nodeId, attributeId, name, value, true, ct);
+            // the editor navigates boxed CLR values, so the Variant is unwrapped for it.
+            return ValueCTRL.ShowValueAsync(nodeId, attributeId, name, value.AsBoxedObject(), true, ct);
         }
         #endregion
 

--- a/Samples/ClientControls.Net4/Common/Client/EditValueCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/EditValueCtrl.cs
@@ -111,7 +111,7 @@ namespace Opc.Ua.Client.Controls
             #pragma warning restore CA2000
                 m_value.TypeInfo,
                 null,
-                m_value.AsBoxedObject(),
+                m_value,
                 "Edit Value");
 
             if (value == null)

--- a/Samples/ClientControls.Net4/Common/Client/EditWriteValueDlg.cs
+++ b/Samples/ClientControls.Net4/Common/Client/EditWriteValueDlg.cs
@@ -82,19 +82,25 @@ namespace Opc.Ua.Client.Controls
 
             if (nodeToWrite.Value.StatusCode != StatusCodes.Good)
             {
-                StatusCodeTB.Text = (string)Variant.From(nodeToWrite.Value.StatusCode).ConvertTo(BuiltInType.String).AsBoxedObject();
+                StatusCodeTB.Text = Variant.From(nodeToWrite.Value.StatusCode)
+                    .ConvertTo(BuiltInType.String)
+                    .TryGetValue(out string statusCodeText) ? statusCodeText : String.Empty;
                 StatusCodeCK.Checked = true;
             }
 
             if (nodeToWrite.Value.SourceTimestamp != DateTime.MinValue)
             {
-                SourceTimestampTB.Text = (string)Variant.From(nodeToWrite.Value.SourceTimestamp).ConvertTo(BuiltInType.String).AsBoxedObject();
+                SourceTimestampTB.Text = Variant.From(nodeToWrite.Value.SourceTimestamp)
+                    .ConvertTo(BuiltInType.String)
+                    .TryGetValue(out string sourceTimestampText) ? sourceTimestampText : String.Empty;
                 SourceTimestampCK.Checked = true;
             }
 
             if (nodeToWrite.Value.ServerTimestamp != DateTime.MinValue)
             {
-                ServerTimestampTB.Text = (string)Variant.From(nodeToWrite.Value.ServerTimestamp).ConvertTo(BuiltInType.String).AsBoxedObject();
+                ServerTimestampTB.Text = Variant.From(nodeToWrite.Value.ServerTimestamp)
+                    .ConvertTo(BuiltInType.String)
+                    .TryGetValue(out string serverTimestampText) ? serverTimestampText : String.Empty;
                 ServerTimestampCK.Checked = true;
             }
 
@@ -113,17 +119,26 @@ namespace Opc.Ua.Client.Controls
 
             if (StatusCodeCK.Checked)
             {
-                dataValue = dataValue.WithStatus((StatusCode)Variant.From(StatusCodeTB.Text).ConvertTo(BuiltInType.StatusCode).AsBoxedObject());
+                if (Variant.From(StatusCodeTB.Text).ConvertTo(BuiltInType.StatusCode).TryGetValue(out StatusCode statusCode))
+                {
+                    dataValue = dataValue.WithStatus(statusCode);
+                }
             }
 
             if (SourceTimestampCK.Checked)
             {
-                dataValue = dataValue.WithSourceTimestamp((DateTimeUtc)Variant.From(SourceTimestampTB.Text).ConvertTo(BuiltInType.DateTime).AsBoxedObject());
+                if (Variant.From(SourceTimestampTB.Text).ConvertTo(BuiltInType.DateTime).TryGetValue(out DateTimeUtc sourceTimestamp))
+                {
+                    dataValue = dataValue.WithSourceTimestamp(sourceTimestamp);
+                }
             }
 
             if (ServerTimestampCK.Checked)
             {
-                dataValue = dataValue.WithServerTimestamp((DateTimeUtc)Variant.From(ServerTimestampTB.Text).ConvertTo(BuiltInType.DateTime).AsBoxedObject());
+                if (Variant.From(ServerTimestampTB.Text).ConvertTo(BuiltInType.DateTime).TryGetValue(out DateTimeUtc serverTimestamp))
+                {
+                    dataValue = dataValue.WithServerTimestamp(serverTimestamp);
+                }
             }
 
             result.Value = dataValue;

--- a/Samples/ClientControls.Net4/Common/Client/EventFilterListViewCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/EventFilterListViewCtrl.cs
@@ -185,7 +185,7 @@ namespace Opc.Ua.Client.Controls
                         declaration.DisplayName,
                         declaration.DataType,
                         declaration.ValueRank,
-                        field.FilterValue.AsBoxedObject(),
+                        field.FilterValue,
                         "Edit Filter Value");
 
                     if (result != null)

--- a/Samples/ClientControls.Net4/Common/Client/EventListViewCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/EventListViewCtrl.cs
@@ -231,14 +231,14 @@ namespace Opc.Ua.Client.Controls
 
             foreach (List<Variant> e in events)
             {
-                byte[] eventId = null;
+                ByteString eventId = default;
 
                 if (e.Count > index)
                 {
-                    eventId = e[index].AsBoxedObject() as byte[];
+                    e[index].TryGetValue(out eventId);
                 }
 
-                eventIds.Add(eventId.ToByteString());
+                eventIds.Add(eventId);
             }
 
             details.EventIds = eventIds;

--- a/Samples/ClientControls.Net4/Common/Client/GdsDiscoverServersDlg.cs
+++ b/Samples/ClientControls.Net4/Common/Client/GdsDiscoverServersDlg.cs
@@ -328,8 +328,8 @@ namespace Opc.Ua.Client.Controls
 
             if (outputArguments != null && outputArguments.Count == 1)
             {
-                ExtensionObject[] extensions = outputArguments[0].AsBoxedObject() as ExtensionObject[];
-                ApplicationDescription[] descriptions = ExtensionObject.ToArray<ApplicationDescription>(extensions).ToArray();
+                outputArguments[0].TryGetValue(out ArrayOf<ExtensionObject> extensions);
+                ApplicationDescription[] descriptions = ExtensionObject.ToArray<ApplicationDescription>(extensions.ToArray()).ToArray();
                 await UpdateResultsAsync(descriptions, ct);
             }
         }

--- a/Samples/ClientControls.Net4/Common/Client/ReadRequestListViewCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/ReadRequestListViewCtrl.cs
@@ -210,7 +210,7 @@ namespace Opc.Ua.Client.Controls
         public async Task UpdateRowAsync(DataRow row, ReadValueId nodeToRead, CancellationToken ct = default)
         {
             row[0] = nodeToRead;
-            row[1] = ImageList.Images[ClientUtils.GetImageIndex(nodeToRead.AttributeId, null)];
+            row[1] = ImageList.Images[ClientUtils.GetImageIndex(nodeToRead.AttributeId, Variant.Null)];
             row[2] = (m_session != null) ? await m_session.NodeCache.GetDisplayTextAsync(nodeToRead.NodeId, ct) : Utils.ToString(nodeToRead.NodeId);
             row[3] = Attributes.GetBrowseName(nodeToRead.AttributeId);
             row[4] = nodeToRead.IndexRange;

--- a/Samples/ClientControls.Net4/Common/Client/SubscribeDataListViewCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/SubscribeDataListViewCtrl.cs
@@ -428,7 +428,7 @@ namespace Opc.Ua.Client.Controls
             MonitoredItemOptions settings = handle.Settings;
 
             row[0] = handle;
-            row[1] = ImageList.Images[ClientUtils.GetImageIndex(settings.AttributeId, null)];
+            row[1] = ImageList.Images[ClientUtils.GetImageIndex(settings.AttributeId, Variant.Null)];
             row[2] = await m_session.NodeCache.GetDisplayTextAsync(settings.StartNodeId, ct) + "/" + Attributes.GetBrowseName(settings.AttributeId);
             row[3] = settings.IndexRange;
             row[4] = settings.Encoding ?? QualifiedName.Null;
@@ -484,7 +484,7 @@ namespace Opc.Ua.Client.Controls
 
             if (!value.IsNull)
             {
-                row[1] = ImageList.Images[ClientUtils.GetImageIndex(Attributes.Value, value.WrappedValue.AsBoxedObject())];
+                row[1] = ImageList.Images[ClientUtils.GetImageIndex(Attributes.Value, value.WrappedValue)];
                 row[12] = (!value.WrappedValue.TypeInfo.IsUnknown) ? value.WrappedValue.TypeInfo.ToString() : String.Empty;
                 row[13] = value.WrappedValue;
                 row[14] = value.StatusCode;
@@ -621,7 +621,7 @@ namespace Opc.Ua.Client.Controls
 
                     if (m_EditComplexValueDlg != null && Object.ReferenceEquals(m_EditComplexValueDlg.Tag, handle))
                     {
-                        await m_EditComplexValueDlg.UpdateValueAsync(handle.Settings.StartNodeId, handle.Settings.AttributeId, null, change.Value.WrappedValue.AsBoxedObject());
+                        await m_EditComplexValueDlg.UpdateValueAsync(handle.Settings.StartNodeId, handle.Settings.AttributeId, null, change.Value.WrappedValue);
                     }
                 }
             }
@@ -779,7 +779,7 @@ namespace Opc.Ua.Client.Controls
                     handle.Settings.StartNodeId,
                     handle.Settings.AttributeId,
                     null,
-                    value.WrappedValue.AsBoxedObject(),
+                    value.WrappedValue,
                     true,
                     "View Data Change");
 

--- a/Samples/ClientControls.Net4/Common/Client/SubscribeEventsDlg.cs
+++ b/Samples/ClientControls.Net4/Common/Client/SubscribeEventsDlg.cs
@@ -398,7 +398,7 @@ namespace Opc.Ua.Client.Controls
             MonitoredItemOptions settings = handle.Settings;
 
             row[0] = handle;
-            row[1] = ImageList.Images[ClientUtils.GetImageIndex(settings.AttributeId, null)];
+            row[1] = ImageList.Images[ClientUtils.GetImageIndex(settings.AttributeId, Variant.Null)];
             row[2] = await m_session.NodeCache.GetDisplayTextAsync(settings.StartNodeId, ct) + "/" + Attributes.GetBrowseName(settings.AttributeId);
             row[3] = settings.MonitoringMode;
             row[4] = settings.SamplingInterval.TotalMilliseconds;

--- a/Samples/ClientControls.Net4/Common/Client/TypeFieldsListViewCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/TypeFieldsListViewCtrl.cs
@@ -161,7 +161,7 @@ namespace Opc.Ua.Client.Controls
         public void UpdateRow(DataRow row, InstanceDeclaration declaration)
         {
             row[0] = declaration;
-            row[1] = ImageList.Images[ClientUtils.GetImageIndex((declaration.NodeClass == NodeClass.Variable) ? Attributes.Value : Attributes.NodeId, null)];
+            row[1] = ImageList.Images[ClientUtils.GetImageIndex((declaration.NodeClass == NodeClass.Variable) ? Attributes.Value : Attributes.NodeId, Variant.Null)];
             row[2] = declaration.DisplayPath;
             row[3] = declaration.DataTypeDisplayText;
             row[4] = declaration.Description;

--- a/Samples/ClientControls.Net4/Common/Client/ViewEventDetailsDlg.cs
+++ b/Samples/ClientControls.Net4/Common/Client/ViewEventDetailsDlg.cs
@@ -71,7 +71,7 @@ namespace Opc.Ua.Client.Controls
                 string text = null;
 
                 // check for missing fields.
-                if (fields.Count <= ii + 1 || fields[ii + 1].AsBoxedObject() == null)
+                if (fields.Count <= ii + 1 || fields[ii + 1].IsNull)
                 {
                     text = String.Empty;
                 }

--- a/Samples/ClientControls.Net4/Common/Client/WriteRequestListViewCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/WriteRequestListViewCtrl.cs
@@ -279,7 +279,7 @@ namespace Opc.Ua.Client.Controls
         public async Task UpdateRowAsync(DataRow row, WriteValue nodeToWrite, CancellationToken ct = default)
         {
             row[0] = nodeToWrite;
-            row[1] = ImageList.Images[ClientUtils.GetImageIndex(nodeToWrite.AttributeId, null)];
+            row[1] = ImageList.Images[ClientUtils.GetImageIndex(nodeToWrite.AttributeId, Variant.Null)];
             row[2] = (m_session != null) ? await m_session.NodeCache.GetDisplayTextAsync(nodeToWrite.NodeId, ct) : Utils.ToString(nodeToWrite.NodeId);
             row[3] = Attributes.GetBrowseName(nodeToWrite.AttributeId);
             row[4] = nodeToWrite.IndexRange;
@@ -393,7 +393,7 @@ namespace Opc.Ua.Client.Controls
                         nodeToWrite.NodeId,
                         nodeToWrite.AttributeId,
                         null,
-                        nodeToWrite.Value.WrappedValue.AsBoxedObject(),
+                        nodeToWrite.Value.WrappedValue,
                         false,
                         "Edit Value");
 

--- a/Samples/ClientControls.Net4/Common/ClientUtils.cs
+++ b/Samples/ClientControls.Net4/Common/ClientUtils.cs
@@ -66,7 +66,7 @@ namespace Opc.Ua.Client.Controls
         /// <summary>
         /// Returns an image index for the specified method argument.
         /// </summary>
-        public static int GetImageIndex(bool isOutputArgument, object value)
+        public static int GetImageIndex(bool isOutputArgument, Variant value)
         {
             if (isOutputArgument)
             {
@@ -103,7 +103,7 @@ namespace Opc.Ua.Client.Controls
         /// Returns an image index for the specified attribute.
         /// </summary>
 #pragma warning disable 0162
-        public static int GetImageIndex(uint attributeId, object value)
+        public static int GetImageIndex(uint attributeId, Variant value)
         {
             // Workaround to avoid exception when accessing ImageList
             // Original ImageStream has been removed a long time ago
@@ -113,21 +113,11 @@ namespace Opc.Ua.Client.Controls
 
             if (attributeId == Attributes.Value)
             {
-                TypeInfo typeInfo = TypeInfo.Construct(value);
+                TypeInfo typeInfo = value.TypeInfo;
 
                 if (typeInfo.ValueRank >= 0)
                 {
                     return ClientUtils.ArrayValue;
-                }
-
-                if (typeInfo.BuiltInType == BuiltInType.Variant)
-                {
-                    typeInfo = ((Variant)value).TypeInfo;
-
-                    if (typeInfo.IsUnknown)
-                    {
-                        typeInfo = TypeInfo.Construct(((Variant)value).AsBoxedObject());
-                    }
                 }
 
                 switch (typeInfo.BuiltInType)

--- a/Samples/ClientControls.Net4/Common/EditArrayDlg.cs
+++ b/Samples/ClientControls.Net4/Common/EditArrayDlg.cs
@@ -124,8 +124,9 @@ namespace Opc.Ua.Client.Controls
                 for (int ii = 0; ii < m_dataset.Tables[0].DefaultView.Count; ii++)
                 {
                     string oldValue = m_dataset.Tables[0].DefaultView[ii].Row[0] as string;
-                    object newValue = ClientUtils.ToVariant(oldValue).ConvertTo(m_dataType).AsBoxedObject();
-                    value.SetValue(newValue, ii);
+
+                    // the array is a CLR array, so the converted value has to be boxed.
+                    value.SetValue(Variant.From(oldValue).ConvertTo(m_dataType).AsBoxedObject(), ii);
                 }
             }
 
@@ -150,7 +151,8 @@ namespace Opc.Ua.Client.Controls
         {
             try
             {
-                object newValue = ClientUtils.ToVariant(e.FormattedValue).ConvertTo(m_dataType).AsBoxedObject();
+                // throws if the text cannot be converted to the array element type.
+                _ = ClientUtils.ToVariant(e.FormattedValue).ConvertTo(m_dataType);
             }
             catch (Exception exception)
             {

--- a/Samples/ClientControls.Net4/Common/EditDataValueCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/EditDataValueCtrl.cs
@@ -317,9 +317,7 @@ namespace Opc.Ua.Client.Controls
             }
 
             // cast the value to the requested data type.
-            object value = Variant.From(ValueTB.Text).ConvertTo(targetType).AsBoxedObject();
-
-            return ClientUtils.ToVariant(value);
+            return Variant.From(ValueTB.Text).ConvertTo(targetType);
         }
 
         /// <summary>
@@ -339,7 +337,7 @@ namespace Opc.Ua.Client.Controls
             DataTypeCB.SelectedItem = targetType;
             ValueRankCB.SelectedItem = (ValueRankOptions)valueRank;
 
-            if (value.AsBoxedObject() == null)
+            if (value.IsNull)
             {
                 ValueTB.Text = String.Empty;
                 return;
@@ -354,7 +352,7 @@ namespace Opc.Ua.Client.Controls
             }
 
             // cast the value to the requested data type.
-            ValueTB.Text = (string)ClientUtils.ToVariant(value.AsBoxedObject()).ConvertTo(BuiltInType.String).AsBoxedObject();
+            ValueTB.Text = value.ConvertTo(BuiltInType.String).TryGetValue(out string text) ? text : String.Empty;
             ValueTB.ReadOnly = false;
         }
 

--- a/Samples/ClientControls.Net4/Common/EditValueCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/EditValueCtrl.cs
@@ -83,13 +83,10 @@ namespace Opc.Ua.Client.Controls
         /// </summary>
         private Variant GetValue()
         {
-            TypeInfo sourceType = m_value.TypeInfo;
-
             // check if the value needs to be updated.
             if (m_textChanged)
             {
-                object value = Variant.From(ValueTB.Text).ConvertTo(sourceType.BuiltInType).AsBoxedObject();
-                m_value = ClientUtils.ToVariant(value);
+                m_value = Variant.From(ValueTB.Text).ConvertTo(m_value.TypeInfo.BuiltInType);
             }
 
             return m_value;
@@ -112,20 +109,15 @@ namespace Opc.Ua.Client.Controls
             // get the source type.
             TypeInfo sourceType = value.TypeInfo;
 
-            if (sourceType.IsUnknown)
-            {
-                sourceType = TypeInfo.Construct(value.AsBoxedObject());
-            }
-
             // convert to target type.
             if (!TargetType.IsUnknown && TargetType.BuiltInType != sourceType.BuiltInType)
             {
-                m_value = ClientUtils.ToVariant(ClientUtils.ToVariant(value.AsBoxedObject()).ConvertTo(TargetType.BuiltInType).AsBoxedObject());
+                m_value = value.ConvertTo(TargetType.BuiltInType);
                 sourceType = TargetType;
             }
             else
             {
-                m_value = ClientUtils.ToVariant(value.AsBoxedObject());
+                m_value = value;
             }
 
             m_textChanged = false;
@@ -139,7 +131,7 @@ namespace Opc.Ua.Client.Controls
             }
 
             // display as editable text.
-            ValueTB.Text = (string)ClientUtils.ToVariant(m_value.AsBoxedObject()).ConvertTo(BuiltInType.String).AsBoxedObject();
+            ValueTB.Text = m_value.ConvertTo(BuiltInType.String).TryGetValue(out string text) ? text : String.Empty;
             ValueTB.Enabled = true;
         }
 

--- a/Samples/ClientControls.Net4/Common/EventListView.cs
+++ b/Samples/ClientControls.Net4/Common/EventListView.cs
@@ -393,7 +393,7 @@ namespace Opc.Ua.Client.Controls
             {
                 NodeId conditionId = NodeId.Null;
 
-                if (fieldValues[0].AsBoxedObject() is NodeId nodeId)
+                if (fieldValues[0].TryGetValue(out NodeId nodeId))
                 {
                     conditionId = nodeId;
                 }
@@ -404,7 +404,7 @@ namespace Opc.Ua.Client.Controls
                     {
                         List<Variant> fields = EventsLV.Items[ii].Tag as List<Variant>;
 
-                        if (fields != null && Utils.IsEqual(conditionId, fields[0].AsBoxedObject()))
+                        if (fields != null && fields[0].TryGetValue(out NodeId fieldId) && conditionId == fieldId)
                         {
                             item = EventsLV.Items[ii];
                             break;
@@ -434,15 +434,15 @@ namespace Opc.Ua.Client.Controls
                 Variant value = fieldValues[ii + 1];
 
                 // check for missing fields.
-                if (value.AsBoxedObject() == null)
+                if (value.IsNull)
                 {
                     text = String.Empty;
                 }
 
                 // display the name of a node instead of the node id.
-                else if (value.TypeInfo.BuiltInType == BuiltInType.NodeId)
+                else if (value.TryGetValue(out NodeId fieldNodeId))
                 {
-                    INode node = await m_session.NodeCache.FindAsync((NodeId)value.AsBoxedObject(), ct);
+                    INode node = await m_session.NodeCache.FindAsync(fieldNodeId, ct);
 
                     if (node != null)
                     {
@@ -451,9 +451,9 @@ namespace Opc.Ua.Client.Controls
                 }
 
                 // display local time for any time fields.
-                else if (value.TypeInfo.BuiltInType == BuiltInType.DateTime)
+                else if (value.TryGetValue(out DateTimeUtc fieldTime))
                 {
-                    DateTime datetime = (DateTime)value.AsBoxedObject();
+                    DateTime datetime = (DateTime)fieldTime;
 
                     if (m_filter.Fields[ii].InstanceDeclaration.DisplayName.Contains("Time", StringComparison.Ordinal))
                     {
@@ -524,7 +524,9 @@ namespace Opc.Ua.Client.Controls
 
                     if (m_displayConditions)
                     {
-                        NodeId eventTypeId = m_filter.GetValue<NodeId>(new QualifiedName(Opc.Ua.BrowseNames.EventType), fields, NodeId.Null);
+                        NodeId eventTypeId = m_filter
+                            .GetValue(new QualifiedName(Opc.Ua.BrowseNames.EventType), fields)
+                            .TryGetValue(out NodeId id) ? id : NodeId.Null;
 
                         if (eventTypeId == Opc.Ua.ObjectTypeIds.RefreshStartEventType)
                         {
@@ -668,14 +670,7 @@ namespace Opc.Ua.Client.Controls
 
                 if (e.Count > index)
                 {
-                    if (e[index].AsBoxedObject() is ByteString byteString)
-                    {
-                        eventId = byteString;
-                    }
-                    else if (e[index].AsBoxedObject() is byte[] bytes)
-                    {
-                        eventId = bytes.ToByteString();
-                    }
+                    e[index].TryGetValue(out eventId);
                 }
 
                 details.EventIds = details.EventIds.AddItem(eventId);

--- a/Samples/ClientControls.Net4/Common/FilterDeclaration.cs
+++ b/Samples/ClientControls.Net4/Common/FilterDeclaration.cs
@@ -474,11 +474,11 @@ namespace Opc.Ua.Client.Controls
         /// <summary>
         /// Returns the value for the specified browse name.
         /// </summary>
-        public T GetValue<T>(QualifiedName browseName, IList<Variant> fields, T defaultValue)
+        public Variant GetValue(QualifiedName browseName, IList<Variant> fields)
         {
             if (fields == null || fields.Count == 0)
             {
-                return defaultValue;
+                return Variant.Null;
             }
 
             if (browseName.IsNull)
@@ -492,21 +492,14 @@ namespace Opc.Ua.Client.Controls
                 {
                     if (ii >= fields.Count + 1)
                     {
-                        return defaultValue;
+                        return Variant.Null;
                     }
 
-                    object value = fields[ii + 1].AsBoxedObject();
-
-                    if (typeof(T).IsInstanceOfType(value))
-                    {
-                        return (T)value;
-                    }
-
-                    break;
+                    return fields[ii + 1];
                 }
             }
 
-            return defaultValue;
+            return Variant.Null;
         }
 
         /// <summary>

--- a/Samples/ClientControls.Net4/Configuration/Common (OLD)/DataListCtrl.cs
+++ b/Samples/ClientControls.Net4/Configuration/Common (OLD)/DataListCtrl.cs
@@ -651,7 +651,7 @@ namespace Opc.Ua.Client.Controls
                     formattedValue.Append("] ");
                 }
 
-                formattedValue.AppendFormat("{0}", dataValue.WrappedValue.AsBoxedObject());
+                formattedValue.Append(dataValue.WrappedValue.ToString());
                 return formattedValue.ToString();
             }
 
@@ -965,9 +965,9 @@ namespace Opc.Ua.Client.Controls
         private Task<(int, bool)> ShowValueAsync(int index, bool overwrite, EventFieldList value, int fieldIndex, CancellationToken ct = default)
         {
             // ignore children that are not elements.
-            object field = value.EventFields[fieldIndex].AsBoxedObject();
+            Variant field = value.EventFields[fieldIndex];
 
-            if (field == null)
+            if (field.IsNull)
             {
                 return Task.FromResult((index, overwrite));
             }

--- a/Samples/ClientControls.Net4/Configuration/Common (OLD)/GuiUtils.cs
+++ b/Samples/ClientControls.Net4/Configuration/Common (OLD)/GuiUtils.cs
@@ -424,9 +424,9 @@ namespace Opc.Ua.Client.Controls
         /// <summary>
         /// Displays a dialog that allows a use to edit a value.
         /// </summary>
-        public static object EditValue(ISession session, object value, ITelemetryContext telemetry)
+        public static object EditValue(ISession session, Variant value, ITelemetryContext telemetry)
         {
-            TypeInfo typeInfo = TypeInfo.Construct(value);
+            TypeInfo typeInfo = value.TypeInfo;
 
             if (!typeInfo.IsUnknown)
             {
@@ -439,12 +439,10 @@ namespace Opc.Ua.Client.Controls
         /// <summary>
         /// Displays a dialog that allows a use to edit a value.
         /// </summary>
-        public static object EditValue(ISession session, object value, NodeId datatypeId, int valueRank, ITelemetryContext telemetry)
+        public static object EditValue(ISession session, Variant variantValue, NodeId datatypeId, int valueRank, ITelemetryContext telemetry)
         {
-            if (value == null)
-            {
-                value = GetDefaultValue(datatypeId, valueRank);
-            }
+            // the value editors below work on boxed CLR values, so the Variant is unwrapped here.
+            object value = variantValue.AsBoxedObject() ?? GetDefaultValue(datatypeId, valueRank);
 
             if (valueRank >= 0)
             {

--- a/Samples/Controls.Net4/Common/ArgumentListCtrl.cs
+++ b/Samples/Controls.Net4/Common/ArgumentListCtrl.cs
@@ -119,11 +119,9 @@ namespace Opc.Ua.Sample.Controls
             // read the value from the server.
             DataValue value = await m_session.ReadValueAsync(argumentsNode.NodeId, ct);
 
-            ExtensionObject[] argumentsList = value.WrappedValue.AsBoxedObject() as ExtensionObject[];
-
-            if (argumentsList != null)
+            if (value.WrappedValue.TryGetValue(out ArrayOf<ExtensionObject> argumentsList))
             {
-                for (int ii = 0; ii < argumentsList.Length; ii++)
+                for (int ii = 0; ii < argumentsList.Count; ii++)
                 {
                     AddItem(argumentsList[ii].TryGetValue<Argument>(out var argument, m_session.MessageContext) ? argument : null);
                 }
@@ -148,7 +146,7 @@ namespace Opc.Ua.Sample.Controls
 
                 if (argument != null)
                 {
-                    values.Add(Variant.From((dynamic)argument.Value));
+                    values.Add(ClientUtils.ToVariant(argument.Value));
                 }
             }
 
@@ -168,7 +166,7 @@ namespace Opc.Ua.Sample.Controls
 
                 if (argument != null)
                 {
-                    argument.Value = values[ii++].AsBoxedObject();
+                    argument.Value = values[ii++];
                     await UpdateItemAsync(item, argument, ct);
                 }
             }
@@ -268,7 +266,7 @@ namespace Opc.Ua.Sample.Controls
                     return;
                 }
 
-                object value = GuiUtils.EditValue(m_session, arguments[0].Value, arguments[0].DataType, arguments[0].ValueRank, Telemetry);
+                object value = GuiUtils.EditValue(m_session, ClientUtils.ToVariant(arguments[0].Value), arguments[0].DataType, arguments[0].ValueRank, Telemetry);
 
                 if (value != null)
                 {

--- a/Samples/Controls.Net4/Common/AttributeListCtrl.cs
+++ b/Samples/Controls.Net4/Common/AttributeListCtrl.cs
@@ -127,7 +127,7 @@ namespace Opc.Ua.Sample.Controls
         private sealed class NodeField
         {
             public string Name;
-            public object Value;
+            public Variant Value;
             public StatusCode StatusCode;
             public DiagnosticInfo DiagnosticInfo;
             public ReadValueId ValueId;
@@ -182,7 +182,7 @@ namespace Opc.Ua.Sample.Controls
 
                 field.ValueId = nodesToRead[ii];
                 field.Name = Attributes.GetBrowseName(nodesToRead[ii].AttributeId);
-                field.Value = values[ii].WrappedValue.AsBoxedObject();
+                field.Value = values[ii].WrappedValue;
                 field.StatusCode = values[ii].StatusCode;
 
                 if (diagnosticInfos != null && diagnosticInfos.Count > ii)
@@ -251,7 +251,7 @@ namespace Opc.Ua.Sample.Controls
 
                 field.ValueId = nodesToRead[ii];
                 field.Name = references[ii].ToString();
-                field.Value = values[ii].WrappedValue.AsBoxedObject();
+                field.Value = values[ii].WrappedValue;
                 field.StatusCode = values[ii].StatusCode;
 
                 if (diagnosticInfos != null && diagnosticInfos.Count > ii)
@@ -303,15 +303,15 @@ namespace Opc.Ua.Sample.Controls
         /// <summary>
         /// Formats the value of an attribute.
         /// </summary>
-        private async Task<string> FormatAttributeValueAsync(uint attributeId, object value, CancellationToken ct = default)
+        private async Task<string> FormatAttributeValueAsync(uint attributeId, Variant value, CancellationToken ct = default)
         {
             switch (attributeId)
             {
                 case Attributes.NodeClass:
                 {
-                    if (value != null)
+                    if (value.TryGetValue(out int nodeClass))
                     {
-                        return String.Format("{0}", Enum.ToObject(typeof(NodeClass), value));
+                        return String.Format("{0}", (NodeClass)nodeClass);
                     }
 
                     return "(null)";
@@ -319,7 +319,7 @@ namespace Opc.Ua.Sample.Controls
 
                 case Attributes.DataType:
                 {
-                    NodeId datatypeId = value is NodeId nodeId ? nodeId : NodeId.Null;
+                    NodeId datatypeId = value.TryGetValue(out NodeId nodeId) ? nodeId : NodeId.Null;
 
                     if (!datatypeId.IsNull)
                     {
@@ -340,11 +340,9 @@ namespace Opc.Ua.Sample.Controls
 
                 case Attributes.ValueRank:
                 {
-                    int? valueRank = value as int?;
-
-                    if (valueRank != null)
+                    if (value.TryGetValue(out int valueRank))
                     {
-                        switch (valueRank.Value)
+                        switch (valueRank)
                         {
                             case ValueRanks.Scalar: return "Scalar";
                             case ValueRanks.OneDimension: return "OneDimension";
@@ -353,7 +351,7 @@ namespace Opc.Ua.Sample.Controls
 
                             default:
                             {
-                                return String.Format("{0}", valueRank.Value);
+                                return String.Format("{0}", valueRank);
                             }
                         }
                     }
@@ -363,21 +361,19 @@ namespace Opc.Ua.Sample.Controls
 
                 case Attributes.MinimumSamplingInterval:
                 {
-                    double? minimumSamplingInterval = value as double?;
-
-                    if (minimumSamplingInterval != null)
+                    if (value.TryGetValue(out double minimumSamplingInterval))
                     {
-                        if (minimumSamplingInterval.Value == MinimumSamplingIntervals.Indeterminate)
+                        if (minimumSamplingInterval == MinimumSamplingIntervals.Indeterminate)
                         {
                             return "Indeterminate";
                         }
 
-                        else if (minimumSamplingInterval.Value == MinimumSamplingIntervals.Continuous)
+                        else if (minimumSamplingInterval == MinimumSamplingIntervals.Continuous)
                         {
                             return "Continuous";
                         }
 
-                        return String.Format("{0}", minimumSamplingInterval.Value);
+                        return String.Format("{0}", minimumSamplingInterval);
                     }
 
                     return String.Format("{0}", value);
@@ -386,7 +382,7 @@ namespace Opc.Ua.Sample.Controls
                 case Attributes.AccessLevel:
                 case Attributes.UserAccessLevel:
                 {
-                    byte accessLevel = Convert.ToByte(value);
+                    value.TryGetValue(out byte accessLevel);
 
                     StringBuilder bits = new StringBuilder();
 
@@ -530,11 +526,9 @@ namespace Opc.Ua.Sample.Controls
                 return;
             }
 
-            Array array = field.Value as Array;
-
             listItem.SubItems[0].Text = String.Format("{0}", field.Name);
 
-            if (array == null)
+            if (field.Value.TypeInfo.ValueRank < 0)
             {
                 if (field.ValueId != null)
                 {
@@ -542,12 +536,12 @@ namespace Opc.Ua.Sample.Controls
                 }
                 else
                 {
-                    listItem.SubItems[1].Text = String.Format("{0}", field.Value);
+                    listItem.SubItems[1].Text = field.Value.ToString();
                 }
             }
             else
             {
-                listItem.SubItems[1].Text = String.Format("{0}[{1}]", field.Value.GetType().GetElementType().Name, array.Length);
+                listItem.SubItems[1].Text = field.Value.TypeInfo.ToString();
             }
 
             listItem.SubItems[2].Text = String.Format("{0}", field.StatusCode);
@@ -570,7 +564,7 @@ namespace Opc.Ua.Sample.Controls
                     {
                         if (value != null)
                         {
-                            items[0].Value = value;
+                            items[0].Value = ClientUtils.ToVariant(value);
                             await UpdateItemAsync(ItemsLV.SelectedItems[0], items[0]);
                         }
                     }

--- a/Samples/Controls.Net4/Subscriptions/ContentFilterElementListCtrl.cs
+++ b/Samples/Controls.Net4/Subscriptions/ContentFilterElementListCtrl.cs
@@ -421,7 +421,8 @@ namespace Opc.Ua.Sample.Controls
                     return;
                 }
 
-                // get the current value.
+                // get the current value. the simple value editor works on a boxed CLR
+                // value and its runtime type, so the Variant is unwrapped for it.
                 object currentValue = literal.Value.AsBoxedObject();
 
                 if (currentValue == null)

--- a/Samples/Controls.Net4/Subscriptions/EventNotificationListCtrl.cs
+++ b/Samples/Controls.Net4/Subscriptions/EventNotificationListCtrl.cs
@@ -268,11 +268,11 @@ namespace Opc.Ua.Sample.Controls
             EventNotification notification = itemEvent.Notification;
 
             // get the event fields selected by the filter the item was created with.
-            NodeId eventType = SubscriptionHandle.GetEventFieldValue(monitoredItem, notification, new QualifiedName(Opc.Ua.BrowseNames.EventType)) is NodeId eventTypeId ? eventTypeId : NodeId.Null;
-            string sourceName = SubscriptionHandle.GetEventFieldValue(monitoredItem, notification, new QualifiedName(Opc.Ua.BrowseNames.SourceName)) as string;
-            DateTime? time = SubscriptionHandle.GetEventFieldValue(monitoredItem, notification, new QualifiedName(Opc.Ua.BrowseNames.Time)) as DateTime?;
-            ushort? severity = SubscriptionHandle.GetEventFieldValue(monitoredItem, notification, new QualifiedName(Opc.Ua.BrowseNames.Severity)) as ushort?;
-            LocalizedText message = SubscriptionHandle.GetEventFieldValue(monitoredItem, notification, new QualifiedName(Opc.Ua.BrowseNames.Message)) is LocalizedText messageText ? messageText : LocalizedText.Null;
+            NodeId eventType = SubscriptionHandle.GetEventFieldValue(monitoredItem, notification, new QualifiedName(Opc.Ua.BrowseNames.EventType)).TryGetValue(out NodeId eventTypeId) ? eventTypeId : NodeId.Null;
+            string sourceName = SubscriptionHandle.GetEventFieldValue(monitoredItem, notification, new QualifiedName(Opc.Ua.BrowseNames.SourceName)).TryGetValue(out string name) ? name : null;
+            DateTime? time = SubscriptionHandle.GetEventFieldValue(monitoredItem, notification, new QualifiedName(Opc.Ua.BrowseNames.Time)).TryGetValue(out DateTimeUtc eventTime) ? (DateTime)eventTime : null;
+            ushort? severity = SubscriptionHandle.GetEventFieldValue(monitoredItem, notification, new QualifiedName(Opc.Ua.BrowseNames.Severity)).TryGetValue(out ushort eventSeverity) ? eventSeverity : null;
+            LocalizedText message = SubscriptionHandle.GetEventFieldValue(monitoredItem, notification, new QualifiedName(Opc.Ua.BrowseNames.Message)).TryGetValue(out LocalizedText messageText) ? messageText : LocalizedText.Null;
 
             // fill in the columns.
             listItem.SubItems[0].Text = String.Format("[{0}]", (monitoredItem.Item != null) ? monitoredItem.Item.ServerId : 0);

--- a/Samples/Controls.Net4/Subscriptions/FilterOperandEditDlg.cs
+++ b/Samples/Controls.Net4/Subscriptions/FilterOperandEditDlg.cs
@@ -130,6 +130,8 @@ namespace Opc.Ua.Sample.Controls
 
                 StringBuilder buffer = new StringBuilder();
 
+                // the operand can hold an array of any built in type, so it is listed
+                // element by element through the boxed CLR array.
                 Array array = literalOperand.Value.AsBoxedObject() as Array;
 
                 if (array != null)

--- a/Samples/Controls.Net4/Subscriptions/MonitoredItemStatusCtrl.cs
+++ b/Samples/Controls.Net4/Subscriptions/MonitoredItemStatusCtrl.cs
@@ -180,13 +180,13 @@ namespace Opc.Ua.Sample.Controls
 
                     string value = null;
 
-                    if (SubscriptionHandle.GetEventFieldValue(handle, notification, new QualifiedName(Opc.Ua.BrowseNames.EventType)) is NodeId eventTypeId)
+                    if (SubscriptionHandle.GetEventFieldValue(handle, notification, new QualifiedName(Opc.Ua.BrowseNames.EventType)).TryGetValue(out NodeId eventTypeId))
                     {
                         INode eventType = await m_subscription.Session.NodeCache.FindAsync(eventTypeId);
                         value = String.Format("{0}", (object)eventType ?? eventTypeId);
                     }
 
-                    DateTime timestamp = (SubscriptionHandle.GetEventFieldValue(handle, notification, new QualifiedName(Opc.Ua.BrowseNames.Time)) as DateTime?) ?? DateTime.MinValue;
+                    DateTime timestamp = SubscriptionHandle.GetEventFieldValue(handle, notification, new QualifiedName(Opc.Ua.BrowseNames.Time)).TryGetValue(out DateTimeUtc eventTime) ? (DateTime)eventTime : DateTime.MinValue;
 
                     m_notifications[handle] = new LastNotification {
                         Value = value,

--- a/Samples/Controls.Net4/Subscriptions/SubscriptionHandle.cs
+++ b/Samples/Controls.Net4/Subscriptions/SubscriptionHandle.cs
@@ -328,18 +328,18 @@ namespace Opc.Ua.Sample.Controls
 
         /// <summary>
         /// Returns the value of an event field selected by the filter the item was created
-        /// with, or null if the filter does not select the field.
+        /// with, or a null Variant if the filter does not select the field.
         /// </summary>
         /// <remarks>
         /// The fields of a V2 <see cref="EventNotification"/> align one to one with the select
         /// clauses of the event filter, which replaces the field lookup the classic
         /// MonitoredItem provided.
         /// </remarks>
-        public static object GetEventFieldValue(MonitoredItemHandle handle, EventNotification notification, QualifiedName browseName)
+        public static Variant GetEventFieldValue(MonitoredItemHandle handle, EventNotification notification, QualifiedName browseName)
         {
             if (handle?.Settings?.Filter is not EventFilter filter)
             {
-                return null;
+                return Variant.Null;
             }
 
             for (int ii = 0; ii < filter.SelectClauses.Count && ii < notification.Fields.Count; ii++)
@@ -348,11 +348,11 @@ namespace Opc.Ua.Sample.Controls
 
                 if (clause.BrowsePath.Count == 1 && clause.BrowsePath[0] == browseName)
                 {
-                    return notification.Fields[ii].AsBoxedObject();
+                    return notification.Fields[ii];
                 }
             }
 
-            return null;
+            return Variant.Null;
         }
 
         /// <inheritdoc/>

--- a/Samples/Controls.Net4/Subscriptions/WriteValueListCtrl.cs
+++ b/Samples/Controls.Net4/Subscriptions/WriteValueListCtrl.cs
@@ -233,7 +233,7 @@ namespace Opc.Ua.Sample.Controls
                 value.Value = new DataValue();
             }
 
-            if (value.Value.WrappedValue.AsBoxedObject() == null)
+            if (value.Value.WrappedValue.IsNull)
             {
                 value.Value = await GetDefaultValueAsync(value.NodeId, value.AttributeId, ct);
             }
@@ -252,7 +252,7 @@ namespace Opc.Ua.Sample.Controls
             listItem.SubItems[1].Text = String.Format("{0}", value.NodeId);
             listItem.SubItems[2].Text = String.Format("{0}", Attributes.GetBrowseName(value.AttributeId));
             listItem.SubItems[3].Text = String.Format("{0}", value.IndexRange);
-            listItem.SubItems[4].Text = String.Format("{0}", value.Value.WrappedValue.AsBoxedObject());
+            listItem.SubItems[4].Text = value.Value.WrappedValue.ToString();
             listItem.SubItems[5].Text = String.Format("{0}", value.Value.StatusCode);
             listItem.SubItems[6].Text = String.Format("{0}", value.Value.SourceTimestamp);
 
@@ -393,17 +393,17 @@ namespace Opc.Ua.Sample.Controls
 
                     if (writeValue != null)
                     {
-                        value = writeValue.Value.WrappedValue.AsBoxedObject();
+                        value = writeValue.Value.WrappedValue;
                     }
                 }
                 else
                 {
-                    value = GuiUtils.EditValue(m_session, values[0].Value.WrappedValue.AsBoxedObject(), datatypeId, valueRank, Telemetry);
+                    value = GuiUtils.EditValue(m_session, values[0].Value.WrappedValue, datatypeId, valueRank, Telemetry);
                 }
 
                 if (value != null)
                 {
-                    values[0].Value = new DataValue(Variant.From((dynamic)value), StatusCodes.Good, values[0].Value.SourceTimestamp, values[0].Value.ServerTimestamp);
+                    values[0].Value = new DataValue(ClientUtils.ToVariant(value), StatusCodes.Good, values[0].Value.SourceTimestamp, values[0].Value.ServerTimestamp);
 
                     await UpdateItemAsync(ItemsLV.SelectedItems[0], values[0]);
 

--- a/Samples/GDS/ClientControls/Controls/EditValueCtrl.cs
+++ b/Samples/GDS/ClientControls/Controls/EditValueCtrl.cs
@@ -247,23 +247,7 @@ namespace Opc.Ua.Gds.Client.Controls
             AccessInfo info = ButtonPanel.Controls[ButtonPanel.Controls.Count - 1].Tag as AccessInfo;
 
             Opc.Ua.TypeInfo currentType = info.TypeInfo;
-            object currentValue = info.Value;
-
-            if (info.Value is Variant)
-            {
-                Variant variant = (Variant)info.Value;
-                currentValue = variant.AsBoxedObject();
-
-                if (currentValue != null)
-                {
-                    currentType = variant.TypeInfo;
-
-                    if (currentType.IsUnknown)
-                    {
-                        currentType = Opc.Ua.TypeInfo.Construct(currentValue);
-                    }
-                }
-            }
+            object currentValue = Unwrap(info.Value, ref currentType);
 
             int[] dimensions = null;
 
@@ -408,21 +392,7 @@ namespace Opc.Ua.Gds.Client.Controls
                 currentValue = TypeInfo.GetDefaultValue(currentType.BuiltInType);
             }
 
-            if (info.Value is Variant)
-            {
-                Variant variant = (Variant)info.Value;
-                currentValue = variant.AsBoxedObject();
-
-                if (currentValue != null)
-                {
-                    currentType = variant.TypeInfo;
-
-                    if (currentType.IsUnknown)
-                    {
-                        currentType = Opc.Ua.TypeInfo.Construct(currentValue);
-                    }
-                }
-            }
+            currentValue = Unwrap(info.Value, ref currentType);
 
             Opc.Ua.TypeInfo targetType = new Opc.Ua.TypeInfo(builtInType, currentType.ValueRank);
             object newValue  = Convert(currentValue, currentType, targetType, true);
@@ -724,21 +694,8 @@ namespace Opc.Ua.Gds.Client.Controls
                 value = parent.WrappedValue;
             }
 
-            if (value is Variant)
-            {
-                Variant variant = (Variant)value;
-                value = variant.AsBoxedObject();
-
-                if (value != null)
-                {
-                    parent.TypeInfo = typeInfo = variant.TypeInfo;
-
-                    if (typeInfo.IsUnknown)
-                    {
-                        parent.TypeInfo = typeInfo = Opc.Ua.TypeInfo.Construct(value);
-                    }
-                }
-            }
+            value = Unwrap(value, ref typeInfo);
+            parent.TypeInfo = typeInfo;
 
             if (typeInfo.ValueRank >= 0)
             {
@@ -1053,6 +1010,25 @@ namespace Opc.Ua.Gds.Client.Controls
 
         #region Private Methods
         /// <summary>
+        /// Unwraps a Variant into the boxed value that this reflection based editor
+        /// navigates, and reports the type information carried by the Variant.
+        /// </summary>
+        private static object Unwrap(object value, ref Opc.Ua.TypeInfo typeInfo)
+        {
+            if (value is Variant variant)
+            {
+                if (!variant.IsNull)
+                {
+                    typeInfo = variant.TypeInfo;
+                }
+
+                return variant.AsBoxedObject();
+            }
+
+            return value;
+        }
+
+        /// <summary>
         /// Returns the index based on the current count.
         /// </summary>
         private int[] GetIndexFromCount(int count, int[] dimensions)
@@ -1355,21 +1331,7 @@ namespace Opc.Ua.Gds.Client.Controls
                 return "<null>";
             }
 
-            if (value is Variant)
-            {
-                Variant variant = (Variant)value;
-                value = variant.AsBoxedObject();
-
-                if (value != null)
-                {
-                    typeInfo = variant.TypeInfo;
-
-                    if (typeInfo.IsUnknown)
-                    {
-                        typeInfo = Opc.Ua.TypeInfo.Construct(value);
-                    }
-                }
-            }
+            value = Unwrap(value, ref typeInfo);
 
             if (typeInfo.ValueRank >= 0)
             {
@@ -1449,19 +1411,7 @@ namespace Opc.Ua.Gds.Client.Controls
             }
 
             Opc.Ua.TypeInfo typeInfo = info.TypeInfo;
-            object value = info.Value;
-
-            if (value is Variant)
-            {
-                Variant variant = (Variant)info.Value;
-                typeInfo = variant.TypeInfo;
-                value = variant.AsBoxedObject();
-
-                if (typeInfo.IsUnknown)
-                {
-                    typeInfo = Opc.Ua.TypeInfo.Construct(value);
-                }
-            }
+            object value = Unwrap(info.Value, ref typeInfo);
 
             if (typeInfo.ValueRank >= 0)
             {
@@ -1567,21 +1517,17 @@ namespace Opc.Ua.Gds.Client.Controls
                 return;
             }
 
+            Opc.Ua.TypeInfo parentTypeInfo = info.Parent.TypeInfo;
             object parentValue = info.Parent.Value;
 
-            if (info.Parent.TypeInfo.BuiltInType == BuiltInType.Variant && info.Parent.TypeInfo.ValueRank < 0)
+            if (parentTypeInfo.BuiltInType == BuiltInType.Variant && parentTypeInfo.ValueRank < 0)
             {
-                parentValue = ((Variant)info.Parent.Value).AsBoxedObject();
+                parentValue = Unwrap(parentValue, ref parentTypeInfo);
             }
 
             if (info.PropertyInfo != null && info.Parent.TypeInfo.ValueRank < 0)
             {
-                Variant? variant = parentValue as Variant?;
-
-                if (variant != null)
-                {
-                    parentValue = variant.Value.AsBoxedObject();
-                }
+                parentValue = Unwrap(parentValue, ref parentTypeInfo);
 
                 if (parentValue is ExtensionObject extension && TryGetExtensionObjectBody(extension, out object body))
                 {

--- a/Samples/GDS/ClientControls/Controls/ImageListControl.cs
+++ b/Samples/GDS/ClientControls/Controls/ImageListControl.cs
@@ -154,11 +154,6 @@ namespace Opc.Ua.Gds.Client.Controls
                 if (typeInfo.BuiltInType == BuiltInType.Variant)
                 {
                     typeInfo = ((Variant)value).TypeInfo;
-
-                    if (typeInfo.IsUnknown)
-                    {
-                        typeInfo = TypeInfo.Construct(((Variant)value).AsBoxedObject());
-                    }
                 }
 
                 switch (typeInfo.BuiltInType)

--- a/Samples/Opc.Ua.Sample/MemoryBuffer/MemoryBufferState.cs
+++ b/Samples/Opc.Ua.Sample/MemoryBuffer/MemoryBufferState.cs
@@ -332,27 +332,23 @@ namespace MemoryBuffer
                 {
                     case BuiltInType.UInt32:
                     {
-                        uint? valueToWrite = value.AsBoxedObject() as uint?;
-
-                        if (valueToWrite == null)
+                        if (!value.TryGetValue(out uint valueToWrite))
                         {
                             return StatusCodes.BadTypeMismatch;
                         }
 
-                        bytes = BitConverter.GetBytes(valueToWrite.Value);
+                        bytes = BitConverter.GetBytes(valueToWrite);
                         break;
                     }
 
                     case BuiltInType.Double:
                     {
-                        double? valueToWrite = value.AsBoxedObject() as double?;
-
-                        if (valueToWrite == null)
+                        if (!value.TryGetValue(out double valueToWrite))
                         {
                             return StatusCodes.BadTypeMismatch;
                         }
 
-                        bytes = BitConverter.GetBytes(valueToWrite.Value);
+                        bytes = BitConverter.GetBytes(valueToWrite);
                         break;
                     }
 

--- a/Samples/Opc.Ua.Sample/TestData/HistoryArchive.cs
+++ b/Samples/Opc.Ua.Sample/TestData/HistoryArchive.cs
@@ -200,8 +200,11 @@ namespace TestData
                         {
                             case BuiltInType.Int32:
                             {
-                                int lastValue = (int)record.RawData[record.RawData.Count - 1].Value.WrappedValue.AsBoxedObject();
-                                value = Variant.From(lastValue + 1);
+                                if (record.RawData[record.RawData.Count - 1].Value.WrappedValue
+                                    .TryGetValue(out int lastValue))
+                                {
+                                    value = Variant.From(lastValue + 1);
+                                }
                                 break;
                             }
                         }

--- a/Samples/Opc.Ua.Sample/TestData/TestDataNodeManager.cs
+++ b/Samples/Opc.Ua.Sample/TestData/TestDataNodeManager.cs
@@ -133,73 +133,17 @@ namespace TestData
         /// </summary>
         public async ValueTask OnDataChangeAsync(
             BaseVariableState variable,
-            object value,
+            Variant value,
             StatusCode statusCode,
             DateTime timestamp,
             CancellationToken cancellationToken = default)
         {
-            variable.Value = ToVariant(value);
+            variable.Value = value;
             variable.StatusCode = statusCode;
             variable.Timestamp = timestamp;
 
             // notifies any monitored items that the value has changed.
             await variable.ClearChangeMasksAsync(SystemContext, false, cancellationToken).ConfigureAwait(false);
-        }
-
-        private static Variant ToVariant(object value)
-        {
-            switch (value)
-            {
-                case null: return Variant.Null;
-                case Variant v: return v;
-                case bool v: return Variant.From(v);
-                case sbyte v: return Variant.From(v);
-                case byte v: return Variant.From(v);
-                case short v: return Variant.From(v);
-                case ushort v: return Variant.From(v);
-                case int v: return Variant.From(v);
-                case uint v: return Variant.From(v);
-                case long v: return Variant.From(v);
-                case ulong v: return Variant.From(v);
-                case float v: return Variant.From(v);
-                case double v: return Variant.From(v);
-                case string v: return Variant.From(v);
-                case DateTime v: return Variant.From(new DateTimeUtc(v));
-                case Guid v: return Variant.From(new Uuid(v));
-                case ByteString v: return Variant.From(v);
-                case byte[] v: return Variant.From(new ArrayOf<byte>(v));
-                case XmlElement v: return Variant.From(v);
-                case NodeId v: return Variant.From(v);
-                case ExpandedNodeId v: return Variant.From(v);
-                case StatusCode v: return Variant.From(v);
-                case QualifiedName v: return Variant.From(v);
-                case LocalizedText v: return Variant.From(v);
-                case ExtensionObject v: return Variant.From(v);
-                case bool[] v: return Variant.From(new ArrayOf<bool>(v));
-                case sbyte[] v: return Variant.From(new ArrayOf<sbyte>(v));
-                case short[] v: return Variant.From(new ArrayOf<short>(v));
-                case ushort[] v: return Variant.From(new ArrayOf<ushort>(v));
-                case int[] v: return Variant.From(new ArrayOf<int>(v));
-                case uint[] v: return Variant.From(new ArrayOf<uint>(v));
-                case long[] v: return Variant.From(new ArrayOf<long>(v));
-                case ulong[] v: return Variant.From(new ArrayOf<ulong>(v));
-                case float[] v: return Variant.From(new ArrayOf<float>(v));
-                case double[] v: return Variant.From(new ArrayOf<double>(v));
-                case string[] v: return Variant.From(new ArrayOf<string>(v));
-                case DateTime[] v: return Variant.From(new ArrayOf<DateTimeUtc>(Array.ConvertAll(v, x => new DateTimeUtc(x))));
-                case Guid[] v: return Variant.From(new ArrayOf<Uuid>(Array.ConvertAll(v, x => new Uuid(x))));
-                case ByteString[] v: return Variant.From(new ArrayOf<ByteString>(v));
-                case XmlElement[] v: return Variant.From(new ArrayOf<XmlElement>(v));
-                case NodeId[] v: return Variant.From(new ArrayOf<NodeId>(v));
-                case ExpandedNodeId[] v: return Variant.From(new ArrayOf<ExpandedNodeId>(v));
-                case StatusCode[] v: return Variant.From(new ArrayOf<StatusCode>(v));
-                case QualifiedName[] v: return Variant.From(new ArrayOf<QualifiedName>(v));
-                case LocalizedText[] v: return Variant.From(new ArrayOf<LocalizedText>(v));
-                case ExtensionObject[] v: return Variant.From(new ArrayOf<ExtensionObject>(v));
-                case IEncodeable v: return Variant.From(new ExtensionObject(v, false));
-                case Variant[] v: return Variant.From(new ArrayOf<Variant>(v));
-                default: return Variant.Null;
-            }
         }
         #endregion
 

--- a/Samples/Opc.Ua.Sample/TestData/TestDataObjectState.cs
+++ b/Samples/Opc.Ua.Sample/TestData/TestDataObjectState.cs
@@ -101,60 +101,36 @@ namespace TestData
             NodeState node,
             ref Variant value)
         {
-            try
+            BaseVariableState euRange = node.FindChild(context, new QualifiedName(Opc.Ua.BrowseNames.EURange)) as BaseVariableState;
+
+            if (euRange == null || !euRange.Value.TryGetStructure(out Range range))
             {
+                return ServiceResult.Good;
+            }
 
-                BaseVariableState euRange = node.FindChild(context, new QualifiedName(Opc.Ua.BrowseNames.EURange)) as BaseVariableState;
+            // the analog variables are all numeric, so the value converts to a double.
+            Variant numbers = value.ConvertTo(BuiltInType.Double);
 
-                if (euRange == null)
+            if (numbers.TryGetValue(out ArrayOf<double> elements))
+            {
+                foreach (double element in elements.Span)
                 {
-                    return ServiceResult.Good;
-                }
-
-                Range range = euRange.Value.AsBoxedObject() as Range;
-
-                if (range == null)
-                {
-                    return ServiceResult.Good;
-                }
-
-                Array array = value.AsBoxedObject() as Array;
-
-                if (array != null)
-                {
-                    for (int ii = 0; ii < array.Length; ii++)
+                    if (element > range.High || element < range.Low)
                     {
-                        object element = array.GetValue(ii);
-
-                        if (typeof(Variant).IsInstanceOfType(element))
-                        {
-                            element = ((Variant)element).AsBoxedObject();
-                        }
-
-                        double elementNumber = Convert.ToDouble(element);
-
-                        if (elementNumber > range.High || elementNumber < range.Low)
-                        {
-                            return StatusCodes.BadOutOfRange;
-                        }
+                        return StatusCodes.BadOutOfRange;
                     }
-
-                    return ServiceResult.Good;
-                }
-
-                double number = Convert.ToDouble(value.AsBoxedObject());
-
-                if (number > range.High || number < range.Low)
-                {
-                    return StatusCodes.BadOutOfRange;
                 }
 
                 return ServiceResult.Good;
             }
-            catch (Exception)
+
+            if (numbers.TryGetValue(out double number) &&
+                (number > range.High || number < range.Low))
             {
-                throw;
+                return StatusCodes.BadOutOfRange;
             }
+
+            return ServiceResult.Good;
         }
 
         /// <summary>
@@ -162,65 +138,9 @@ namespace TestData
         /// </summary>
         protected void GenerateValue(TestDataSystem system, BaseVariableState variable)
         {
-            variable.Value = ToVariant(system.ReadValue(variable));
+            variable.Value = system.ReadValue(variable);
             variable.Timestamp = DateTime.UtcNow;
             variable.StatusCode = StatusCodes.Good;
-        }
-
-        private static Variant ToVariant(object value)
-        {
-            switch (value)
-            {
-                case null: return Variant.Null;
-                case Variant v: return v;
-                case bool v: return Variant.From(v);
-                case sbyte v: return Variant.From(v);
-                case byte v: return Variant.From(v);
-                case short v: return Variant.From(v);
-                case ushort v: return Variant.From(v);
-                case int v: return Variant.From(v);
-                case uint v: return Variant.From(v);
-                case long v: return Variant.From(v);
-                case ulong v: return Variant.From(v);
-                case float v: return Variant.From(v);
-                case double v: return Variant.From(v);
-                case string v: return Variant.From(v);
-                case DateTime v: return Variant.From(new DateTimeUtc(v));
-                case Guid v: return Variant.From(new Uuid(v));
-                case ByteString v: return Variant.From(v);
-                case byte[] v: return Variant.From(new ArrayOf<byte>(v));
-                case XmlElement v: return Variant.From(v);
-                case NodeId v: return Variant.From(v);
-                case ExpandedNodeId v: return Variant.From(v);
-                case StatusCode v: return Variant.From(v);
-                case QualifiedName v: return Variant.From(v);
-                case LocalizedText v: return Variant.From(v);
-                case ExtensionObject v: return Variant.From(v);
-                case bool[] v: return Variant.From(new ArrayOf<bool>(v));
-                case sbyte[] v: return Variant.From(new ArrayOf<sbyte>(v));
-                case short[] v: return Variant.From(new ArrayOf<short>(v));
-                case ushort[] v: return Variant.From(new ArrayOf<ushort>(v));
-                case int[] v: return Variant.From(new ArrayOf<int>(v));
-                case uint[] v: return Variant.From(new ArrayOf<uint>(v));
-                case long[] v: return Variant.From(new ArrayOf<long>(v));
-                case ulong[] v: return Variant.From(new ArrayOf<ulong>(v));
-                case float[] v: return Variant.From(new ArrayOf<float>(v));
-                case double[] v: return Variant.From(new ArrayOf<double>(v));
-                case string[] v: return Variant.From(new ArrayOf<string>(v));
-                case DateTime[] v: return Variant.From(new ArrayOf<DateTimeUtc>(Array.ConvertAll(v, x => new DateTimeUtc(x))));
-                case Guid[] v: return Variant.From(new ArrayOf<Uuid>(Array.ConvertAll(v, x => new Uuid(x))));
-                case ByteString[] v: return Variant.From(new ArrayOf<ByteString>(v));
-                case XmlElement[] v: return Variant.From(new ArrayOf<XmlElement>(v));
-                case NodeId[] v: return Variant.From(new ArrayOf<NodeId>(v));
-                case ExpandedNodeId[] v: return Variant.From(new ArrayOf<ExpandedNodeId>(v));
-                case StatusCode[] v: return Variant.From(new ArrayOf<StatusCode>(v));
-                case QualifiedName[] v: return Variant.From(new ArrayOf<QualifiedName>(v));
-                case LocalizedText[] v: return Variant.From(new ArrayOf<LocalizedText>(v));
-                case ExtensionObject[] v: return Variant.From(new ArrayOf<ExtensionObject>(v));
-                case IEncodeable v: return Variant.From(new ExtensionObject(v, false));
-                case Variant[] v: return Variant.From(new ArrayOf<Variant>(v));
-                default: return Variant.Null;
-            }
         }
 
         /// <summary>
@@ -301,7 +221,7 @@ namespace TestData
 
             try
             {
-                value = ToVariant(system.ReadValue(variable));
+                value = system.ReadValue(variable);
 
                 statusCode = StatusCodes.Good;
                 timestamp = DateTime.UtcNow;

--- a/Samples/Opc.Ua.Sample/TestData/TestDataSystem.cs
+++ b/Samples/Opc.Ua.Sample/TestData/TestDataSystem.cs
@@ -44,7 +44,7 @@ namespace TestData
     {
         ValueTask OnDataChangeAsync(
             BaseVariableState variable,
-            object value,
+            Variant value,
             StatusCode statusCode,
             DateTime timestamp,
             CancellationToken cancellationToken = default);
@@ -145,7 +145,7 @@ namespace TestData
         /// <summary>
         /// Returns a new value for the variable.
         /// </summary>
-        public object ReadValue(BaseVariableState variable)
+        public Variant ReadValue(BaseVariableState variable)
         {
             lock (m_lock)
             {
@@ -333,7 +333,7 @@ namespace TestData
                     case TestData.Variables.ScalarValueObjectType_VariantValue:
                     case TestData.Variables.UserScalarValueObjectType_VariantValue:
                     {
-                        return m_generator.GetRandomVariant(false).AsBoxedObject();
+                        return m_generator.GetRandomVariant(false);
                     }
 
                     case TestData.Variables.ScalarValueObjectType_StructureValue:
@@ -348,311 +348,316 @@ namespace TestData
 
                     case TestData.Variables.ScalarValueObjectType_NumberValue:
                     {
-                        return m_generator.GetRandomScalar(BuiltInType.Number, false).AsBoxedObject();
+                        return m_generator.GetRandomScalar(BuiltInType.Number, false);
                     }
 
                     case TestData.Variables.ScalarValueObjectType_IntegerValue:
                     {
-                        return m_generator.GetRandomScalar(BuiltInType.Integer, false).AsBoxedObject();
+                        return m_generator.GetRandomScalar(BuiltInType.Integer, false);
                     }
 
                     case TestData.Variables.ScalarValueObjectType_UIntegerValue:
                     {
-                        return m_generator.GetRandomScalar(BuiltInType.UInteger, false).AsBoxedObject();
+                        return m_generator.GetRandomScalar(BuiltInType.UInteger, false);
                     }
 
                     case TestData.Variables.ArrayValueObjectType_BooleanValue:
                     case TestData.Variables.UserArrayValueObjectType_BooleanValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.Boolean, 100, false, false).AsBoxedObject();
+                        return m_generator.GetRandomArray(BuiltInType.Boolean, 100, false, false);
                     }
 
                     case TestData.Variables.ArrayValueObjectType_SByteValue:
                     case TestData.Variables.UserArrayValueObjectType_SByteValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.SByte, 100, false, false).AsBoxedObject();
+                        return m_generator.GetRandomArray(BuiltInType.SByte, 100, false, false);
                     }
 
                     case TestData.Variables.AnalogArrayValueObjectType_SByteValue:
                     {
-                        sbyte[] values = ((ArrayOf<sbyte>)m_generator.GetRandomArray(BuiltInType.SByte, 100, false, false).AsBoxedObject()).ToArray();
+                        sbyte[] values = ((ArrayOf<sbyte>)m_generator.GetRandomArray(BuiltInType.SByte, 100, false, false)).ToArray();
 
                         for (int ii = 0; ii < values.Length; ii++)
                         {
                             values[ii] = (sbyte)(((int)(m_generator.GetRandomUInt32(false) % 201)) - 100);
                         }
 
-                        return values;
+                        return new ArrayOf<sbyte>(values);
                     }
 
                     case TestData.Variables.ArrayValueObjectType_ByteValue:
                     case TestData.Variables.UserArrayValueObjectType_ByteValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.Byte, 100, false, false).AsBoxedObject();
+                        return m_generator.GetRandomArray(BuiltInType.Byte, 100, false, false);
                     }
 
                     case TestData.Variables.AnalogArrayValueObjectType_ByteValue:
                     {
-                        byte[] values = ((ArrayOf<byte>)m_generator.GetRandomArray(BuiltInType.Byte, 100, false, false).AsBoxedObject()).ToArray();
+                        byte[] values = ((ArrayOf<byte>)m_generator.GetRandomArray(BuiltInType.Byte, 100, false, false)).ToArray();
 
                         for (int ii = 0; ii < values.Length; ii++)
                         {
                             values[ii] = (byte)((m_generator.GetRandomUInt32(false) % 201) + 50);
                         }
 
-                        return values;
+                        return new ArrayOf<byte>(values);
                     }
 
                     case TestData.Variables.ArrayValueObjectType_Int16Value:
                     case TestData.Variables.UserArrayValueObjectType_Int16Value:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.Int16, 100, false, false).AsBoxedObject();
+                        return m_generator.GetRandomArray(BuiltInType.Int16, 100, false, false);
                     }
 
                     case TestData.Variables.AnalogArrayValueObjectType_Int16Value:
                     {
-                        short[] values = ((ArrayOf<short>)m_generator.GetRandomArray(BuiltInType.Int16, 100, false, false).AsBoxedObject()).ToArray();
+                        short[] values = ((ArrayOf<short>)m_generator.GetRandomArray(BuiltInType.Int16, 100, false, false)).ToArray();
 
                         for (int ii = 0; ii < values.Length; ii++)
                         {
                             values[ii] = (short)(((int)(m_generator.GetRandomUInt32(false) % 201)) - 100);
                         }
 
-                        return values;
+                        return new ArrayOf<short>(values);
                     }
 
                     case TestData.Variables.ArrayValueObjectType_UInt16Value:
                     case TestData.Variables.UserArrayValueObjectType_UInt16Value:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.UInt16, 100, false, false).AsBoxedObject();
+                        return m_generator.GetRandomArray(BuiltInType.UInt16, 100, false, false);
                     }
 
                     case TestData.Variables.AnalogArrayValueObjectType_UInt16Value:
                     {
-                        ushort[] values = ((ArrayOf<ushort>)m_generator.GetRandomArray(BuiltInType.UInt16, 100, false, false).AsBoxedObject()).ToArray();
+                        ushort[] values = ((ArrayOf<ushort>)m_generator.GetRandomArray(BuiltInType.UInt16, 100, false, false)).ToArray();
 
                         for (int ii = 0; ii < values.Length; ii++)
                         {
                             values[ii] = (ushort)((m_generator.GetRandomUInt32(false) % 201) + 50);
                         }
 
-                        return values;
+                        return new ArrayOf<ushort>(values);
                     }
 
                     case TestData.Variables.ArrayValueObjectType_Int32Value:
                     case TestData.Variables.UserArrayValueObjectType_Int32Value:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.Int32, 100, false, false).AsBoxedObject();
+                        return m_generator.GetRandomArray(BuiltInType.Int32, 100, false, false);
                     }
 
                     case TestData.Variables.AnalogArrayValueObjectType_Int32Value:
                     case TestData.Variables.AnalogArrayValueObjectType_IntegerValue:
                     {
-                        int[] values = ((ArrayOf<int>)m_generator.GetRandomArray(BuiltInType.Int32, 100, false, false).AsBoxedObject()).ToArray();
+                        int[] values = ((ArrayOf<int>)m_generator.GetRandomArray(BuiltInType.Int32, 100, false, false)).ToArray();
 
                         for (int ii = 0; ii < values.Length; ii++)
                         {
                             values[ii] = (int)(((int)(m_generator.GetRandomUInt32(false) % 201)) - 100);
                         }
 
-                        return values;
+                        return new ArrayOf<int>(values);
                     }
 
                     case TestData.Variables.ArrayValueObjectType_UInt32Value:
                     case TestData.Variables.UserArrayValueObjectType_UInt32Value:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.UInt32, 100, false, false).AsBoxedObject();
+                        return m_generator.GetRandomArray(BuiltInType.UInt32, 100, false, false);
                     }
 
                     case TestData.Variables.AnalogArrayValueObjectType_UInt32Value:
                     case TestData.Variables.AnalogArrayValueObjectType_UIntegerValue:
                     {
-                        uint[] values = ((ArrayOf<uint>)m_generator.GetRandomArray(BuiltInType.UInt32, 100, false, false).AsBoxedObject()).ToArray();
+                        uint[] values = ((ArrayOf<uint>)m_generator.GetRandomArray(BuiltInType.UInt32, 100, false, false)).ToArray();
 
                         for (int ii = 0; ii < values.Length; ii++)
                         {
                             values[ii] = (uint)((m_generator.GetRandomUInt32(false) % 201) + 50);
                         }
 
-                        return values;
+                        return new ArrayOf<uint>(values);
                     }
 
                     case TestData.Variables.ArrayValueObjectType_Int64Value:
                     case TestData.Variables.UserArrayValueObjectType_Int64Value:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.Int64, 100, false, false).AsBoxedObject();
+                        return m_generator.GetRandomArray(BuiltInType.Int64, 100, false, false);
                     }
 
                     case TestData.Variables.AnalogArrayValueObjectType_Int64Value:
                     {
-                        long[] values = ((ArrayOf<long>)m_generator.GetRandomArray(BuiltInType.Int64, 100, false, false).AsBoxedObject()).ToArray();
+                        long[] values = ((ArrayOf<long>)m_generator.GetRandomArray(BuiltInType.Int64, 100, false, false)).ToArray();
 
                         for (int ii = 0; ii < values.Length; ii++)
                         {
                             values[ii] = (long)(((int)(m_generator.GetRandomUInt32(false) % 201)) - 100);
                         }
 
-                        return values;
+                        return new ArrayOf<long>(values);
                     }
 
                     case TestData.Variables.ArrayValueObjectType_UInt64Value:
                     case TestData.Variables.UserArrayValueObjectType_UInt64Value:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.UInt64, 100, false, false).AsBoxedObject();
+                        return m_generator.GetRandomArray(BuiltInType.UInt64, 100, false, false);
                     }
 
                     case TestData.Variables.AnalogArrayValueObjectType_UInt64Value:
                     {
-                        ulong[] values = ((ArrayOf<ulong>)m_generator.GetRandomArray(BuiltInType.UInt64, 100, false, false).AsBoxedObject()).ToArray();
+                        ulong[] values = ((ArrayOf<ulong>)m_generator.GetRandomArray(BuiltInType.UInt64, 100, false, false)).ToArray();
 
                         for (int ii = 0; ii < values.Length; ii++)
                         {
                             values[ii] = (ulong)((m_generator.GetRandomUInt32(false) % 201) + 50);
                         }
 
-                        return values;
+                        return new ArrayOf<ulong>(values);
                     }
 
                     case TestData.Variables.ArrayValueObjectType_FloatValue:
                     case TestData.Variables.UserArrayValueObjectType_FloatValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.Float, 100, false, false).AsBoxedObject();
+                        return m_generator.GetRandomArray(BuiltInType.Float, 100, false, false);
                     }
 
                     case TestData.Variables.AnalogArrayValueObjectType_FloatValue:
                     {
-                        float[] values = ((ArrayOf<float>)m_generator.GetRandomArray(BuiltInType.Float, 100, false, false).AsBoxedObject()).ToArray();
+                        float[] values = ((ArrayOf<float>)m_generator.GetRandomArray(BuiltInType.Float, 100, false, false)).ToArray();
 
                         for (int ii = 0; ii < values.Length; ii++)
                         {
                             values[ii] = (float)(((int)(m_generator.GetRandomUInt32(false) % 201)) - 100);
                         }
 
-                        return values;
+                        return new ArrayOf<float>(values);
                     }
 
                     case TestData.Variables.ArrayValueObjectType_DoubleValue:
                     case TestData.Variables.UserArrayValueObjectType_DoubleValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.Double, 100, false, false).AsBoxedObject();
+                        return m_generator.GetRandomArray(BuiltInType.Double, 100, false, false);
                     }
 
                     case TestData.Variables.AnalogArrayValueObjectType_DoubleValue:
                     case TestData.Variables.AnalogArrayValueObjectType_NumberValue:
                     {
-                        double[] values = ((ArrayOf<double>)m_generator.GetRandomArray(BuiltInType.Double, 100, false, false).AsBoxedObject()).ToArray();
+                        double[] values = ((ArrayOf<double>)m_generator.GetRandomArray(BuiltInType.Double, 100, false, false)).ToArray();
 
                         for (int ii = 0; ii < values.Length; ii++)
                         {
                             values[ii] = (double)(((int)(m_generator.GetRandomUInt32(false) % 201)) - 100);
                         }
 
-                        return values;
+                        return new ArrayOf<double>(values);
                     }
 
                     case TestData.Variables.ArrayValueObjectType_StringValue:
                     case TestData.Variables.UserArrayValueObjectType_StringValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.String, 100, false, false).AsBoxedObject();
+                        return m_generator.GetRandomArray(BuiltInType.String, 100, false, false);
                     }
 
                     case TestData.Variables.ArrayValueObjectType_DateTimeValue:
                     case TestData.Variables.UserArrayValueObjectType_DateTimeValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.DateTime, 100, false, false).AsBoxedObject();
+                        return m_generator.GetRandomArray(BuiltInType.DateTime, 100, false, false);
                     }
 
                     case TestData.Variables.ArrayValueObjectType_GuidValue:
                     case TestData.Variables.UserArrayValueObjectType_GuidValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.Guid, 100, false, false).AsBoxedObject();
+                        return m_generator.GetRandomArray(BuiltInType.Guid, 100, false, false);
                     }
 
                     case TestData.Variables.ArrayValueObjectType_ByteStringValue:
                     case TestData.Variables.UserArrayValueObjectType_ByteStringValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.ByteString, 100, false, false).AsBoxedObject();
+                        return m_generator.GetRandomArray(BuiltInType.ByteString, 100, false, false);
                     }
 
                     case TestData.Variables.ArrayValueObjectType_XmlElementValue:
                     case TestData.Variables.UserArrayValueObjectType_XmlElementValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.XmlElement, 100, false, false).AsBoxedObject();
+                        return m_generator.GetRandomArray(BuiltInType.XmlElement, 100, false, false);
                     }
 
                     case TestData.Variables.ArrayValueObjectType_NodeIdValue:
                     case TestData.Variables.UserArrayValueObjectType_NodeIdValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.NodeId, 100, false, false).AsBoxedObject();
+                        return m_generator.GetRandomArray(BuiltInType.NodeId, 100, false, false);
                     }
 
                     case TestData.Variables.ArrayValueObjectType_ExpandedNodeIdValue:
                     case TestData.Variables.UserArrayValueObjectType_ExpandedNodeIdValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.ExpandedNodeId, 100, false, false).AsBoxedObject();
+                        return m_generator.GetRandomArray(BuiltInType.ExpandedNodeId, 100, false, false);
                     }
 
                     case TestData.Variables.ArrayValueObjectType_QualifiedNameValue:
                     case TestData.Variables.UserArrayValueObjectType_QualifiedNameValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.QualifiedName, 100, false, false).AsBoxedObject();
+                        return m_generator.GetRandomArray(BuiltInType.QualifiedName, 100, false, false);
                     }
 
                     case TestData.Variables.ArrayValueObjectType_LocalizedTextValue:
                     case TestData.Variables.UserArrayValueObjectType_LocalizedTextValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.LocalizedText, 100, false, false).AsBoxedObject();
+                        return m_generator.GetRandomArray(BuiltInType.LocalizedText, 100, false, false);
                     }
 
                     case TestData.Variables.ArrayValueObjectType_StatusCodeValue:
                     case TestData.Variables.UserArrayValueObjectType_StatusCodeValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.StatusCode, 100, false, false).AsBoxedObject();
+                        return m_generator.GetRandomArray(BuiltInType.StatusCode, 100, false, false);
                     }
 
                     case TestData.Variables.ArrayValueObjectType_VariantValue:
                     case TestData.Variables.UserArrayValueObjectType_VariantValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.Variant, 100, false, false).AsBoxedObject();
+                        return m_generator.GetRandomArray(BuiltInType.Variant, 100, false, false);
                     }
 
                     case TestData.Variables.ArrayValueObjectType_StructureValue:
                     {
                         // the generator has no random extension objects, so the array may be null.
-                        object random = m_generator.GetRandomArray(BuiltInType.ExtensionObject, 10, false, false).AsBoxedObject();
+                        if (!m_generator
+                            .GetRandomArray(BuiltInType.ExtensionObject, 10, false, false)
+                            .TryGetValue(out ArrayOf<ExtensionObject> random))
+                        {
+                            return Variant.Null;
+                        }
 
-                        ExtensionObject[] values = (random is ArrayOf<ExtensionObject> array) ? array.ToArray() : null;
+                        ExtensionObject[] values = random.ToArray();
 
-                        for (int ii = 0; values != null && ii < values.Length; ii++)
+                        for (int ii = 0; ii < values.Length; ii++)
                         {
                             values[ii] = GetRandomStructure();
                         }
 
-                        return values;
+                        return new ArrayOf<ExtensionObject>(values);
                     }
 
                     case TestData.Variables.ArrayValueObjectType_EnumerationValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.Int32, 100, false, false).AsBoxedObject();
+                        return m_generator.GetRandomArray(BuiltInType.Int32, 100, false, false);
                     }
 
                     case TestData.Variables.ArrayValueObjectType_NumberValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.Number, 100, false, false).AsBoxedObject();
+                        return m_generator.GetRandomArray(BuiltInType.Number, 100, false, false);
                     }
 
                     case TestData.Variables.ArrayValueObjectType_IntegerValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.Integer, 100, false, false).AsBoxedObject();
+                        return m_generator.GetRandomArray(BuiltInType.Integer, 100, false, false);
                     }
 
                     case TestData.Variables.ArrayValueObjectType_UIntegerValue:
                     {
-                        return m_generator.GetRandomArray(BuiltInType.UInteger, 100, false, false).AsBoxedObject();
+                        return m_generator.GetRandomArray(BuiltInType.UInteger, 100, false, false);
                     }
                 }
 
-                return null;
+                return Variant.Null;
             }
         }
 
@@ -844,7 +849,7 @@ namespace TestData
         private class Sample
         {
             public BaseVariableState Variable;
-            public object Value;
+            public Variant Value;
             public StatusCode StatusCode;
             public DateTime Timestamp;
         }

--- a/Samples/ReferenceServer/Aggregates/AggregateCalculator.cs
+++ b/Samples/ReferenceServer/Aggregates/AggregateCalculator.cs
@@ -703,8 +703,9 @@ namespace Opc.Ua.Aggregates
             DataValue retval = new DataValue { SourceTimestamp = bucket.From }; ;
             StatusCode code = StatusCodes.Good;
             DataValue previous = new DataValue { SourceTimestamp = bucket.From };
-            if (bucket.EarlyBound.Value != null)
-                previous.StatusCode = (StatusCode)bucket.EarlyBound.Value.WrappedValue.Value;
+            if (bucket.EarlyBound.Value != null &&
+                bucket.EarlyBound.Value.WrappedValue.TryGetValue(out StatusCode earlyBoundCode))
+                previous.StatusCode = earlyBoundCode;
             else
                 previous.StatusCode = StatusCodes.Bad;
             if (!RightStatusCode(previous))

--- a/Tests/SampleNodeManagers.Tests/AggregationNodeManagerTests.cs
+++ b/Tests/SampleNodeManagers.Tests/AggregationNodeManagerTests.cs
@@ -265,7 +265,7 @@ namespace Opc.Ua.Samples.Tests
                     $"Reading the proxy root failed: {browseName.StatusCode}");
 
                 Assert.That(
-                    nodeClass.WrappedValue.AsBoxedObject(),
+                    nodeClass.WrappedValue.TryGetValue(out int proxyNodeClass) ? proxyNodeClass : 0,
                     Is.EqualTo((int)NodeClass.Object),
                     "The proxy root is an object.");
             });

--- a/Tests/SampleNodeManagers.Tests/BoilerSampleNodeManagerTests.cs
+++ b/Tests/SampleNodeManagers.Tests/BoilerSampleNodeManagerTests.cs
@@ -83,7 +83,7 @@ namespace Opc.Ua.Samples.Tests
                     .ReadAttributeAsync(Session, partId, Attributes.DisplayName, ct)
                     .ConfigureAwait(false);
 
-                string shown = ((LocalizedText)displayName.WrappedValue.AsBoxedObject()).Text;
+                string shown = displayName.WrappedValue.TryGetValue(out LocalizedText text) ? text.Text : null;
 
                 renamed.Add($"{part.BrowseName.Name} shown as {shown}");
             }
@@ -150,7 +150,7 @@ namespace Opc.Ua.Samples.Tests
                     $"Reading the state of the simulation of {name} failed: {state.StatusCode}");
 
                 Assert.That(
-                    ((LocalizedText)state.WrappedValue.AsBoxedObject()).Text,
+                    state.WrappedValue.TryGetValue(out LocalizedText simulationState) ? simulationState.Text : null,
                     Is.EqualTo("Running"),
                     $"The node manager starts the simulation of {name} itself, so it has to be running.");
             }

--- a/Tests/SampleNodeManagers.Tests/BoilerWorkshopNodeManagerTests.cs
+++ b/Tests/SampleNodeManagers.Tests/BoilerWorkshopNodeManagerTests.cs
@@ -171,7 +171,7 @@ namespace Opc.Ua.Samples.Tests
                 .ConfigureAwait(false);
 
             double[] levels = values
-                .Select(value => Convert.ToDouble(value.WrappedValue.AsBoxedObject(), CultureInfo.InvariantCulture))
+                .Select(value => value.WrappedValue.ConvertTo(BuiltInType.Double).TryGetValue(out double level) ? level : double.NaN)
                 .ToArray();
 
             await ReportAsync(

--- a/Tests/SampleNodeManagers.Tests/DataAccessNodeManagerTests.cs
+++ b/Tests/SampleNodeManagers.Tests/DataAccessNodeManagerTests.cs
@@ -144,12 +144,11 @@ namespace Opc.Ua.Samples.Tests
                 $"Reading the engineering units failed: {units.StatusCode}");
 
             Assert.That(
-                units.WrappedValue.AsBoxedObject(),
-                Is.InstanceOf<ExtensionObject>(),
+                units.WrappedValue.TryGetValue(out ExtensionObject unitsStructure),
+                Is.True,
                 "The engineering units of an analog item are a structure.");
 
-            ((ExtensionObject)units.WrappedValue.AsBoxedObject())
-                .TryGetValue(out EUInformation information, Session.MessageContext);
+            unitsStructure.TryGetValue(out EUInformation information, Session.MessageContext);
 
             Assert.That(
                 information?.DisplayName.Text,
@@ -327,7 +326,7 @@ namespace Opc.Ua.Samples.Tests
                 Is.True,
                 $"Reading the set point failed: {original.StatusCode}");
 
-            float written = (original.WrappedValue.AsBoxedObject() as float? ?? 0f) + 10f;
+            float written = (original.WrappedValue.TryGetValue(out float setPoint) ? setPoint : 0f) + 10f;
 
             try
             {
@@ -349,7 +348,7 @@ namespace Opc.Ua.Samples.Tests
                     .ConfigureAwait(false);
 
                 Assert.That(
-                    readBack.WrappedValue.AsBoxedObject(),
+                    readBack.WrappedValue.TryGetValue(out float readBackSetPoint) ? readBackSetPoint : float.NaN,
                     Is.EqualTo(written),
                     "The set point has to come back from the underlying system with the written value.");
             }

--- a/Tests/SampleNodeManagers.Tests/DataTypesNodeManagerTests.cs
+++ b/Tests/SampleNodeManagers.Tests/DataTypesNodeManagerTests.cs
@@ -109,13 +109,12 @@ namespace Opc.Ua.Samples.Tests
                 .ConfigureAwait(false);
 
             Assert.That(
-                value.WrappedValue.AsBoxedObject(),
-                Is.InstanceOf<ExtensionObject>(),
+                value.WrappedValue.TryGetValue(out ExtensionObject encoded),
+                Is.True,
                 "The primary vehicle is a structure, so it arrives as an extension object.");
 
             // the type id of the structure has to name one of the encodings the sample
             // serves, otherwise a client has nothing to decode it with
-            var encoded = (ExtensionObject)value.WrappedValue.AsBoxedObject();
 
             Assert.That(
                 encoded.TypeId.IsNull,
@@ -168,11 +167,12 @@ namespace Opc.Ua.Samples.Tests
                 Is.True,
                 $"Reading the primary vehicle failed: {value.StatusCode}");
 
-            var decoded = value.WrappedValue.AsBoxedObject() as ExtensionObject?;
+            Assert.That(
+                value.WrappedValue.TryGetValue(out ExtensionObject decoded),
+                Is.True,
+                "The primary vehicle is a structure.");
 
-            Assert.That(decoded, Is.Not.Null, "The primary vehicle is a structure.");
-
-            decoded.Value.TryGetValue(out IEncodeable body);
+            decoded.TryGetValue(out IEncodeable body);
 
             await TestContext.Out
                 .WriteLineAsync($"PrimaryVehicle: {body?.GetType().Name}")
@@ -240,12 +240,13 @@ namespace Opc.Ua.Samples.Tests
                 .ReadValueAsync(Session, PrimaryVehicle, ct)
                 .ConfigureAwait(false);
 
-            var decoded = value.WrappedValue.AsBoxedObject() as ExtensionObject?;
-
-            Assert.That(decoded, Is.Not.Null, "The primary vehicle is a structure.");
+            Assert.That(
+                value.WrappedValue.TryGetValue(out ExtensionObject decoded),
+                Is.True,
+                "The primary vehicle is a structure.");
 
             Assert.That(
-                decoded.Value.TryGetValue(out BicycleType read),
+                decoded.TryGetValue(out BicycleType read),
                 Is.True,
                 "What went in as a bicycle has to come back as one.");
 

--- a/Tests/SampleNodeManagers.Tests/EmptyNodeManagerTests.cs
+++ b/Tests/SampleNodeManagers.Tests/EmptyNodeManagerTests.cs
@@ -99,12 +99,12 @@ namespace Opc.Ua.Samples.Tests
 
             Assert.Multiple(() => {
                 Assert.That(
-                    dataType.WrappedValue.AsBoxedObject(),
+                    dataType.WrappedValue.TryGetValue(out NodeId matrixDataType) ? matrixDataType : NodeId.Null,
                     Is.EqualTo(DataTypeIds.Int32),
                     "The matrix holds integers.");
 
                 Assert.That(
-                    valueRank.WrappedValue.AsBoxedObject(),
+                    valueRank.WrappedValue.TryGetValue(out int matrixValueRank) ? matrixValueRank : ValueRanks.Any,
                     Is.EqualTo(ValueRanks.TwoDimensions),
                     "The matrix is two dimensional.");
 
@@ -183,11 +183,11 @@ namespace Opc.Ua.Samples.Tests
 
             Assert.Multiple(() => {
                 Assert.That(
-                    ((QualifiedName)browseName.WrappedValue.AsBoxedObject()).Name,
+                    browseName.WrappedValue.TryGetValue(out QualifiedName name) ? name.Name : null,
                     Is.EqualTo("IsTriggerSource"));
 
                 Assert.That(
-                    ((LocalizedText)inverseName.WrappedValue.AsBoxedObject()).Text,
+                    inverseName.WrappedValue.TryGetValue(out LocalizedText inverse) ? inverse.Text : null,
                     Is.EqualTo("IsSourceOfTrigger"));
             });
 
@@ -209,11 +209,7 @@ namespace Opc.Ua.Samples.Tests
 
         private static uint[] AsUInt32Array(Variant value)
         {
-            return value.AsBoxedObject() switch {
-                uint[] array => array,
-                ArrayOf<uint> arrayOf => arrayOf.ToArray(),
-                _ => [],
-            };
+            return value.TryGetValue(out ArrayOf<uint> array) ? array.ToArray() : [];
         }
     }
 }

--- a/Tests/SampleNodeManagers.Tests/HistoricalAccessNodeManagerTests.cs
+++ b/Tests/SampleNodeManagers.Tests/HistoricalAccessNodeManagerTests.cs
@@ -9,7 +9,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -67,7 +66,7 @@ namespace Opc.Ua.Samples.Tests
                 .ConfigureAwait(false);
 
             Assert.That(
-                Convert.ToByte(accessLevel.WrappedValue.AsBoxedObject(), CultureInfo.InvariantCulture)
+                (accessLevel.WrappedValue.TryGetValue(out byte flags) ? flags : (byte)0)
                     & AccessLevels.HistoryRead,
                 Is.Not.Zero,
                 "An archive item has to allow reading its history.");
@@ -106,13 +105,13 @@ namespace Opc.Ua.Samples.Tests
 
             Assert.Multiple(() => {
                 Assert.That(
-                    onCollecting.WrappedValue.AsBoxedObject(),
-                    Is.EqualTo(true),
+                    onCollecting.WrappedValue.TryGetValue(out bool collecting) && collecting,
+                    Is.True,
                     "An item the simulation appends to is being collected.");
 
                 Assert.That(
-                    onRecorded.WrappedValue.AsBoxedObject(),
-                    Is.EqualTo(false),
+                    onRecorded.WrappedValue.TryGetValue(out bool recorded) ? recorded : (bool?)null,
+                    Is.False,
                     "A finished recording is not being collected, even though it can be read.");
             });
         }
@@ -150,8 +149,8 @@ namespace Opc.Ua.Samples.Tests
                 announced.Add($"{name}={value.WrappedValue}");
 
                 Assert.That(
-                    value.WrappedValue.AsBoxedObject(),
-                    Is.EqualTo(true),
+                    value.WrappedValue.TryGetValue(out bool announcedValue) && announcedValue,
+                    Is.True,
                     $"The sample turns {name} on while it builds its address space.");
             }
 
@@ -516,7 +515,7 @@ namespace Opc.Ua.Samples.Tests
             DataValue inserted = archive.First(value => At(value) == ReadBackAt);
 
             Assert.That(
-                Convert.ToDouble(inserted.WrappedValue.AsBoxedObject(), CultureInfo.InvariantCulture),
+                inserted.WrappedValue.ConvertTo(BuiltInType.Double).TryGetValue(out double insertedValue) ? insertedValue : double.NaN,
                 Is.EqualTo(42.0),
                 "The value which comes back has to be the value which was written.");
         }
@@ -835,7 +834,7 @@ namespace Opc.Ua.Samples.Tests
         /// </summary>
         private static Annotation Decode(DataValue value)
         {
-            return value.WrappedValue.AsBoxedObject() is ExtensionObject extension
+            return value.WrappedValue.TryGetValue(out ExtensionObject extension)
                 ? ExtensionObject.ToEncodeable(extension) as Annotation
                 : null;
         }

--- a/Tests/SampleNodeManagers.Tests/HistoricalEventsNodeManagerTests.cs
+++ b/Tests/SampleNodeManagers.Tests/HistoricalEventsNodeManagerTests.cs
@@ -87,9 +87,7 @@ namespace Opc.Ua.Samples.Tests
                 .ReadAttributeAsync(Session, platforms, Attributes.EventNotifier, ct)
                 .ConfigureAwait(false);
 
-            byte flags = Convert.ToByte(
-                notifier.WrappedValue.AsBoxedObject(),
-                System.Globalization.CultureInfo.InvariantCulture);
+            notifier.WrappedValue.TryGetValue(out byte flags);
 
             await TestContext.Out
                 .WriteLineAsync($"EventNotifier of the platforms object: {flags}")
@@ -134,7 +132,7 @@ namespace Opc.Ua.Samples.Tests
                 [new QualifiedName(ReportBrowseNames.UidWell, ns)]).ConfigureAwait(false);
 
             CapturedEvent reported = await capture.WaitAsync(
-                candidate => candidate.Field(ReportBrowseNames.UidWell).AsBoxedObject() != null,
+                candidate => !candidate.Field(ReportBrowseNames.UidWell).IsNull,
                 TimeSpan.FromSeconds(25),
                 "a well test report carrying the well it belongs to",
                 ct).ConfigureAwait(false);
@@ -148,7 +146,7 @@ namespace Opc.Ua.Samples.Tests
                     "The report names the well it came from as its source.");
 
                 Assert.That(
-                    reported.Field(ReportBrowseNames.UidWell).AsBoxedObject() as string,
+                    reported.Field(ReportBrowseNames.UidWell).TryGetValue(out string uidWell) ? uidWell : null,
                     Does.StartWith("Well_"),
                     "The report carries the sample's own well identifier field.");
             });

--- a/Tests/SampleNodeManagers.Tests/MethodsNodeManagerTests.cs
+++ b/Tests/SampleNodeManagers.Tests/MethodsNodeManagerTests.cs
@@ -387,19 +387,18 @@ namespace Opc.Ua.Samples.Tests
         /// </summary>
         private static IEnumerable<ExtensionObject> AsExtensionObjects(Variant value)
         {
-            object boxed = value.AsBoxedObject();
+            if (!value.TryGetValue(out ArrayOf<ExtensionObject> structures))
+            {
+                throw new InvalidOperationException(
+                    $"The value is not an array of structures but a {value.TypeInfo}.");
+            }
 
-            return boxed switch {
-                ExtensionObject[] array => array,
-                ArrayOf<ExtensionObject> arrayOf => arrayOf.ToArray(),
-                _ => throw new InvalidOperationException(
-                    $"The value is not an array of structures but a {boxed?.GetType().Name ?? "null"}."),
-            };
+            return structures.ToArray();
         }
 
         private static uint ToUInt32(Variant value)
         {
-            return Convert.ToUInt32(value.AsBoxedObject(), System.Globalization.CultureInfo.InvariantCulture);
+            return value.ConvertTo(BuiltInType.UInt32).TryGetValue(out uint number) ? number : 0;
         }
     }
 }

--- a/Tests/SampleNodeManagers.Tests/PerfTestNodeManagerTests.cs
+++ b/Tests/SampleNodeManagers.Tests/PerfTestNodeManagerTests.cs
@@ -95,7 +95,7 @@ namespace Opc.Ua.Samples.Tests
                 .ConfigureAwait(false);
 
             Assert.That(
-                ((QualifiedName)browseName.WrappedValue.AsBoxedObject()).Name,
+                browseName.WrappedValue.TryGetValue(out QualifiedName name) ? name.Name : null,
                 Is.EqualTo("000005"),
                 "The browse name of a register variable is its index padded to six digits.");
 
@@ -104,7 +104,7 @@ namespace Opc.Ua.Samples.Tests
                 .ConfigureAwait(false);
 
             Assert.That(
-                dataType.WrappedValue.AsBoxedObject(),
+                dataType.WrappedValue.TryGetValue(out NodeId registerDataType) ? registerDataType : NodeId.Null,
                 Is.EqualTo(DataTypeIds.Int32),
                 "A register holds integers.");
         }

--- a/Tests/SampleNodeManagers.Tests/SimpleEventsNodeManagerTests.cs
+++ b/Tests/SampleNodeManagers.Tests/SimpleEventsNodeManagerTests.cs
@@ -126,7 +126,7 @@ namespace Opc.Ua.Samples.Tests
             CapturedEvent last = await capture.WaitAsync(
                 candidate => {
                     if (candidate.EventType == CycleStartedType
-                        && candidate.Field(Opc.Ua.BrowseNames.Severity).AsBoxedObject() is ushort severity)
+                        && candidate.Field(Opc.Ua.BrowseNames.Severity).TryGetValue(out ushort severity))
                     {
                         severities.Add(severity);
                     }
@@ -205,13 +205,13 @@ namespace Opc.Ua.Samples.Tests
 
             CapturedEvent reported = await capture.WaitAsync(
                 candidate => candidate.EventType == CycleStartedType
-                    && candidate.Field(EventBrowseNames.CycleId).AsBoxedObject() != null,
+                    && !candidate.Field(EventBrowseNames.CycleId).IsNull,
                 TimeSpan.FromSeconds(15),
                 "a cycle event carrying a cycle id",
                 ct).ConfigureAwait(false);
 
             Assert.That(
-                reported.Field(EventBrowseNames.CycleId).AsBoxedObject() as string,
+                reported.Field(EventBrowseNames.CycleId).TryGetValue(out string cycleId) ? cycleId : null,
                 Is.Not.Null.And.Not.Empty,
                 "The cycle id is a field of the sample's own event type.");
         }

--- a/Tests/SampleNodeManagers.Tests/TestDataNodeManagerTests.cs
+++ b/Tests/SampleNodeManagers.Tests/TestDataNodeManagerTests.cs
@@ -82,7 +82,7 @@ namespace Opc.Ua.Samples.Tests
 
             DataValue before = await SessionOps.ReadValueAsync(Session, value, ct).ConfigureAwait(false);
 
-            int written = Convert.ToInt32(before.WrappedValue.AsBoxedObject(), CultureInfo.InvariantCulture) + 4711;
+            int written = (before.WrappedValue.TryGetValue(out int previous) ? previous : 0) + 4711;
 
             StatusCode result = await SessionOps
                 .WriteValueAsync(Session, value, Variant.From(written), ct)
@@ -100,7 +100,7 @@ namespace Opc.Ua.Samples.Tests
                 .ConfigureAwait(false);
 
             Assert.That(
-                Convert.ToInt32(after.WrappedValue.AsBoxedObject(), CultureInfo.InvariantCulture),
+                after.WrappedValue.TryGetValue(out int current) ? current : 0,
                 Is.EqualTo(written),
                 "A static variable has to keep the value it was written.");
         }
@@ -180,18 +180,18 @@ namespace Opc.Ua.Samples.Tests
 
             Assert.Multiple(() => {
                 Assert.That(
-                    onArchived.WrappedValue.AsBoxedObject(),
-                    Is.EqualTo(true),
+                    onArchived.WrappedValue.TryGetValue(out bool archivedFlag) && archivedFlag,
+                    Is.True,
                     "The node manager turns archiving on for the simulated integer.");
 
                 Assert.That(
-                    onOther.WrappedValue.AsBoxedObject(),
-                    Is.EqualTo(false),
+                    onOther.WrappedValue.TryGetValue(out bool otherFlag) ? otherFlag : (bool?)null,
+                    Is.False,
                     "No other simulated variable is archived.");
 
                 Assert.That(
-                    onStatic.WrappedValue.AsBoxedObject(),
-                    Is.EqualTo(false),
+                    onStatic.WrappedValue.TryGetValue(out bool staticFlag) ? staticFlag : (bool?)null,
+                    Is.False,
                     "The static variables are not archived.");
             });
 
@@ -200,7 +200,7 @@ namespace Opc.Ua.Samples.Tests
                 .ConfigureAwait(false);
 
             Assert.That(
-                Convert.ToByte(accessLevel.WrappedValue.AsBoxedObject(), CultureInfo.InvariantCulture)
+                (accessLevel.WrappedValue.TryGetValue(out byte flags) ? flags : (byte)0)
                     & AccessLevels.HistoryRead,
                 Is.Not.Zero,
                 "The archived variable has to say that its history can be read.");

--- a/Tests/SampleNodeManagers.Tests/UserAuthenticationNodeManagerTests.cs
+++ b/Tests/SampleNodeManagers.Tests/UserAuthenticationNodeManagerTests.cs
@@ -8,7 +8,6 @@
  * ======================================================================*/
 
 using System;
-using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -101,8 +100,8 @@ namespace Opc.Ua.Samples.Tests
                 .ReadAttributeAsync(Session, logFilePath, Attributes.UserAccessLevel, ct)
                 .ConfigureAwait(false);
 
-            byte forTheNode = Convert.ToByte(accessLevel.WrappedValue.AsBoxedObject(), CultureInfo.InvariantCulture);
-            byte forThisUser = Convert.ToByte(userAccessLevel.WrappedValue.AsBoxedObject(), CultureInfo.InvariantCulture);
+            accessLevel.WrappedValue.TryGetValue(out byte forTheNode);
+            userAccessLevel.WrappedValue.TryGetValue(out byte forThisUser);
 
             await TestContext.Out
                 .WriteLineAsync($"AccessLevel {forTheNode}, UserAccessLevel {forThisUser} for an anonymous session")
@@ -231,7 +230,7 @@ namespace Opc.Ua.Samples.Tests
                 .ConfigureAwait(false);
 
             Assert.That(
-                Convert.ToByte(userAccessLevel.WrappedValue.AsBoxedObject(), CultureInfo.InvariantCulture),
+                userAccessLevel.WrappedValue.TryGetValue(out byte writable) ? writable : (byte)0,
                 Is.EqualTo(AccessLevels.CurrentReadOrWrite),
                 "An authenticated session has to be told it may write.");
 

--- a/Tests/SampleServers.Tests/ConsoleSampleTests.cs
+++ b/Tests/SampleServers.Tests/ConsoleSampleTests.cs
@@ -8,7 +8,6 @@
  * ======================================================================*/
 
 using System;
-using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -122,7 +121,8 @@ namespace Opc.Ua.Samples.Tests
                 Is.True,
                 $"Reading the server state failed: {state.StatusCode}");
 
-            var serverState = (ServerState)Convert.ToInt32(state.WrappedValue.AsBoxedObject(), CultureInfo.InvariantCulture);
+            state.WrappedValue.TryGetValue(out int stateCode);
+            var serverState = (ServerState)stateCode;
 
             Assert.That(serverState, Is.EqualTo(ServerState.Running), "The server does not report itself as running.");
         }

--- a/Tests/SampleServers.Tests/SampleServerTests.cs
+++ b/Tests/SampleServers.Tests/SampleServerTests.cs
@@ -9,7 +9,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Runtime.ExceptionServices;
 using System.Threading;
@@ -157,7 +156,8 @@ namespace Opc.Ua.Samples.Tests
                 Is.True,
                 $"Reading the server state failed: {state.StatusCode}");
 
-            var serverState = (ServerState)Convert.ToInt32(state.WrappedValue.AsBoxedObject(), CultureInfo.InvariantCulture);
+            state.WrappedValue.TryGetValue(out int stateCode);
+            var serverState = (ServerState)stateCode;
 
             Assert.That(serverState, Is.EqualTo(ServerState.Running), "The server does not report itself as running.");
 

--- a/Tests/Samples.Tests.Common/EventCapture.cs
+++ b/Tests/Samples.Tests.Common/EventCapture.cs
@@ -44,19 +44,19 @@ namespace Opc.Ua.Samples.Tests
         /// The type of the event.
         /// </summary>
         public NodeId EventType
-            => Field(Opc.Ua.BrowseNames.EventType).AsBoxedObject() as NodeId? ?? NodeId.Null;
+            => Field(Opc.Ua.BrowseNames.EventType).TryGetValue(out NodeId eventType) ? eventType : NodeId.Null;
 
         /// <summary>
         /// The name of the source which reported the event.
         /// </summary>
         public string SourceName
-            => Field(Opc.Ua.BrowseNames.SourceName).AsBoxedObject() as string;
+            => Field(Opc.Ua.BrowseNames.SourceName).TryGetValue(out string sourceName) ? sourceName : null;
 
         /// <summary>
         /// The message of the event.
         /// </summary>
         public string Message
-            => (Field(Opc.Ua.BrowseNames.Message).AsBoxedObject() as LocalizedText?)?.Text;
+            => Field(Opc.Ua.BrowseNames.Message).TryGetValue(out LocalizedText message) ? message.Text : null;
 
         /// <summary>
         /// The value of one of the selected fields, by the name it was selected under.

--- a/Workshop/Aggregation/Server/NamespaceMapper.cs
+++ b/Workshop/Aggregation/Server/NamespaceMapper.cs
@@ -46,18 +46,6 @@ namespace AggregationServer
             get { return m_localNamespaceIndexes; }
         }
 
-        private Array CastArray(Array source, Func<object, BuiltInType, BuiltInType, object> converter)
-        {
-            Type elementType = source.GetType().GetElementType() ?? typeof(object);
-            Array result = Array.CreateInstance(elementType, source.Length);
-            for (int ii = 0; ii < source.Length; ii++)
-            {
-                object mapped = converter(source.GetValue(ii), BuiltInType.Null, BuiltInType.Null);
-                result.SetValue(mapped, ii);
-            }
-            return result;
-        }
-
         /// <summary>
         /// Gets or sets the Uris for the Node Managers it supports e.g. "http://samples.org/UA/memorybuffer".
         /// </summary>
@@ -344,11 +332,6 @@ namespace AggregationServer
 
             if (type.IsUnknown)
             {
-                type = TypeInfo.Construct(value.AsBoxedObject());
-            }
-
-            if (type.IsUnknown)
-            {
                 return Variant.Null;
             }
 
@@ -358,22 +341,30 @@ namespace AggregationServer
                 {
                     case BuiltInType.NodeId:
                     {
-                        return Variant.From(ToId((NodeId)value.AsBoxedObject(), namespaceIndexes));
+                        return value.TryGetValue(out NodeId nodeId)
+                            ? Variant.From(ToId(nodeId, namespaceIndexes))
+                            : value;
                     }
 
                     case BuiltInType.ExpandedNodeId:
                     {
-                        return Variant.From(ToId((ExpandedNodeId)value.AsBoxedObject(), namespaceIndexes));
+                        return value.TryGetValue(out ExpandedNodeId expandedNodeId)
+                            ? Variant.From(ToId(expandedNodeId, namespaceIndexes))
+                            : value;
                     }
 
                     case BuiltInType.QualifiedName:
                     {
-                        return Variant.From(ToName((QualifiedName)value.AsBoxedObject(), namespaceIndexes));
+                        return value.TryGetValue(out QualifiedName qualifiedName)
+                            ? Variant.From(ToName(qualifiedName, namespaceIndexes))
+                            : value;
                     }
 
                     case BuiltInType.ExtensionObject:
                     {
-                        return Variant.From(ToExtensionObject((ExtensionObject)value.AsBoxedObject(), namespaceIndexes));
+                        return value.TryGetValue(out ExtensionObject extension)
+                            ? Variant.From(ToExtensionObject(extension, namespaceIndexes))
+                            : value;
                     }
                 }
             }
@@ -382,31 +373,38 @@ namespace AggregationServer
                 switch (type.BuiltInType)
                 {
                     case BuiltInType.NodeId:
+                    {
+                        return value.TryGetValue(out ArrayOf<NodeId> nodeIds)
+                            ? Variant.From(MapElements(nodeIds, x => ToId(x, namespaceIndexes)))
+                            : value;
+                    }
+
                     case BuiltInType.ExpandedNodeId:
+                    {
+                        return value.TryGetValue(out ArrayOf<ExpandedNodeId> expandedNodeIds)
+                            ? Variant.From(MapElements(expandedNodeIds, x => ToId(x, namespaceIndexes)))
+                            : value;
+                    }
+
                     case BuiltInType.QualifiedName:
+                    {
+                        return value.TryGetValue(out ArrayOf<QualifiedName> qualifiedNames)
+                            ? Variant.From(MapElements(qualifiedNames, x => ToName(x, namespaceIndexes)))
+                            : value;
+                    }
+
                     case BuiltInType.ExtensionObject:
+                    {
+                        return value.TryGetValue(out ArrayOf<ExtensionObject> extensions)
+                            ? Variant.From(MapElements(extensions, x => ToExtensionObject(x, namespaceIndexes)))
+                            : value;
+                    }
+
                     case BuiltInType.Variant:
                     {
-                        Array array = null;
-
-                        if (Object.ReferenceEquals(m_localNamespaceIndexes, namespaceIndexes))
-                        {
-                            array = CastArray((Array)value.AsBoxedObject(), CastArrayToLocal);
-                        }
-                        else
-                        {
-                            array = CastArray((Array)value.AsBoxedObject(), CastArrayToRemote);
-                        }
-
-                        return type.BuiltInType switch
-                        {
-                            BuiltInType.NodeId => Variant.From((NodeId[])array),
-                            BuiltInType.ExpandedNodeId => Variant.From((ExpandedNodeId[])array),
-                            BuiltInType.QualifiedName => Variant.From((QualifiedName[])array),
-                            BuiltInType.ExtensionObject => Variant.From((ExtensionObject[])array),
-                            BuiltInType.Variant => Variant.From((Variant[])array),
-                            _ => value
-                        };
+                        return value.TryGetValue(out ArrayOf<Variant> variants)
+                            ? Variant.From(MapElements(variants, x => ToVariant(x, namespaceIndexes)))
+                            : value;
                     }
                 }
             }
@@ -415,36 +413,20 @@ namespace AggregationServer
         }
 
         /// <summary>
-        /// Casts an array value to a local value.
+        /// Maps the namespace indexes of every element of an array.
         /// </summary>
-        private object CastArrayToLocal(object source, BuiltInType srcType, BuiltInType dstType)
+        private static ArrayOf<T> MapElements<T>(ArrayOf<T> source, Func<T, T> converter)
         {
-            return MapElement(source, m_localNamespaceIndexes);
-        }
+            T[] result = new T[source.Count];
 
-        /// <summary>
-        /// Casts an array value to a remote value.
-        /// </summary>
-        private object CastArrayToRemote(object source, BuiltInType srcType, BuiltInType dstType)
-        {
-            return MapElement(source, m_remoteNamespaceIndexes);
-        }
-
-        /// <summary>
-        /// Maps the namespace indexes of a single array element.
-        /// </summary>
-        private object MapElement(object source, int[] namespaceIndexes)
-        {
-            switch (source)
+            for (int ii = 0; ii < result.Length; ii++)
             {
-                case Variant variant: return ToVariant(variant, namespaceIndexes);
-                case NodeId nodeId: return ToId(nodeId, namespaceIndexes);
-                case ExpandedNodeId expandedNodeId: return ToId(expandedNodeId, namespaceIndexes);
-                case QualifiedName qualifiedName: return ToName(qualifiedName, namespaceIndexes);
-                case ExtensionObject extension: return ToExtensionObject(extension, namespaceIndexes);
-                default: return source;
+                result[ii] = converter(source[ii]);
             }
+
+            return new ArrayOf<T>(result);
         }
+
         #endregion
 
         #region Private Fields

--- a/Workshop/AlarmCondition/Client/FormUtils.cs
+++ b/Workshop/AlarmCondition/Client/FormUtils.cs
@@ -178,7 +178,7 @@ namespace Quickstarts.AlarmConditionClient
 
                     if (clause.BrowsePath.Count == 1 && clause.BrowsePath[0] == BrowseNames.EventType)
                     {
-                        return notification.EventFields[ii].AsBoxedObject() is NodeId nodeId ? nodeId : NodeId.Null;
+                        return notification.EventFields[ii].TryGetValue(out NodeId nodeId) ? nodeId : NodeId.Null;
                     }
                 }
             }

--- a/Workshop/AlarmCondition/Client/ViewEventDetailsDlg.cs
+++ b/Workshop/AlarmCondition/Client/ViewEventDetailsDlg.cs
@@ -66,7 +66,7 @@ namespace Quickstarts.AlarmConditionClient
             // the filter the item was created with determines what is in each field.
             if (filter != null)
             {
-                if (eventFields.EventFields[0].AsBoxedObject() != null)
+                if (!eventFields.EventFields[0].IsNull)
                 {
                     fieldNames.Add("ConditionId");
                     fieldValues.Add(eventFields.EventFields[0]);
@@ -74,9 +74,7 @@ namespace Quickstarts.AlarmConditionClient
 
                 for (int ii = 1; ii < filter.SelectClauses.Count; ii++)
                 {
-                    object fieldValue = eventFields.EventFields[ii].AsBoxedObject();
-
-                    if (fieldValue == null)
+                    if (eventFields.EventFields[ii].IsNull)
                     {
                         continue;
                     }
@@ -103,8 +101,8 @@ namespace Quickstarts.AlarmConditionClient
             {
                 ListViewItem item = new ListViewItem(fieldNames[ii]);
 
-                item.SubItems.Add(Utils.Format("{0}", fieldValues[ii].AsBoxedObject()));
-                item.SubItems.Add(Utils.Format("{0}", fieldValues[ii].AsBoxedObject().GetType().Name));
+                item.SubItems.Add(fieldValues[ii].ToString());
+                item.SubItems.Add(fieldValues[ii].TypeInfo.ToString());
 
                 FieldsLV.Items.Add(item);
             }

--- a/Workshop/Common/FormUtils.cs
+++ b/Workshop/Common/FormUtils.cs
@@ -187,11 +187,9 @@ namespace Quickstarts
                 case Attributes.AccessLevel:
                 case Attributes.UserAccessLevel:
                 {
-                    byte? field = value.AsBoxedObject() as byte?;
-
-                    if (field != null)
+                    if (value.TryGetValue(out byte accessLevel))
                     {
-                        return GetAccessLevelDisplayText(field.Value);
+                        return GetAccessLevelDisplayText(accessLevel);
                     }
 
                     break;
@@ -199,11 +197,9 @@ namespace Quickstarts
 
                 case Attributes.EventNotifier:
                 {
-                    byte? field = value.AsBoxedObject() as byte?;
-
-                    if (field != null)
+                    if (value.TryGetValue(out byte eventNotifier))
                     {
-                        return GetEventNotifierDisplayText(field.Value);
+                        return GetEventNotifierDisplayText(eventNotifier);
                     }
 
                     break;
@@ -211,16 +207,14 @@ namespace Quickstarts
 
                 case Attributes.DataType:
                 {
-                    return await session.NodeCache.GetDisplayTextAsync(value.AsBoxedObject() is NodeId nodeId ? nodeId : NodeId.Null, ct);
+                    return await session.NodeCache.GetDisplayTextAsync(value.TryGetValue(out NodeId dataTypeId) ? dataTypeId : NodeId.Null, ct);
                 }
 
                 case Attributes.ValueRank:
                 {
-                    int? field = value.AsBoxedObject() as int?;
-
-                    if (field != null)
+                    if (value.TryGetValue(out int valueRank))
                     {
-                        return GetValueRankDisplayText(field.Value);
+                        return GetValueRankDisplayText(valueRank);
                     }
 
                     break;
@@ -228,11 +222,9 @@ namespace Quickstarts
 
                 case Attributes.NodeClass:
                 {
-                    int? field = value.AsBoxedObject() as int?;
-
-                    if (field != null)
+                    if (value.TryGetValue(out int nodeClass))
                     {
-                        return ((NodeClass)field.Value).ToString();
+                        return ((NodeClass)nodeClass).ToString();
                     }
 
                     break;
@@ -240,9 +232,7 @@ namespace Quickstarts
 
                 case Attributes.NodeId:
                 {
-                    NodeId field = value.AsBoxedObject() is NodeId nodeId ? nodeId : NodeId.Null;
-
-                    if (!(field).IsNull)
+                    if (value.TryGetValue(out NodeId field) && !field.IsNull)
                     {
                         return field.ToString();
                     }
@@ -252,9 +242,9 @@ namespace Quickstarts
             }
 
             // check for byte strings.
-            if (value.AsBoxedObject() is byte[])
+            if (value.TryGetValue(out ByteString byteString))
             {
-                return Utils.ToHexString(value.AsBoxedObject() as byte[]);
+                return Utils.ToHexString(byteString.Span);
             }
 
             // use default format.
@@ -561,7 +551,7 @@ namespace Quickstarts
 
                     if (clause.BrowsePath.Count == 1 && clause.BrowsePath[0] == BrowseNames.EventType)
                     {
-                        return notification.EventFields[ii].AsBoxedObject() is NodeId nodeId ? nodeId : NodeId.Null;
+                        return notification.EventFields[ii].TryGetValue(out NodeId nodeId) ? nodeId : NodeId.Null;
                     }
                 }
             }

--- a/Workshop/Common/ModelUtils.cs
+++ b/Workshop/Common/ModelUtils.cs
@@ -727,11 +727,11 @@ namespace Quickstarts
         /// <summary>
         /// Returns the value for the specified browse name.
         /// </summary>
-        public T GetValue<T>(QualifiedName browseName, IList<Variant> fields, T defaultValue)
+        public Variant GetValue(QualifiedName browseName, IList<Variant> fields)
         {
             if (fields == null || fields.Count == 0)
             {
-                return defaultValue;
+                return Variant.Null;
             }
 
             for (int ii = 0; ii < this.Fields.Count; ii++)
@@ -740,21 +740,14 @@ namespace Quickstarts
                 {
                     if (ii >= fields.Count + 1)
                     {
-                        return defaultValue;
+                        return Variant.Null;
                     }
 
-                    object value = fields[ii + 1].AsBoxedObject();
-
-                    if (typeof(T).IsInstanceOfType(value))
-                    {
-                        return (T)value;
-                    }
-
-                    break;
+                    return fields[ii + 1];
                 }
             }
 
-            return defaultValue;
+            return Variant.Null;
         }
 
         #pragma warning disable CA1051 // Justification: sample data transfer type intentionally exposes mutable fields.

--- a/Workshop/Common/QuickstartNodeManager.cs
+++ b/Workshop/Common/QuickstartNodeManager.cs
@@ -1051,36 +1051,39 @@ namespace Quickstarts
                 metadata.BrowseName = target.BrowseName;
                 metadata.DisplayName = target.DisplayName;
 
-                if (values[0].AsBoxedObject() != null && values[1].AsBoxedObject() != null)
+                if (values[0].TryGetValue(out uint writeMask) &&
+                    values[1].TryGetValue(out uint userWriteMask))
                 {
-                    metadata.WriteMask = (AttributeWriteMask)(((uint)values[0].AsBoxedObject()) & ((uint)values[1].AsBoxedObject()));
+                    metadata.WriteMask = (AttributeWriteMask)(writeMask & userWriteMask);
                 }
 
-                if (values[2].AsBoxedObject() != null)
+                if (values[2].TryGetValue(out NodeId dataType))
                 {
-                    metadata.DataType = (NodeId)values[2].AsBoxedObject();
+                    metadata.DataType = dataType;
                 }
 
-                if (values[3].AsBoxedObject() != null)
+                if (values[3].TryGetValue(out int valueRank))
                 {
-                    metadata.ValueRank = (int)values[3].AsBoxedObject();
+                    metadata.ValueRank = valueRank;
                 }
 
-                metadata.ArrayDimensions = values[4].AsBoxedObject() is IList<uint> dims ? dims.ToArrayOf() : ArrayOf<uint>.Empty;
+                metadata.ArrayDimensions = values[4].TryGetValue(out ArrayOf<uint> dims) ? dims : ArrayOf<uint>.Empty;
 
-                if (values[5].AsBoxedObject() != null && values[6].AsBoxedObject() != null)
+                if (values[5].TryGetValue(out byte accessLevel) &&
+                    values[6].TryGetValue(out byte userAccessLevel))
                 {
-                    metadata.AccessLevel = (byte)(((byte)values[5].AsBoxedObject()) & ((byte)values[6].AsBoxedObject()));
+                    metadata.AccessLevel = (byte)(accessLevel & userAccessLevel);
                 }
 
-                if (values[7].AsBoxedObject() != null)
+                if (values[7].TryGetValue(out byte eventNotifier))
                 {
-                    metadata.EventNotifier = (byte)values[7].AsBoxedObject();
+                    metadata.EventNotifier = eventNotifier;
                 }
 
-                if (values[8].AsBoxedObject() != null && values[9].AsBoxedObject() != null)
+                if (values[8].TryGetValue(out bool executable) &&
+                    values[9].TryGetValue(out bool userExecutable))
                 {
-                    metadata.Executable = (((bool)values[8].AsBoxedObject()) && ((bool)values[9].AsBoxedObject()));
+                    metadata.Executable = executable && userExecutable;
                 }
 
                 // get instance references.
@@ -3522,9 +3525,7 @@ namespace Quickstarts
                     return StatusCodes.BadFilterNotAllowed;
                 }
 
-                range = property.Value.AsBoxedObject() as Opc.Ua.Range;
-
-                if (range == null)
+                if (!property.Value.TryGetStructure(out range))
                 {
                     return StatusCodes.BadFilterNotAllowed;
                 }

--- a/Workshop/DataAccess/Client/MainForm.cs
+++ b/Workshop/DataAccess/Client/MainForm.cs
@@ -423,7 +423,7 @@ namespace Quickstarts.DataAccessClient
                         // display the value.
                         else
                         {
-                            TypeInfo typeInfo = TypeInfo.Construct(results[ii].WrappedValue.AsBoxedObject());
+                            TypeInfo typeInfo = results[ii].WrappedValue.TypeInfo;
 
                             datatype = typeInfo.BuiltInType.ToString();
 
@@ -432,7 +432,7 @@ namespace Quickstarts.DataAccessClient
                                 datatype += "[]";
                             }
 
-                            value = Utils.Format("{0}", results[ii].WrappedValue.AsBoxedObject());
+                            value = results[ii].WrappedValue.ToString();
                         }
                     }
 
@@ -458,7 +458,7 @@ namespace Quickstarts.DataAccessClient
                         // display the value.
                         else
                         {
-                            TypeInfo typeInfo = TypeInfo.Construct(results[ii].WrappedValue.AsBoxedObject());
+                            TypeInfo typeInfo = results[ii].WrappedValue.TypeInfo;
 
                             datatype = typeInfo.BuiltInType.ToString();
 
@@ -467,7 +467,7 @@ namespace Quickstarts.DataAccessClient
                                 datatype += "[]";
                             }
 
-                            value = Utils.Format("{0}", results[ii].WrappedValue.AsBoxedObject());
+                            value = results[ii].WrappedValue.ToString();
                         }
                     }
 

--- a/Workshop/DataAccess/Server/Model/BlockState.cs
+++ b/Workshop/DataAccess/Server/Model/BlockState.cs
@@ -163,7 +163,7 @@ namespace Quickstarts.DataAccessServer
                     new AttributeWriteResult(StatusCodes.BadNodeIdUnknown));
             }
 
-            StatusCode error = block.WriteTagValue(node.SymbolicName, value.AsBoxedObject());
+            StatusCode error = block.WriteTagValue(node.SymbolicName, value);
 
             if (error != 0)
             {
@@ -329,7 +329,7 @@ namespace Quickstarts.DataAccessServer
         private void UpdateVariable(ISystemContext context, UnderlyingSystemTag tag, BaseVariableState variable)
         {
             variable.Description = new LocalizedText(tag.Description);
-            variable.Value = Variant.From((dynamic)tag.Value);
+            variable.Value = tag.Value;
             variable.Timestamp = tag.Timestamp;
 
             switch (tag.DataType)

--- a/Workshop/DataAccess/Server/UnderlyingSystem/UnderlyingSystemBlock.cs
+++ b/Workshop/DataAccess/Server/UnderlyingSystem/UnderlyingSystemBlock.cs
@@ -207,7 +207,7 @@ namespace Quickstarts.DataAccessServer
         /// <param name="tagName">Name of the tag.</param>
         /// <param name="value">The value.</param>
         /// <returns>The status code for the operation.</returns>
-        public StatusCode WriteTagValue(string tagName, object value)
+        public StatusCode WriteTagValue(string tagName, Variant value)
         {
             UnderlyingSystemTag tag = null;
             TagsChangedEventHandler onTagsChanged = null;
@@ -224,45 +224,63 @@ namespace Quickstarts.DataAccessServer
                     return StatusCodes.BadNodeIdUnknown;
                 }
 
-                // cast value to correct type.
-                try
+                // the value must match the type of the tag.
+                switch (tag.DataType)
                 {
-                    switch (tag.DataType)
+                    case UnderlyingSystemDataType.Integer1:
                     {
-                        case UnderlyingSystemDataType.Integer1:
+                        if (!value.TryGetValue(out sbyte int1Value))
                         {
-                            tag.Value = (sbyte)value;
-                            break;
+                            return StatusCodes.BadTypeMismatch;
                         }
 
-                        case UnderlyingSystemDataType.Integer2:
-                        {
-                            tag.Value = (short)value;
-                            break;
-                        }
-
-                        case UnderlyingSystemDataType.Integer4:
-                        {
-                            tag.Value = (int)value;
-                            break;
-                        }
-
-                        case UnderlyingSystemDataType.Real4:
-                        {
-                            tag.Value = (float)value;
-                            break;
-                        }
-
-                        case UnderlyingSystemDataType.String:
-                        {
-                            tag.Value = (string)value;
-                            break;
-                        }
+                        tag.Value = int1Value;
+                        break;
                     }
-                }
-                catch
-                {
-                    return StatusCodes.BadTypeMismatch;
+
+                    case UnderlyingSystemDataType.Integer2:
+                    {
+                        if (!value.TryGetValue(out short int2Value))
+                        {
+                            return StatusCodes.BadTypeMismatch;
+                        }
+
+                        tag.Value = int2Value;
+                        break;
+                    }
+
+                    case UnderlyingSystemDataType.Integer4:
+                    {
+                        if (!value.TryGetValue(out int int4Value))
+                        {
+                            return StatusCodes.BadTypeMismatch;
+                        }
+
+                        tag.Value = int4Value;
+                        break;
+                    }
+
+                    case UnderlyingSystemDataType.Real4:
+                    {
+                        if (!value.TryGetValue(out float real4Value))
+                        {
+                            return StatusCodes.BadTypeMismatch;
+                        }
+
+                        tag.Value = real4Value;
+                        break;
+                    }
+
+                    case UnderlyingSystemDataType.String:
+                    {
+                        if (!value.TryGetValue(out string stringValue))
+                        {
+                            return StatusCodes.BadTypeMismatch;
+                        }
+
+                        tag.Value = stringValue;
+                        break;
+                    }
                 }
 
                 // updated the timestamp.

--- a/Workshop/DataAccess/Server/UnderlyingSystem/UnderlyingSystemTag.cs
+++ b/Workshop/DataAccess/Server/UnderlyingSystem/UnderlyingSystemTag.cs
@@ -108,7 +108,7 @@ namespace Quickstarts.DataAccessServer
         /// Gets or sets the value of the tag.
         /// </summary>
         /// <value>The tag value.</value>
-        public object Value
+        public Variant Value
         {
             get { return m_value; }
             set { m_value = value; }
@@ -184,7 +184,7 @@ namespace Quickstarts.DataAccessServer
         private bool m_isWriteable;
         private double[] m_euRange;
         private string[] m_labels;
-        private object m_value;
+        private Variant m_value;
         private DateTime m_timestamp;
         #endregion
     }

--- a/Workshop/HistoricalAccess/Client/WriteValueDlg.cs
+++ b/Workshop/HistoricalAccess/Client/WriteValueDlg.cs
@@ -104,7 +104,7 @@ namespace Quickstarts.HistoricalAccess.Client
             ClientBase.ValidateDiagnosticInfos(diagnosticInfos, nodesToRead);
 
             m_value = results[0];
-            ValueTB.Text = Utils.Format("{0}", m_value.WrappedValue.AsBoxedObject());
+            ValueTB.Text = m_value.WrappedValue.ToString();
 
             // display the dialog.
             if (ShowDialog() != DialogResult.OK)

--- a/Workshop/HistoricalAccess/Server/Program.cs
+++ b/Workshop/HistoricalAccess/Server/Program.cs
@@ -333,10 +333,14 @@ namespace Quickstarts.HistoricalAccessServer
 
                 if (StatusCode.IsNotBad(values[ii].StatusCode))
                 {
-                    double value1 = Math.Round(Convert.ToDouble(values[ii].WrappedValue.AsBoxedObject()), 4);
-                    double value2 = Math.Round(Convert.ToDouble(expectedValues[ii].WrappedValue.AsBoxedObject()), 4);
+                    if (!values[ii].WrappedValue.ConvertTo(BuiltInType.Double).TryGetValue(out double value1) ||
+                        !expectedValues[ii].WrappedValue.ConvertTo(BuiltInType.Double).TryGetValue(out double value2))
+                    {
+                        logger.LogTrace("Wrong Value");
+                        continue;
+                    }
 
-                    if (value1 != value2)
+                    if (Math.Round(value1, 4) != Math.Round(value2, 4))
                     {
                         logger.LogTrace("Wrong Value");
                         continue;

--- a/Workshop/HistoricalAccess/Server/UnderlyingSystem/ArchiveItemState.cs
+++ b/Workshop/HistoricalAccess/Server/UnderlyingSystem/ArchiveItemState.cs
@@ -216,11 +216,6 @@ namespace Quickstarts.HistoricalAccessServer
             {
                 TypeInfo typeInfo = value.WrappedValue.TypeInfo;
 
-                if (typeInfo.IsUnknown)
-                {
-                    typeInfo = TypeInfo.Construct(value.WrappedValue.AsBoxedObject());
-                }
-
                 if (typeInfo.IsUnknown || typeInfo.BuiltInType != m_archiveItem.DataType || typeInfo.ValueRank != ValueRanks.Scalar)
                 {
                     return StatusCodes.BadTypeMismatch.Code;

--- a/Workshop/HistoricalAccess/Tester/MainForm.cs
+++ b/Workshop/HistoricalAccess/Tester/MainForm.cs
@@ -575,15 +575,15 @@ namespace Quickstarts
 
                 if (!result.TypeInfo.IsUnknown)
                 {
-                    if (result.TypeInfo.BuiltInType == BuiltInType.Double)
+                    if (result.TryGetValue(out double doubleValue))
                     {
-                        if (Math.Truncate((double)result.AsBoxedObject()) == (double)result.AsBoxedObject())
+                        if (Math.Truncate(doubleValue) == doubleValue)
                         {
-                            buffer.AppendFormat("{0}", (long)(double)result.AsBoxedObject());
+                            buffer.AppendFormat("{0}", (long)doubleValue);
                         }
                         else
                         {
-                            buffer.AppendFormat("{0:F3}", result.AsBoxedObject());
+                            buffer.AppendFormat("{0:F3}", doubleValue);
                         }
                     }
                     else
@@ -883,13 +883,10 @@ namespace Quickstarts
                 {
                     Variant expectedValue = TestData.ValidateValue(row[3]);
 
-                    StatusCode? statusValue1 = expectedValue.AsBoxedObject() as StatusCode?;
-
-                    if (statusValue1 != null)
+                    if (expectedValue.TryGetValue(out StatusCode statusValue1))
                     {
-                        StatusCode? statusValue2 = actualValue.Value as StatusCode?;
-
-                        if (statusValue2 == null || statusValue2.Value != statusValue1.Value)
+                        if (!actualValue.WrappedValue.TryGetValue(out StatusCode statusValue2) ||
+                            statusValue2 != statusValue1)
                         {
                             UpdateActualValue(row.Row, actualValue, RowState.Failed);
                             continue;
@@ -898,10 +895,9 @@ namespace Quickstarts
 
                     else
                     {
-                        double value1 = Math.Round(Convert.ToDouble(expectedValue.AsBoxedObject()), 4);
-                        double value2 = Math.Round(Convert.ToDouble(actualValue.Value), 4);
-
-                        if (value1 != value2)
+                        if (!expectedValue.ConvertTo(BuiltInType.Double).TryGetValue(out double value1) ||
+                            !actualValue.WrappedValue.ConvertTo(BuiltInType.Double).TryGetValue(out double value2) ||
+                            Math.Round(value1, 4) != Math.Round(value2, 4))
                         {
                             UpdateActualValue(row.Row, actualValue, RowState.Failed);
                             continue;
@@ -1035,7 +1031,7 @@ namespace Quickstarts
 
                 TestData.DataValue dv = new TestData.DataValue();
 
-                dv.Value = TestData.ValidateValue(TestDataDV.Rows[e.RowIndex].Cells[3].FormattedValue);
+                dv.WrappedValue = TestData.ValidateValue(TestDataDV.Rows[e.RowIndex].Cells[3].FormattedValue);
                 dv.StatusCode = TestData.ValidateQuality(TestDataDV.Rows[e.RowIndex].Cells[4].FormattedValue);
                 dv.SourceTimestamp = TestData.ValidateTimestamp(TestDataDV.Rows[e.RowIndex].Cells[0].FormattedValue);
                 dv.Comment = TestDataDV.Rows[e.RowIndex].Cells[8].FormattedValue as string;
@@ -1344,15 +1340,15 @@ namespace Quickstarts
 
                     if (!value.TypeInfo.IsUnknown)
                     {
-                        if (value.TypeInfo.BuiltInType == BuiltInType.Double)
+                        if (value.TryGetValue(out double doubleValue))
                         {
-                            if (Math.Truncate((double)value.AsBoxedObject()) == (double)value.AsBoxedObject())
+                            if (Math.Truncate(doubleValue) == doubleValue)
                             {
-                                buffer.AppendFormat("{0}", (long)(double)value.AsBoxedObject());
+                                buffer.AppendFormat("{0}", (long)doubleValue);
                             }
                             else
                             {
-                                buffer.AppendFormat("{0:F3}", value.AsBoxedObject());
+                                buffer.AppendFormat("{0:F3}", doubleValue);
                             }
                         }
                         else

--- a/Workshop/HistoricalAccess/Tester/TestDataHelpers.cs
+++ b/Workshop/HistoricalAccess/Tester/TestDataHelpers.cs
@@ -236,66 +236,12 @@ namespace Quickstarts
             public DataValue() { m_value = new Opc.Ua.DataValue(); }
             public DataValue(Opc.Ua.DataValue value) { m_value = value; }
             public string Comment { get; set; }
-            public object Value { get { return m_value.WrappedValue.AsBoxedObject(); } set { WrappedValue = ToVariant(value); } }
             public Variant WrappedValue { get { return m_value.WrappedValue; } set { m_value = new Opc.Ua.DataValue(value, m_value.StatusCode, m_value.SourceTimestamp, m_value.ServerTimestamp, m_value.SourcePicoseconds, m_value.ServerPicoseconds); } }
             public DateTime SourceTimestamp { get { return (DateTime)m_value.SourceTimestamp; } set { m_value = new Opc.Ua.DataValue(m_value.WrappedValue, m_value.StatusCode, value, m_value.ServerTimestamp, m_value.SourcePicoseconds, m_value.ServerPicoseconds); } }
             public StatusCode StatusCode { get { return m_value.StatusCode; } set { m_value = new Opc.Ua.DataValue(m_value.WrappedValue, value, m_value.SourceTimestamp, m_value.ServerTimestamp, m_value.SourcePicoseconds, m_value.ServerPicoseconds); } }
 
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Existing sample API exposes explicit conversion only.")]
             public static explicit operator Opc.Ua.DataValue(DataValue value) { return value.m_value; }
-
-            private static Variant ToVariant(object value)
-            {
-                switch (value)
-                {
-                    case null: return Variant.Null;
-                    case Variant v: return v;
-                    case bool v: return Variant.From(v);
-                    case sbyte v: return Variant.From(v);
-                    case byte v: return Variant.From(v);
-                    case short v: return Variant.From(v);
-                    case ushort v: return Variant.From(v);
-                    case int v: return Variant.From(v);
-                    case uint v: return Variant.From(v);
-                    case long v: return Variant.From(v);
-                    case ulong v: return Variant.From(v);
-                    case float v: return Variant.From(v);
-                    case double v: return Variant.From(v);
-                    case string v: return Variant.From(v);
-                    case DateTime v: return Variant.From(new DateTimeUtc(v));
-                    case Guid v: return Variant.From(new Uuid(v));
-                    case ByteString v: return Variant.From(v);
-                    case byte[] v: return Variant.From(v.ToByteString());
-                    case NodeId v: return Variant.From(v);
-                    case ExpandedNodeId v: return Variant.From(v);
-                    case StatusCode v: return Variant.From(v);
-                    case QualifiedName v: return Variant.From(v);
-                    case LocalizedText v: return Variant.From(v);
-                    case ExtensionObject v: return Variant.From(v);
-                    case bool[] v: return Variant.From(new ArrayOf<bool>(v));
-                    case sbyte[] v: return Variant.From(new ArrayOf<sbyte>(v));
-                    case short[] v: return Variant.From(new ArrayOf<short>(v));
-                    case ushort[] v: return Variant.From(new ArrayOf<ushort>(v));
-                    case int[] v: return Variant.From(new ArrayOf<int>(v));
-                    case uint[] v: return Variant.From(new ArrayOf<uint>(v));
-                    case long[] v: return Variant.From(new ArrayOf<long>(v));
-                    case ulong[] v: return Variant.From(new ArrayOf<ulong>(v));
-                    case float[] v: return Variant.From(new ArrayOf<float>(v));
-                    case double[] v: return Variant.From(new ArrayOf<double>(v));
-                    case string[] v: return Variant.From(new ArrayOf<string>(v));
-                    case DateTime[] v: return Variant.From(new ArrayOf<DateTimeUtc>(Array.ConvertAll(v, x => new DateTimeUtc(x))));
-                    case Guid[] v: return Variant.From(new ArrayOf<Uuid>(Array.ConvertAll(v, x => new Uuid(x))));
-                    case ByteString[] v: return Variant.From(new ArrayOf<ByteString>(v));
-                    case NodeId[] v: return Variant.From(new ArrayOf<NodeId>(v));
-                    case ExpandedNodeId[] v: return Variant.From(new ArrayOf<ExpandedNodeId>(v));
-                    case StatusCode[] v: return Variant.From(new ArrayOf<StatusCode>(v));
-                    case QualifiedName[] v: return Variant.From(new ArrayOf<QualifiedName>(v));
-                    case LocalizedText[] v: return Variant.From(new ArrayOf<LocalizedText>(v));
-                    case ExtensionObject[] v: return Variant.From(new ArrayOf<ExtensionObject>(v));
-                    case IEncodeable v: return Variant.From(new ExtensionObject(v, false));
-                    default: return Variant.Null;
-                }
-            }
 
             private Opc.Ua.DataValue m_value;
         }
@@ -361,14 +307,10 @@ namespace Quickstarts
                 return String.Empty;
             }
 
-            double? doubleValue = value.AsBoxedObject() as double?;
-
-            if (doubleValue != null)
+            if (value.TryGetValue(out double doubleValue) &&
+                doubleValue != Math.Truncate(doubleValue))
             {
-                if (doubleValue.Value != Math.Truncate(doubleValue.Value))
-                {
-                    return String.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:F4}", doubleValue);
-                }
+                return String.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:F4}", doubleValue);
             }
 
             return String.Format(System.Globalization.CultureInfo.InvariantCulture, "{0}", value);
@@ -584,7 +526,7 @@ namespace Quickstarts
                 foreach (ValueType value in values)
                 {
                     DataValue dv = new DataValue();
-                    dv.Value = ValidateValue(value.Value);
+                    dv.WrappedValue = ValidateValue(value.Value);
                     dv.StatusCode = ValidateQuality(value.Quality);
                     dv.SourceTimestamp = ValidateTimestamp(value.Timestamp);
                     dv.Comment = value.Comment;

--- a/Workshop/HistoricalEvents/Client/EventListView.cs
+++ b/Workshop/HistoricalEvents/Client/EventListView.cs
@@ -425,15 +425,15 @@ namespace Quickstarts.HistoricalEvents.Client
                 string text = null;
 
                 // check for missing fields.
-                if (fieldValues[ii].AsBoxedObject() == null)
+                if (fieldValues[ii].IsNull)
                 {
                     text = String.Empty;
                 }
 
                 // display the name of a node instead of the node id.
-                else if (fieldValues[ii].TypeInfo.BuiltInType == BuiltInType.NodeId)
+                else if (fieldValues[ii].TryGetValue(out NodeId fieldNodeId))
                 {
-                    INode node = await m_session.NodeCache.FindAsync((NodeId)fieldValues[ii].AsBoxedObject(), ct);
+                    INode node = await m_session.NodeCache.FindAsync(fieldNodeId, ct);
 
                     if (node != null)
                     {
@@ -442,15 +442,9 @@ namespace Quickstarts.HistoricalEvents.Client
                 }
 
                 // display local time for any time fields.
-                else if (fieldValues[ii].TypeInfo.BuiltInType == BuiltInType.DateTime)
+                else if (fieldValues[ii].TryGetValue(out DateTimeUtc fieldTime))
                 {
-                    // the 2.0 stack boxes a DateTime field as a DateTimeUtc, which does not
-                    // unbox as a DateTime.
-                    object boxed = fieldValues[ii].AsBoxedObject();
-
-                    DateTime value = boxed is DateTimeUtc utc
-                        ? utc.ToLocalTime()
-                        : ((DateTime)boxed).ToLocalTime();
+                    DateTime value = fieldTime.ToLocalTime();
 
                     if (m_filter.Fields[ii - 1].InstanceDeclaration.DisplayName.Contains("Time", StringComparison.Ordinal))
                     {
@@ -618,14 +612,14 @@ namespace Quickstarts.HistoricalEvents.Client
 
             foreach (List<Variant> e in events)
             {
-                byte[] eventId = null;
+                ByteString eventId = default;
 
                 if (e.Count > index)
                 {
-                    eventId = e[index].AsBoxedObject() as byte[];
+                    e[index].TryGetValue(out eventId);
                 }
 
-                details.EventIds = details.EventIds.AddItem(eventId.ToByteString());
+                details.EventIds = details.EventIds.AddItem(eventId);
             }
 
             // delete the events.

--- a/Workshop/HistoricalEvents/Client/ReadEventHistoryDlg.cs
+++ b/Workshop/HistoricalEvents/Client/ReadEventHistoryDlg.cs
@@ -243,15 +243,13 @@ namespace Quickstarts.HistoricalEvents.Client
             }
 
             // get the event time.
-            DateTime? eventTime = data.Events[0].EventFields[0].AsBoxedObject() as DateTime?;
-
-            if (eventTime == null)
+            if (!data.Events[0].EventFields[0].TryGetValue(out DateTimeUtc eventTime))
             {
                 throw new ServiceResultException(StatusCodes.BadTypeMismatch);
             }
 
             // return time as UTC value.
-            return eventTime.Value;
+            return (DateTime)eventTime;
         }
 
         /// <summary>

--- a/Workshop/HistoricalEvents/Client/ViewEventDetailsDlg.cs
+++ b/Workshop/HistoricalEvents/Client/ViewEventDetailsDlg.cs
@@ -71,7 +71,7 @@ namespace Quickstarts.HistoricalEvents.Client
                 string text = null;
 
                 // check for missing fields.
-                if (fields.Count <= ii || fields[ii].AsBoxedObject() == null)
+                if (fields.Count <= ii || fields[ii].IsNull)
                 {
                     text = String.Empty;
                 }

--- a/Workshop/HistoricalEvents/Server/HistoricalEventsNodeManager.cs
+++ b/Workshop/HistoricalEvents/Server/HistoricalEventsNodeManager.cs
@@ -413,7 +413,7 @@ namespace Quickstarts.HistoricalEvents.Server
                 if (!value.IsNull)
                 {
                     // translate any localized text.
-                    if (value.AsBoxedObject() is LocalizedText text && !text.IsNullOrEmpty)
+                    if (value.TryGetValue(out LocalizedText text) && !text.IsNullOrEmpty)
                     {
                         value = Variant.From(Server.ResourceManager.Translate(request.FilterContext.PreferredLocales, text));
                     }

--- a/Workshop/Methods/Client/MainForm.cs
+++ b/Workshop/Methods/Client/MainForm.cs
@@ -319,8 +319,8 @@ namespace Quickstarts.MethodsClient
 
                 if (outputArguments != null && outputArguments.Count > 1)
                 {
-                    RevisedInitialStateTB.Text = String.Format("{0}", outputArguments[0].AsBoxedObject());
-                    RevisedFinalStateTB.Text = String.Format("{0}", outputArguments[1].AsBoxedObject());
+                    RevisedInitialStateTB.Text = outputArguments[0].ToString();
+                    RevisedFinalStateTB.Text = outputArguments[1].ToString();
                 }
             }
             catch (Exception exception)

--- a/Workshop/Methods/Server/MethodsNodeManager.cs
+++ b/Workshop/Methods/Server/MethodsNodeManager.cs
@@ -243,18 +243,16 @@ namespace Quickstarts.MethodsServer
             }
 
             // check the data type of the input arguments.
-            uint? initialState = inputArguments[0].AsBoxedObject() as uint?;
-            uint? finalState = inputArguments[1].AsBoxedObject() as uint?;
-
-            if (initialState == null || finalState == null)
+            if (!inputArguments[0].TryGetValue(out uint initialState) ||
+                !inputArguments[1].TryGetValue(out uint finalState))
             {
                 return StatusCodes.BadTypeMismatch;
             }
 
-            StartProcess(initialState.Value, finalState.Value, outputArguments);
+            StartProcess(initialState, finalState, outputArguments);
 
             // signal update to state node.
-            m_stateNode.Value = initialState.Value;
+            m_stateNode.Value = initialState;
             await m_stateNode.ClearChangeMasksAsync(SystemContext, true, cancellationToken).ConfigureAwait(false);
 
             return ServiceResult.Good;

--- a/Workshop/UserAuthentication/Server/UserAuthenticationNodeManager.cs
+++ b/Workshop/UserAuthentication/Server/UserAuthenticationNodeManager.cs
@@ -160,7 +160,7 @@ namespace Quickstarts.UserAuthenticationServer
             // written value in the variable, mirroring the synchronous write path.
             try
             {
-                string filePath = value.AsBoxedObject() as string;
+                value.TryGetValue(out string filePath);
                 PropertyState<string> variable = node as PropertyState<string>;
 
                 if (!String.IsNullOrEmpty(variable.Value))


### PR DESCRIPTION
Fixes #807.

Replaces `Variant.AsBoxedObject()` with the type safe `TryGet` pattern across the samples, and upleveles `object` values to `Variant` wherever the trail could be followed. **254 call sites down to 20**, 81 files, +583/−963.

## Upleveling object to Variant

This is what removes most of the code, and it is the part the issue asked for first:

- `TestDataSystem.ReadValue` and `ITestDataSystemCallback.OnDataChangeAsync` now speak `Variant`. That deletes two hand written `ToVariant(object)` switches over every built in type (`TestDataObjectState`, `TestDataNodeManager`) and a third in the aggregate tester.
- `UnderlyingSystemTag.Value` and `UnderlyingSystemBlock.WriteTagValue` in the DataAccess sample take a `Variant`. The cast-and-catch block becomes a `TryGetValue` per tag type, and a `Variant.From((dynamic)tag.Value)` goes away.
- `SubscriptionHandle.GetEventFieldValue`, `FilterDeclaration.GetValue`, `NodeField.Value`, `FormatAttributeValueAsync`, `ClientUtils.GetImageIndex` and the `EditComplexValueDlg` entry points take or return `Variant`.
- `NamespaceMapper.ToVariant` maps arrays through a typed `MapElements<T>(ArrayOf<T>, …)` instead of the reflection based `CastArray` / `CastArrayToLocal` / `CastArrayToRemote` / `MapElement` group.

## Dead code this uncovered

Two patterns turned out to have been unreachable for a while, and converting them changes behaviour for the better:

- `TypeInfo.Construct(variant.AsBoxedObject())` guarded by `variant.TypeInfo.IsUnknown` — `TypeInfo` is authoritative, and unknown means the Variant is null, so the fallback never ran.
- Type checks against the boxed value: `is byte[]`, `as int?`, `as DateTime?`. `AsBoxedObject()` defaults to `BoxingBehavior.None`, so it returns `ByteString`, `ArrayOf<T>` and `DateTimeUtc` and none of those matched. Replacing them with `TryGetValue` restores the Time column of the event lists, the hex rendering of byte strings, and `QuickstartNodeManager`'s `ArrayDimensions` metadata, all of which were silently empty.

One trap worth naming for reviewers: `Variant.ToString()` is **not** interchangeable with `ConvertTo(BuiltInType.String)`. For `StatusCode` the former gives the symbolic id and the latter the numeric code; for `DateTime` the former is culture formatted and the latter uses `XmlConvert`. Anywhere a text box is filled for display *and* parsed back with `Variant.From(text).ConvertTo(...)` — `EditWriteValueDlg`'s status code and timestamps — the round trip only works with `ConvertTo`. `ToString()` is used only on display-only paths here.

## What is deliberately left, and why

20 calls remain, all at one boundary: the WinForms value editors (`EditComplexValueCtrl`, the GDS `EditValueCtrl`, the old `DataListCtrl`, `GuiUtils.EditValue`, `EditArrayDlg`) navigate and mutate arbitrary CLR objects through `PropertyInfo`, `Array` and `Activator.CreateInstance`, so they need a boxed value rather than a `Variant`.

Rather than spread the conversion over the call sites, it is concentrated at the boundary: the dialogs now take a `Variant` and unwrap once, and the four repeated unwrap blocks inside each of the two big editors are collapsed into a single documented `Unwrap` helper. Every remaining call carries a comment saying why it is there.

Converting the editors themselves is a redesign — `AccessInfo.Value` has to stop being `object`, the `object`-typed dialogs go with it, and the `null` means cancelled convention needs replacing — so it is tracked separately in #824.

## Verification

- Full solution builds clean. The three remaining analyzer warnings (CA2016, CA1307, CA1068) are pre-existing and in code this PR does not touch.
- `SampleNodeManagers.Tests` 95 passed / 1 skipped, `SampleServers.Tests` 88 passed, `SampleClients.Tests` 27 passed (these drive the WinForms sample clients through `WinFormsHarness`, so they exercise the changed controls), `SampleConfiguration.Tests` 143 passed. No failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
