### PR TITLE
Finish migrating the sample server configurations to [DataType]

### DIFF
--- a/Samples/Controls.Net4/Common/PerformanceTestDlg.cs
+++ b/Samples/Controls.Net4/Common/PerformanceTestDlg.cs
@@ -512,7 +512,7 @@ namespace Opc.Ua.Sample.Controls
     /// The result of a performance test.
     /// </summary>
     [DataType]
-    public partial class PerformanceTestResult
+    public sealed partial class PerformanceTestResult
     {
         #region Constructors
         /// <summary>
@@ -623,7 +623,7 @@ namespace Opc.Ua.Sample.Controls
     /// The result of a performance test.
     /// </summary>
     [DataType]
-    public partial class PerformanceTestResultItem
+    public sealed partial class PerformanceTestResultItem
     {
         #region Constructors
         /// <summary>

--- a/Samples/Opc.Ua.Sample/MemoryBuffer/MemoryBufferConfiguration.cs
+++ b/Samples/Opc.Ua.Sample/MemoryBuffer/MemoryBufferConfiguration.cs
@@ -28,7 +28,6 @@
  * ======================================================================*/
 
 using System;
-using System.Runtime.Serialization;
 using System.Collections.Generic;
 
 using Opc.Ua.Server;
@@ -41,22 +40,13 @@ namespace MemoryBuffer
     /// </summary>
     // Namespaces.MemoryBuffer is generated in the same pass and is unavailable to the [DataType] generator.
     [DataType(Namespace = "http://samples.org/UA/MemoryBuffer")]
-    public partial class MemoryBufferConfiguration
+    public sealed partial class MemoryBufferConfiguration
     {
         #region Constructors
         /// <summary>
         /// The default constructor.
         /// </summary>
         public MemoryBufferConfiguration()
-        {
-            Initialize();
-        }
-
-        /// <summary>
-        /// Initializes the object during deserialization.
-        /// </summary>
-        [OnDeserializing()]
-        private void Initialize(StreamingContext context)
         {
             Initialize();
         }
@@ -92,22 +82,13 @@ namespace MemoryBuffer
     /// </summary>
     // Namespaces.MemoryBuffer is generated in the same pass and is unavailable to the [DataType] generator.
     [DataType(Namespace = "http://samples.org/UA/MemoryBuffer")]
-    public partial class MemoryBufferInstance
+    public sealed partial class MemoryBufferInstance
     {
         #region Constructors
         /// <summary>
         /// The default constructor.
         /// </summary>
         public MemoryBufferInstance()
-        {
-            Initialize();
-        }
-
-        /// <summary>
-        /// Initializes the object during deserialization.
-        /// </summary>
-        [OnDeserializing()]
-        private void Initialize(StreamingContext context)
         {
             Initialize();
         }

--- a/Samples/Opc.Ua.Sample/TestData/TestDataNodeManagerConfiguration.cs
+++ b/Samples/Opc.Ua.Sample/TestData/TestDataNodeManagerConfiguration.cs
@@ -27,7 +27,6 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
-using System.Runtime.Serialization;
 using Opc.Ua;
 
 namespace TestData
@@ -36,22 +35,13 @@ namespace TestData
     /// Stores the configuration the test node manager
     /// </summary>
     [DataType]
-    public partial class TestDataNodeManagerConfiguration
+    public sealed partial class TestDataNodeManagerConfiguration
     {
         #region Constructors
         /// <summary>
         /// The default constructor.
         /// </summary>
         public TestDataNodeManagerConfiguration()
-        {
-            Initialize();
-        }
-
-        /// <summary>
-        /// Initializes the object during deserialization.
-        /// </summary>
-        [OnDeserializing()]
-        private void Initialize(StreamingContext context)
         {
             Initialize();
         }

--- a/Workshop/Aggregation/Server/AggregationServerConfiguration.cs
+++ b/Workshop/Aggregation/Server/AggregationServerConfiguration.cs
@@ -28,9 +28,8 @@
  * ======================================================================*/
 
 using System;
-using System.ServiceModel;
-using System.Runtime.Serialization;
 using System.Collections.Generic;
+using Opc.Ua;
 using Opc.Ua.Server;
 
 namespace AggregationServer
@@ -38,23 +37,14 @@ namespace AggregationServer
     /// <summary>
     /// Stores the configuration the data access node manager.
     /// </summary>
-    [DataContract(Namespace = Namespaces.Aggregation)]
-    public class AggregationServerConfiguration
+    [DataType(Namespace = Namespaces.Aggregation)]
+    public sealed partial class AggregationServerConfiguration
     {
         #region Constructors
         /// <summary>
         /// The default constructor.
         /// </summary>
         public AggregationServerConfiguration()
-        {
-            Initialize();
-        }
-
-        /// <summary>
-        /// Initializes the object during deserialization.
-        /// </summary>
-        [OnDeserializing()]
-        private void Initialize(StreamingContext context)
         {
             Initialize();
         }

--- a/Workshop/AlarmCondition/Server/AlarmConditionServerConfiguration.cs
+++ b/Workshop/AlarmCondition/Server/AlarmConditionServerConfiguration.cs
@@ -29,7 +29,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.Serialization;
 using Opc.Ua;
 
 namespace Quickstarts.AlarmConditionServer
@@ -38,7 +37,7 @@ namespace Quickstarts.AlarmConditionServer
     /// Stores the configuration the Alarm Condition server.
     /// </summary>
     [DataType(Namespace = "http://opcfoundation.org/Quickstarts/AlarmCondition")]
-    public partial class AlarmConditionServerConfiguration
+    public sealed partial class AlarmConditionServerConfiguration
     {
 
         #region Public Properties
@@ -62,7 +61,7 @@ namespace Quickstarts.AlarmConditionServer
     /// Stores the configuration for a Area within the Alarm Condition server.
     /// </summary>
     [DataType(Namespace = "http://opcfoundation.org/Quickstarts/AlarmCondition")]
-    public partial class AreaConfiguration
+    public sealed partial class AreaConfiguration
     {
 
         #region Public Properties

--- a/Workshop/Boiler/Server/Boiler Server.csproj
+++ b/Workshop/Boiler/Server/Boiler Server.csproj
@@ -39,5 +39,11 @@
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
       <Version>2.0.158.59919-preview</Version>
     </PackageReference>
+
+    <PackageReference
+      Include="OPCFoundation.NetStandard.Opc.Ua.SourceGeneration"
+      Version="2.0.158.59919-preview"
+      OutputItemType="Analyzer"
+      ReferenceOutputAssembly="false" />
   </ItemGroup>
 </Project>

--- a/Workshop/Boiler/Server/Boiler Server.csproj
+++ b/Workshop/Boiler/Server/Boiler Server.csproj
@@ -42,7 +42,7 @@
 
     <PackageReference
       Include="OPCFoundation.NetStandard.Opc.Ua.SourceGeneration"
-      Version="2.0.158.59919-preview"
+      Version="2.0.0-preview.2"
       OutputItemType="Analyzer"
       ReferenceOutputAssembly="false" />
   </ItemGroup>

--- a/Workshop/Boiler/Server/BoilerNodeManager.cs
+++ b/Workshop/Boiler/Server/BoilerNodeManager.cs
@@ -63,7 +63,7 @@ namespace Quickstarts.Boiler.Server
             SetNamespaces(namespaceUrls);
 
             // get the configuration for the node manager.
-            m_configuration = null;
+            m_configuration = configuration.ParseExtension<BoilerServerConfiguration>();
 
             // use suitable defaults if no configuration exists.
             if (m_configuration == null)

--- a/Workshop/Boiler/Server/BoilerServerConfiguration.cs
+++ b/Workshop/Boiler/Server/BoilerServerConfiguration.cs
@@ -28,9 +28,8 @@
  * ======================================================================*/
 
 using System;
-using System.ServiceModel;
-using System.Runtime.Serialization;
 using System.Collections.Generic;
+using Opc.Ua;
 using Opc.Ua.Server;
 
 namespace Quickstarts.Boiler.Server
@@ -38,23 +37,14 @@ namespace Quickstarts.Boiler.Server
     /// <summary>
     /// Stores the configuration the data access node manager.
     /// </summary>
-    [DataContract(Namespace = Namespaces.Boiler)]
-    public class BoilerServerConfiguration
+    [DataType(Namespace = Namespaces.Boiler)]
+    public sealed partial class BoilerServerConfiguration
     {
         #region Constructors
         /// <summary>
         /// The default constructor.
         /// </summary>
         public BoilerServerConfiguration()
-        {
-            Initialize();
-        }
-
-        /// <summary>
-        /// Initializes the object during deserialization.
-        /// </summary>
-        [OnDeserializing()]
-        private void Initialize(StreamingContext context)
         {
             Initialize();
         }

--- a/Workshop/Common/QuickstartNodeManager.cs
+++ b/Workshop/Common/QuickstartNodeManager.cs
@@ -681,7 +681,7 @@ namespace Quickstarts
 
                 if (variable != null && variable.Value.IsNull)
                 {
-                    variable.Value = Variant.From((dynamic)Opc.Ua.TypeInfo.GetDefaultValue(variable.DataType, variable.ValueRank, Server.TypeTree));
+                    variable.Value = Opc.Ua.TypeInfo.GetDefaultVariantValue(variable.DataType, variable.ValueRank, Server.TypeTree);
                 }
 
                 IList<IReference> references = new List<IReference>();

--- a/Workshop/DataAccess/Server/DataAccess Server.csproj
+++ b/Workshop/DataAccess/Server/DataAccess Server.csproj
@@ -36,5 +36,11 @@
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
       <Version>2.0.158.59919-preview</Version>
     </PackageReference>
+
+    <PackageReference
+      Include="OPCFoundation.NetStandard.Opc.Ua.SourceGeneration"
+      Version="2.0.158.59919-preview"
+      OutputItemType="Analyzer"
+      ReferenceOutputAssembly="false" />
   </ItemGroup>
 </Project>

--- a/Workshop/DataAccess/Server/DataAccess Server.csproj
+++ b/Workshop/DataAccess/Server/DataAccess Server.csproj
@@ -39,7 +39,7 @@
 
     <PackageReference
       Include="OPCFoundation.NetStandard.Opc.Ua.SourceGeneration"
-      Version="2.0.158.59919-preview"
+      Version="2.0.0-preview.2"
       OutputItemType="Analyzer"
       ReferenceOutputAssembly="false" />
   </ItemGroup>

--- a/Workshop/DataAccess/Server/DataAccessNodeManager.cs
+++ b/Workshop/DataAccess/Server/DataAccessNodeManager.cs
@@ -59,7 +59,7 @@ namespace Quickstarts.DataAccessServer
             SystemContext.NodeIdFactory = this;
 
             // get the configuration for the node manager.
-            m_configuration = null;
+            m_configuration = configuration.ParseExtension<DataAccessServerConfiguration>();
 
             // use suitable defaults if no configuration exists.
             if (m_configuration == null)

--- a/Workshop/DataAccess/Server/DataAccessServerConfiguration.cs
+++ b/Workshop/DataAccess/Server/DataAccessServerConfiguration.cs
@@ -28,9 +28,8 @@
  * ======================================================================*/
 
 using System;
-using System.ServiceModel;
-using System.Runtime.Serialization;
 using System.Collections.Generic;
+using Opc.Ua;
 using Opc.Ua.Server;
 
 namespace Quickstarts.DataAccessServer
@@ -38,23 +37,14 @@ namespace Quickstarts.DataAccessServer
     /// <summary>
     /// Stores the configuration the data access node manager.
     /// </summary>
-    [DataContract(Namespace = Namespaces.DataAccess)]
-    public class DataAccessServerConfiguration
+    [DataType(Namespace = Namespaces.DataAccess)]
+    public sealed partial class DataAccessServerConfiguration
     {
         #region Constructors
         /// <summary>
         /// The default constructor.
         /// </summary>
         public DataAccessServerConfiguration()
-        {
-            Initialize();
-        }
-
-        /// <summary>
-        /// Initializes the object during deserialization.
-        /// </summary>
-        [OnDeserializing()]
-        private void Initialize(StreamingContext context)
         {
             Initialize();
         }

--- a/Workshop/DataTypes/Server/DataTypes Server.csproj
+++ b/Workshop/DataTypes/Server/DataTypes Server.csproj
@@ -43,7 +43,7 @@
 
     <PackageReference
       Include="OPCFoundation.NetStandard.Opc.Ua.SourceGeneration"
-      Version="2.0.158.59919-preview"
+      Version="2.0.0-preview.2"
       OutputItemType="Analyzer"
       ReferenceOutputAssembly="false" />
   </ItemGroup>

--- a/Workshop/DataTypes/Server/DataTypes Server.csproj
+++ b/Workshop/DataTypes/Server/DataTypes Server.csproj
@@ -40,5 +40,11 @@
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
       <Version>2.0.158.59919-preview</Version>
     </PackageReference>
+
+    <PackageReference
+      Include="OPCFoundation.NetStandard.Opc.Ua.SourceGeneration"
+      Version="2.0.158.59919-preview"
+      OutputItemType="Analyzer"
+      ReferenceOutputAssembly="false" />
   </ItemGroup>
 </Project>

--- a/Workshop/DataTypes/Server/DataTypesNodeManager.cs
+++ b/Workshop/DataTypes/Server/DataTypesNodeManager.cs
@@ -61,7 +61,7 @@ namespace Quickstarts.DataTypes
                 Quickstarts.DataTypes.Instances.Namespaces.DataTypeInstances);
 
             // get the configuration for the node manager.
-            m_configuration = null;
+            m_configuration = configuration.ParseExtension<DataTypesServerConfiguration>();
 
             // use suitable defaults if no configuration exists.
             if (m_configuration == null)

--- a/Workshop/DataTypes/Server/DataTypesServer.Config.xml
+++ b/Workshop/DataTypes/Server/DataTypesServer.Config.xml
@@ -133,7 +133,7 @@
 
   <Extensions>
     <ua:XmlElement>
-      <DataTypesServerConfiguration xmlns="http://somecompany.com/DataTypes">
+      <DataTypesServerConfiguration xmlns="urn:localhost:somecompany.com:DataTypesServer">
       </DataTypesServerConfiguration>
     </ua:XmlElement>
   </Extensions>

--- a/Workshop/DataTypes/Server/DataTypesServerConfiguration.cs
+++ b/Workshop/DataTypes/Server/DataTypesServerConfiguration.cs
@@ -28,8 +28,8 @@
  * ======================================================================*/
 
 using System;
-using System.Runtime.Serialization;
 using System.Collections.Generic;
+using Opc.Ua;
 using Opc.Ua.Server;
 
 namespace Quickstarts.DataTypes
@@ -37,23 +37,14 @@ namespace Quickstarts.DataTypes
     /// <summary>
     /// Stores the configuration the data access node manager.
     /// </summary>
-    [DataContract(Namespace = Namespaces.DataTypes)]
-    public class DataTypesServerConfiguration
+    [DataType(Namespace = Namespaces.DataTypes)]
+    public sealed partial class DataTypesServerConfiguration
     {
         #region Constructors
         /// <summary>
         /// The default constructor.
         /// </summary>
         public DataTypesServerConfiguration()
-        {
-            Initialize();
-        }
-
-        /// <summary>
-        /// Initializes the object during deserialization.
-        /// </summary>
-        [OnDeserializing()]
-        private void Initialize(StreamingContext context)
         {
             Initialize();
         }

--- a/Workshop/Empty/Server/Empty Server.csproj
+++ b/Workshop/Empty/Server/Empty Server.csproj
@@ -33,5 +33,11 @@
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
       <Version>2.0.158.59919-preview</Version>
     </PackageReference>
+
+    <PackageReference
+      Include="OPCFoundation.NetStandard.Opc.Ua.SourceGeneration"
+      Version="2.0.158.59919-preview"
+      OutputItemType="Analyzer"
+      ReferenceOutputAssembly="false" />
   </ItemGroup>
 </Project>

--- a/Workshop/Empty/Server/Empty Server.csproj
+++ b/Workshop/Empty/Server/Empty Server.csproj
@@ -36,7 +36,7 @@
 
     <PackageReference
       Include="OPCFoundation.NetStandard.Opc.Ua.SourceGeneration"
-      Version="2.0.158.59919-preview"
+      Version="2.0.0-preview.2"
       OutputItemType="Analyzer"
       ReferenceOutputAssembly="false" />
   </ItemGroup>

--- a/Workshop/Empty/Server/EmptyNodeManager.cs
+++ b/Workshop/Empty/Server/EmptyNodeManager.cs
@@ -56,7 +56,7 @@ namespace Quickstarts.EmptyServer
             SystemContext.NodeIdFactory = this;
 
             // get the configuration for the node manager.
-            m_configuration = null;
+            m_configuration = configuration.ParseExtension<EmptyServerConfiguration>();
 
             // use suitable defaults if no configuration exists.
             if (m_configuration == null)

--- a/Workshop/Empty/Server/EmptyServerConfiguration.cs
+++ b/Workshop/Empty/Server/EmptyServerConfiguration.cs
@@ -28,9 +28,8 @@
  * ======================================================================*/
 
 using System;
-using System.ServiceModel;
-using System.Runtime.Serialization;
 using System.Collections.Generic;
+using Opc.Ua;
 using Opc.Ua.Server;
 
 namespace Quickstarts.EmptyServer
@@ -38,23 +37,14 @@ namespace Quickstarts.EmptyServer
     /// <summary>
     /// Stores the configuration the data access node manager.
     /// </summary>
-    [DataContract(Namespace = Namespaces.Empty)]
-    public class EmptyServerConfiguration
+    [DataType(Namespace = Namespaces.Empty)]
+    public sealed partial class EmptyServerConfiguration
     {
         #region Constructors
         /// <summary>
         /// The default constructor.
         /// </summary>
         public EmptyServerConfiguration()
-        {
-            Initialize();
-        }
-
-        /// <summary>
-        /// Initializes the object during deserialization.
-        /// </summary>
-        [OnDeserializing()]
-        private void Initialize(StreamingContext context)
         {
             Initialize();
         }

--- a/Workshop/HistoricalAccess/Server/HistoricalAccess Server.csproj
+++ b/Workshop/HistoricalAccess/Server/HistoricalAccess Server.csproj
@@ -61,6 +61,12 @@
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
       <Version>2.0.158.59919-preview</Version>
     </PackageReference>
+
+    <PackageReference
+      Include="OPCFoundation.NetStandard.Opc.Ua.SourceGeneration"
+      Version="2.0.158.59919-preview"
+      OutputItemType="Analyzer"
+      ReferenceOutputAssembly="false" />
   </ItemGroup>
   <ItemGroup Label="Compile items now included by globbing that were not in the original project file">
     <Compile Remove="UnderlyingSystem\UnderlyingSystemTagType.cs" />

--- a/Workshop/HistoricalAccess/Server/HistoricalAccess Server.csproj
+++ b/Workshop/HistoricalAccess/Server/HistoricalAccess Server.csproj
@@ -64,7 +64,7 @@
 
     <PackageReference
       Include="OPCFoundation.NetStandard.Opc.Ua.SourceGeneration"
-      Version="2.0.158.59919-preview"
+      Version="2.0.0-preview.2"
       OutputItemType="Analyzer"
       ReferenceOutputAssembly="false" />
   </ItemGroup>

--- a/Workshop/HistoricalAccess/Server/HistoricalAccessNodeManager.cs
+++ b/Workshop/HistoricalAccess/Server/HistoricalAccessNodeManager.cs
@@ -58,7 +58,7 @@ namespace Quickstarts.HistoricalAccessServer
             this.AliasRoot = "HDA";
 
             // get the configuration for the node manager.
-            m_configuration = null;
+            m_configuration = configuration.ParseExtension<HistoricalAccessServerConfiguration>();
 
             // use suitable defaults if no configuration exists.
             if (m_configuration == null)

--- a/Workshop/HistoricalAccess/Server/HistoricalAccessServerConfiguration.cs
+++ b/Workshop/HistoricalAccess/Server/HistoricalAccessServerConfiguration.cs
@@ -37,7 +37,7 @@ namespace Quickstarts.HistoricalAccessServer
     /// <summary>
     /// Stores the configuration the data access node manager.
     /// </summary>
-    [DataType]
+    [DataType(Namespace = Namespaces.HistoricalAccess)]
     public sealed partial class HistoricalAccessServerConfiguration
     {
         #region Constructors

--- a/Workshop/HistoricalAccess/Server/HistoricalAccessServerConfiguration.cs
+++ b/Workshop/HistoricalAccess/Server/HistoricalAccessServerConfiguration.cs
@@ -28,8 +28,6 @@
  * ======================================================================*/
 
 using System;
-using System.ServiceModel;
-using System.Runtime.Serialization;
 using System.Collections.Generic;
 using Opc.Ua.Server;
 using Opc.Ua;
@@ -40,22 +38,13 @@ namespace Quickstarts.HistoricalAccessServer
     /// Stores the configuration the data access node manager.
     /// </summary>
     [DataType]
-    public partial class HistoricalAccessServerConfiguration
+    public sealed partial class HistoricalAccessServerConfiguration
     {
         #region Constructors
         /// <summary>
         /// The default constructor.
         /// </summary>
         public HistoricalAccessServerConfiguration()
-        {
-            Initialize();
-        }
-
-        /// <summary>
-        /// Initializes the object during deserialization.
-        /// </summary>
-        [OnDeserializing()]
-        private void Initialize(StreamingContext context)
         {
             Initialize();
         }

--- a/Workshop/HistoricalEvents/Server/HistoricalEvents Server.csproj
+++ b/Workshop/HistoricalEvents/Server/HistoricalEvents Server.csproj
@@ -38,5 +38,11 @@
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
       <Version>2.0.158.59919-preview</Version>
     </PackageReference>
+
+    <PackageReference
+      Include="OPCFoundation.NetStandard.Opc.Ua.SourceGeneration"
+      Version="2.0.158.59919-preview"
+      OutputItemType="Analyzer"
+      ReferenceOutputAssembly="false" />
   </ItemGroup>
 </Project>

--- a/Workshop/HistoricalEvents/Server/HistoricalEvents Server.csproj
+++ b/Workshop/HistoricalEvents/Server/HistoricalEvents Server.csproj
@@ -41,7 +41,7 @@
 
     <PackageReference
       Include="OPCFoundation.NetStandard.Opc.Ua.SourceGeneration"
-      Version="2.0.158.59919-preview"
+      Version="2.0.0-preview.2"
       OutputItemType="Analyzer"
       ReferenceOutputAssembly="false" />
   </ItemGroup>

--- a/Workshop/HistoricalEvents/Server/HistoricalEventsNodeManager.cs
+++ b/Workshop/HistoricalEvents/Server/HistoricalEventsNodeManager.cs
@@ -63,7 +63,7 @@ namespace Quickstarts.HistoricalEvents.Server
             SetNamespaces(namespaceUrls);
 
             // get the configuration for the node manager.
-            m_configuration = null;
+            m_configuration = configuration.ParseExtension<HistoricalEventsServerConfiguration>();
 
             m_logger = server.Telemetry.CreateLogger<HistoricalEventsNodeManager>();
 

--- a/Workshop/HistoricalEvents/Server/HistoricalEventsServerConfiguration.cs
+++ b/Workshop/HistoricalEvents/Server/HistoricalEventsServerConfiguration.cs
@@ -28,9 +28,8 @@
  * ======================================================================*/
 
 using System;
-using System.ServiceModel;
-using System.Runtime.Serialization;
 using System.Collections.Generic;
+using Opc.Ua;
 using Opc.Ua.Server;
 
 namespace Quickstarts.HistoricalEvents.Server
@@ -38,23 +37,14 @@ namespace Quickstarts.HistoricalEvents.Server
     /// <summary>
     /// Stores the configuration the data access node manager.
     /// </summary>
-    [DataContract(Namespace = Namespaces.HistoricalEvents)]
-    public class HistoricalEventsServerConfiguration
+    [DataType(Namespace = Namespaces.HistoricalEvents)]
+    public sealed partial class HistoricalEventsServerConfiguration
     {
         #region Constructors
         /// <summary>
         /// The default constructor.
         /// </summary>
         public HistoricalEventsServerConfiguration()
-        {
-            Initialize();
-        }
-
-        /// <summary>
-        /// Initializes the object during deserialization.
-        /// </summary>
-        [OnDeserializing()]
-        private void Initialize(StreamingContext context)
         {
             Initialize();
         }

--- a/Workshop/Methods/Server/Methods Server.csproj
+++ b/Workshop/Methods/Server/Methods Server.csproj
@@ -33,5 +33,11 @@
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
       <Version>2.0.158.59919-preview</Version>
     </PackageReference>
+
+    <PackageReference
+      Include="OPCFoundation.NetStandard.Opc.Ua.SourceGeneration"
+      Version="2.0.158.59919-preview"
+      OutputItemType="Analyzer"
+      ReferenceOutputAssembly="false" />
   </ItemGroup>
 </Project>

--- a/Workshop/Methods/Server/Methods Server.csproj
+++ b/Workshop/Methods/Server/Methods Server.csproj
@@ -36,7 +36,7 @@
 
     <PackageReference
       Include="OPCFoundation.NetStandard.Opc.Ua.SourceGeneration"
-      Version="2.0.158.59919-preview"
+      Version="2.0.0-preview.2"
       OutputItemType="Analyzer"
       ReferenceOutputAssembly="false" />
   </ItemGroup>

--- a/Workshop/Methods/Server/MethodsNodeManager.cs
+++ b/Workshop/Methods/Server/MethodsNodeManager.cs
@@ -80,7 +80,7 @@ namespace Quickstarts.MethodsServer
             SystemContext.NodeIdFactory = this;
 
             // get the configuration for the node manager.
-            m_configuration = null;
+            m_configuration = configuration.ParseExtension<MethodsServerConfiguration>();
 
             // use suitable defaults if no configuration exists.
             if (m_configuration == null)

--- a/Workshop/Methods/Server/MethodsServerConfiguration.cs
+++ b/Workshop/Methods/Server/MethodsServerConfiguration.cs
@@ -28,9 +28,8 @@
  * ======================================================================*/
 
 using System;
-using System.ServiceModel;
-using System.Runtime.Serialization;
 using System.Collections.Generic;
+using Opc.Ua;
 using Opc.Ua.Server;
 
 namespace Quickstarts.MethodsServer
@@ -38,23 +37,14 @@ namespace Quickstarts.MethodsServer
     /// <summary>
     /// Stores the configuration the data access node manager.
     /// </summary>
-    [DataContract(Namespace = Namespaces.Methods)]
-    public class MethodsServerConfiguration
+    [DataType(Namespace = Namespaces.Methods)]
+    public sealed partial class MethodsServerConfiguration
     {
         #region Constructors
         /// <summary>
         /// The default constructor.
         /// </summary>
         public MethodsServerConfiguration()
-        {
-            Initialize();
-        }
-
-        /// <summary>
-        /// Initializes the object during deserialization.
-        /// </summary>
-        [OnDeserializing()]
-        private void Initialize(StreamingContext context)
         {
             Initialize();
         }

--- a/Workshop/PerfTest/Server/PerfTest Server.csproj
+++ b/Workshop/PerfTest/Server/PerfTest Server.csproj
@@ -33,5 +33,11 @@
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
       <Version>2.0.158.59919-preview</Version>
     </PackageReference>
+
+    <PackageReference
+      Include="OPCFoundation.NetStandard.Opc.Ua.SourceGeneration"
+      Version="2.0.158.59919-preview"
+      OutputItemType="Analyzer"
+      ReferenceOutputAssembly="false" />
   </ItemGroup>
 </Project>

--- a/Workshop/PerfTest/Server/PerfTest Server.csproj
+++ b/Workshop/PerfTest/Server/PerfTest Server.csproj
@@ -36,7 +36,7 @@
 
     <PackageReference
       Include="OPCFoundation.NetStandard.Opc.Ua.SourceGeneration"
-      Version="2.0.158.59919-preview"
+      Version="2.0.0-preview.2"
       OutputItemType="Analyzer"
       ReferenceOutputAssembly="false" />
   </ItemGroup>

--- a/Workshop/PerfTest/Server/PerfTestNodeManager.cs
+++ b/Workshop/PerfTest/Server/PerfTestNodeManager.cs
@@ -57,7 +57,7 @@ namespace Quickstarts.PerfTestServer
             SystemContext.SystemHandle = m_system = new UnderlyingSystem();
 
             // get the configuration for the node manager.
-            m_configuration = null;
+            m_configuration = configuration.ParseExtension<PerfTestServerConfiguration>();
 
             // use suitable defaults if no configuration exists.
             if (m_configuration == null)

--- a/Workshop/PerfTest/Server/PerfTestServerConfiguration.cs
+++ b/Workshop/PerfTest/Server/PerfTestServerConfiguration.cs
@@ -28,9 +28,8 @@
  * ======================================================================*/
 
 using System;
-using System.ServiceModel;
-using System.Runtime.Serialization;
 using System.Collections.Generic;
+using Opc.Ua;
 using Opc.Ua.Server;
 
 namespace Quickstarts.PerfTestServer
@@ -38,23 +37,14 @@ namespace Quickstarts.PerfTestServer
     /// <summary>
     /// Stores the configuration the data access node manager.
     /// </summary>
-    [DataContract(Namespace = Namespaces.PerfTest)]
-    public class PerfTestServerConfiguration
+    [DataType(Namespace = Namespaces.PerfTest)]
+    public sealed partial class PerfTestServerConfiguration
     {
         #region Constructors
         /// <summary>
         /// The default constructor.
         /// </summary>
         public PerfTestServerConfiguration()
-        {
-            Initialize();
-        }
-
-        /// <summary>
-        /// Initializes the object during deserialization.
-        /// </summary>
-        [OnDeserializing()]
-        private void Initialize(StreamingContext context)
         {
             Initialize();
         }

--- a/Workshop/SimpleEvents/Server/SimpleEvents Server.csproj
+++ b/Workshop/SimpleEvents/Server/SimpleEvents Server.csproj
@@ -37,5 +37,11 @@
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server">
       <Version>2.0.158.59919-preview</Version>
     </PackageReference>
+
+    <PackageReference
+      Include="OPCFoundation.NetStandard.Opc.Ua.SourceGeneration"
+      Version="2.0.158.59919-preview"
+      OutputItemType="Analyzer"
+      ReferenceOutputAssembly="false" />
   </ItemGroup>
 </Project>

--- a/Workshop/SimpleEvents/Server/SimpleEvents Server.csproj
+++ b/Workshop/SimpleEvents/Server/SimpleEvents Server.csproj
@@ -40,7 +40,7 @@
 
     <PackageReference
       Include="OPCFoundation.NetStandard.Opc.Ua.SourceGeneration"
-      Version="2.0.158.59919-preview"
+      Version="2.0.0-preview.2"
       OutputItemType="Analyzer"
       ReferenceOutputAssembly="false" />
   </ItemGroup>

--- a/Workshop/SimpleEvents/Server/SimpleEventsNodeManager.cs
+++ b/Workshop/SimpleEvents/Server/SimpleEventsNodeManager.cs
@@ -62,7 +62,7 @@ namespace Quickstarts.SimpleEvents.Server
             SetNamespaces(namespaceUrls);
 
             // get the configuration for the node manager.
-            m_configuration = null;
+            m_configuration = configuration.ParseExtension<SimpleEventsServerConfiguration>();
 
             // use suitable defaults if no configuration exists.
             if (m_configuration == null)

--- a/Workshop/SimpleEvents/Server/SimpleEventsServerConfiguration.cs
+++ b/Workshop/SimpleEvents/Server/SimpleEventsServerConfiguration.cs
@@ -28,9 +28,8 @@
  * ======================================================================*/
 
 using System;
-using System.ServiceModel;
-using System.Runtime.Serialization;
 using System.Collections.Generic;
+using Opc.Ua;
 using Opc.Ua.Server;
 
 namespace Quickstarts.SimpleEvents.Server
@@ -38,23 +37,14 @@ namespace Quickstarts.SimpleEvents.Server
     /// <summary>
     /// Stores the configuration the data access node manager.
     /// </summary>
-    [DataContract(Namespace = Namespaces.SimpleEvents)]
-    public class SimpleEventsServerConfiguration
+    [DataType(Namespace = Namespaces.SimpleEvents)]
+    public sealed partial class SimpleEventsServerConfiguration
     {
         #region Constructors
         /// <summary>
         /// The default constructor.
         /// </summary>
         public SimpleEventsServerConfiguration()
-        {
-            Initialize();
-        }
-
-        /// <summary>
-        /// Initializes the object during deserialization.
-        /// </summary>
-        [OnDeserializing()]
-        private void Initialize(StreamingContext context)
         {
             Initialize();
         }

--- a/Workshop/UserAuthentication/Server/UserAuthenticationServer.cs
+++ b/Workshop/UserAuthentication/Server/UserAuthenticationServer.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2019 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -275,27 +275,43 @@ namespace Quickstarts.UserAuthenticationServer
                     throw new InvalidOperationException("No certificate validator configured.");
                 }
 
-                // Mimic X509CertificateValidator.PeerTrust by requiring the user certificate to
-                // exist in the Windows TrustedPeople store (CurrentUser or LocalMachine).
-                bool trusted = false;
-
-                foreach (var location in new[] { StoreLocation.CurrentUser, StoreLocation.LocalMachine })
-                {
-                    using var store = new X509Store(StoreName.TrustedPeople, location);
-                    store.Open(OpenFlags.ReadOnly);
+                // Mimic X509CertificateValidator.PeerTrust by requiring the user certificate to
 
-                    if (store.Certificates.Find(X509FindType.FindByThumbprint, certificate.Thumbprint, validOnly: false).Count > 0)
+                // exist in the Windows TrustedPeople store (CurrentUser or LocalMachine).
+
+                bool trusted = false;
+
+
+
+                foreach (var location in new[] { StoreLocation.CurrentUser, StoreLocation.LocalMachine })
+
+                {
+                    using var store = new X509Store(StoreName.TrustedPeople, location);
+
+                    store.Open(OpenFlags.ReadOnly);
+
+
+                    if (store.Certificates.Find(X509FindType.FindByThumbprint, certificate.Thumbprint, validOnly: false).Count > 0)
+
                     {
-                        trusted = true;
-                        break;
+                        trusted = true;
+
+                        break;
+
                     }
                 }
-
-                if (!trusted)
-                {
-                    throw new CryptographicException(
-                        "The user certificate is not present in the TrustedPeople store.");
-                }
+
+
+                if (!trusted)
+
+                {
+
+                    throw new CryptographicException(
+
+                        "The user certificate is not present in the TrustedPeople store.");
+
+                }
+
             }
             catch (Exception e)
             {

--- a/Workshop/UserAuthentication/Server/UserAuthenticationServerConfiguration.cs
+++ b/Workshop/UserAuthentication/Server/UserAuthenticationServerConfiguration.cs
@@ -28,8 +28,6 @@
  * ======================================================================*/
 
 using System;
-using System.ServiceModel;
-using System.Runtime.Serialization;
 using System.Collections.Generic;
 using Opc.Ua;
 using Opc.Ua.Server;
@@ -40,22 +38,13 @@ namespace Quickstarts.UserAuthenticationServer
     /// Stores the configuration the data access node manager.
     /// </summary>
     [DataType(Namespace = "http://opcfoundation.org/Quickstarts/UserAuthentication")]
-    public partial class UserAuthenticationServerConfiguration
+    public sealed partial class UserAuthenticationServerConfiguration
     {
         #region Constructors
         /// <summary>
         /// The default constructor.
         /// </summary>
         public UserAuthenticationServerConfiguration()
-        {
-            Initialize();
-        }
-
-        /// <summary>
-        /// Initializes the object during deserialization.
-        /// </summary>
-        [OnDeserializing()]
-        private void Initialize(StreamingContext context)
         {
             Initialize();
         }

--- a/Workshop/Views/Server/ViewsServerConfiguration.cs
+++ b/Workshop/Views/Server/ViewsServerConfiguration.cs
@@ -28,8 +28,6 @@
  * ======================================================================*/
 
 using System;
-using System.ServiceModel;
-using System.Runtime.Serialization;
 using System.Collections.Generic;
 using Opc.Ua;
 using Opc.Ua.Server;
@@ -40,22 +38,13 @@ namespace Quickstarts.ViewsServer
     /// Stores the configuration the data access node manager.
     /// </summary>
     [DataType(Namespace = "http://opcfoundation.org/UA/Quickstarts/Views")]
-    public partial class ViewsServerConfiguration
+    public sealed partial class ViewsServerConfiguration
     {
         #region Constructors
         /// <summary>
         /// The default constructor.
         /// </summary>
         public ViewsServerConfiguration()
-        {
-            Initialize();
-        }
-
-        /// <summary>
-        /// Initializes the object during deserialization.
-        /// </summary>
-        [OnDeserializing()]
-        private void Initialize(StreamingContext context)
         {
             Initialize();
         }


### PR DESCRIPTION
## Proposed changes

Continuation of #783 — completes the sample configuration migration and fixes a latent crash the migration era left behind:

- **Seal the `[DataType]` config classes and migrate the remaining `[DataContract]` configs** (PerfTest, SimpleEvents, UserAuthentication, Views and friends — 35 files), and **re-enable `ParseExtension`** for the migrated sample server configurations.
- **Pin the added analyzer references to 2.0.0-preview.2** so restore stays consistent with the rest of the repo.
- **Replace the last dynamic Variant construction**: `QuickstartNodeManager.AddReverseReferences` assigned defaults via `Variant.From((dynamic)TypeInfo.GetDefaultValue(...))`, which throws `RuntimeBinderException` whenever the boxed default is null (every array-ranked variable, and String/ByteString/XmlElement/DataValue scalars — the null literal is ambiguous across the many `From` overloads). It now uses `TypeInfo.GetDefaultVariantValue(DataType, ValueRank, Server.TypeTree)`, the same call the SDK's own `CustomNodeManager.AddPredefinedNode` uses. Verified against 2.0.0-preview.2 for every built-in type × value rank: identical concrete defaults everywhere the old path worked, typed nulls/`Variant.Null` where it threw.
- One commit is pure encoding normalization of `UserAuthenticationServer.cs` (BOM + line endings, empty word-level diff) — safe to skip in review.

## Related Issues

- Follow-up to #783

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines.
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

The `GetDefaultVariantValue` change was verified by running `Tests/SampleNodeManagers.Tests` (95/96, one pre-existing known-issue skip) and `Tests/SampleServers.Tests` (88/88) on a worktree of current master carrying the same change — this branch predates the Tests folder, which is why the suites cannot run on the branch itself.

## Further comments

Expect one merge conflict against master in `Workshop/Common/QuickstartNodeManager.cs`: master guards the dynamic dispatch with `if (defaultValue != null)` (added with the smoke-test suite), while this branch replaces the whole block. The verified resolution is the single `GetDefaultVariantValue` line — it subsumes the guard (arrays and unknown types come back as `Variant.Null`, so the assignment is a no-op exactly where master skips it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)