### PR TITLE
Bound the session close in the sample clients so an unreachable server cannot hold them up

### DIFF
--- a/Samples/ClientControls.Net4/ClientUtils.cs
+++ b/Samples/ClientControls.Net4/ClientUtils.cs
@@ -1255,6 +1255,77 @@ namespace Opc.Ua.Client.Controls
         }
         #endregion
 
+        #region Sessions
+        /// <summary>
+        /// How long a sample waits for a session to close before it stops waiting and tears
+        /// the session down instead.
+        /// </summary>
+        public static readonly TimeSpan DefaultCloseTimeout = TimeSpan.FromSeconds(5);
+
+        /// <summary>
+        /// Closes a session and disposes it, without letting a server which is no longer
+        /// reachable hold the sample up.
+        /// </summary>
+        /// <remarks>
+        /// A managed session cannot close while its connection state machine is inside a
+        /// reconnect attempt: requesting the close only moves the state machine to Closing,
+        /// and the attempt in flight runs to its own end first. Against a host which accepts
+        /// the connection but never answers - a server which was stopped while its machine
+        /// stayed up, a firewall which swallows the traffic - that end is the OperationTimeout
+        /// of the endpoint, which the sample configurations set to ten minutes. Closing the
+        /// window of a sample would then block for those ten minutes.
+        ///
+        /// So the wait is bounded and, when it expires, the session is disposed instead:
+        /// disposing cancels the state machine, which does cancel the attempt in flight. The
+        /// session is disposed either way, which is also what stops its background workers.
+        /// </remarks>
+        /// <param name="session">The session to close. A null session is ignored.</param>
+        /// <param name="ct">The cancellation token.</param>
+        public static Task CloseAndDisposeAsync(ISession session, CancellationToken ct = default)
+        {
+            return CloseAndDisposeAsync(session, DefaultCloseTimeout, ct);
+        }
+
+        /// <summary>
+        /// Closes a session and disposes it, waiting no longer than the given timeout.
+        /// </summary>
+        /// <param name="session">The session to close. A null session is ignored.</param>
+        /// <param name="timeout">How long to wait for the close before disposing instead.</param>
+        /// <param name="ct">The cancellation token.</param>
+        public static async Task CloseAndDisposeAsync(
+            ISession session,
+            TimeSpan timeout,
+            CancellationToken ct = default)
+        {
+            if (session == null)
+            {
+                return;
+            }
+
+            try
+            {
+                using var bounded = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                bounded.CancelAfter(timeout);
+
+                await session.CloseAsync((int)timeout.TotalMilliseconds, bounded.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                // the server did not answer in time, or the caller gave up: the dispose below
+                // is what actually tears the session down
+            }
+            catch (ServiceResultException)
+            {
+                // closing a session on a server which is already gone is not an error a
+                // sample has anything to do about
+            }
+            finally
+            {
+                await session.DisposeAsync();
+            }
+        }
+        #endregion
+
         #region Subscriptions
         /// <summary>
         /// Adds a subscription driven by the V2 subscription engine to the session.

--- a/Samples/ClientControls.Net4/Common/Client/ConnectServerCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/ConnectServerCtrl.cs
@@ -503,11 +503,17 @@ namespace Opc.Ua.Client.Controls
         {
             // disconnect any existing session. Closing the managed session also stops its
             // connection state machine, so there is no separate reconnect handler to cancel.
+            // The close is bounded: a session which is in the middle of a reconnect attempt
+            // against a server that is gone cannot close until that attempt has run out, and
+            // the sample must not wait for that. See ClientUtils.CloseAndDisposeAsync.
             if (m_session != null)
             {
                 DetachSession();
-                await m_session.CloseAsync(10000, ct);
+
+                ISession session = m_session;
                 m_session = null;
+
+                await ClientUtils.CloseAndDisposeAsync(session, ct);
             }
 
             // raise an event.

--- a/Samples/Controls.Net4/ClientForm.cs
+++ b/Samples/Controls.Net4/ClientForm.cs
@@ -177,8 +177,10 @@ namespace Opc.Ua.Sample.Controls
                 // there is no separate reconnect handler to cancel.
                 DetachSession(m_session);
 
-                await m_session.CloseAsync(ct);
+                ISession session = m_session;
                 m_session = null;
+
+                await ClientUtils.CloseAndDisposeAsync(session, ct);
             }
 
             ServerUrlLB.Text = "";

--- a/Samples/Controls.Net4/Sessions/SessionTreeCtrl.cs
+++ b/Samples/Controls.Net4/Sessions/SessionTreeCtrl.cs
@@ -129,7 +129,7 @@ namespace Opc.Ua.Sample.Controls
 
                 if (session != null)
                 {
-                    await session.CloseAsync(ct);
+                    await ClientUtils.CloseAndDisposeAsync(session, ct);
                 }
             }
 
@@ -246,7 +246,7 @@ namespace Opc.Ua.Sample.Controls
 
             m_subscriptions.RemoveAll(handle => Object.ReferenceEquals(handle.Session, session));
 
-            await session.CloseAsync(ct);
+            await ClientUtils.CloseAndDisposeAsync(session, ct);
             NodesTV.SelectedNode = null;
             SelectNode();
         }

--- a/Tests/Samples.Tests.Common/TestClient.cs
+++ b/Tests/Samples.Tests.Common/TestClient.cs
@@ -27,6 +27,11 @@ namespace Opc.Ua.Samples.Tests
     /// </remarks>
     public sealed class TestClient : IAsyncDisposable
     {
+        /// <summary>
+        /// How long a teardown waits for the session to close before it disposes it instead.
+        /// </summary>
+        private static readonly TimeSpan kCloseTimeout = TimeSpan.FromSeconds(5);
+
         private readonly TemporaryPki m_pki;
         private readonly ApplicationInstance m_application;
 
@@ -240,13 +245,24 @@ namespace Opc.Ua.Samples.Tests
         {
             if (Session != null)
             {
+                // the close is bounded: a session which is inside a reconnect attempt against
+                // a server that is gone only leaves that attempt when it runs out, and against
+                // an endpoint which accepts but never answers that is the OperationTimeout of
+                // the sample configuration - ten minutes. Disposing is what actually cancels
+                // the attempt, so a teardown must not wait for the close indefinitely.
+                using var bounded = new CancellationTokenSource(kCloseTimeout);
+
                 try
                 {
-                    await Session.CloseAsync(default).ConfigureAwait(false);
+                    await Session.CloseAsync(bounded.Token).ConfigureAwait(false);
                 }
                 catch (ServiceResultException)
                 {
                     // closing a session on a server which is already gone must not fail a test
+                }
+                catch (OperationCanceledException)
+                {
+                    // the server did not answer in time, the dispose below tears it down
                 }
 
                 await Session.DisposeAsync().ConfigureAwait(false);


### PR DESCRIPTION
## Proposed changes

Closing a sample client window could block for up to ten minutes when the server it was
connected to had gone away.

A `ManagedSession` cannot close while its connection state machine is inside a reconnect
attempt. `RequestClose()` only moves the state to `Closing`; the worker is sitting in
`HandleReconnectingAsync` and finishes its current backoff delay **and** its current reconnect
attempt before it looks at the state again. So the time a close takes is the *remaining time of
the reconnect attempt in flight*. Against a host which accepts the connection but never answers
- a server stopped while its machine stayed up, a firewall which swallows the traffic, a hung
server - that attempt runs to the endpoint's `OperationTimeout`, and the sample configurations
ship `<OperationTimeout>600000</OperationTimeout>`. `MainForm_FormClosing` calls
`ConnectServerCTRL.Disconnect()` synchronously, so this blocks the UI thread.

Measured against `2.0.0-preview.2` with the Quickstart Reference Server, the server stopped and
its port taken over by a `TcpListener` which accepts and never answers, `OperationTimeout`
reduced to 20 s to keep the run short:

```
47.024  ManagedSession: Reconnecting.                                  <- attempt starts
56.128  ConnectionStateMachine: State changed from Reconnecting to Closing.   <- close called here
58.130  ManagedSession: Reconnect attempt failed.
58.131  ConnectionStateMachine: State changed from Closing to Closed.
```

The close returned after **10 886 ms** - exactly the remainder of the 20 s attempt. Scale
`OperationTimeout` to the shipped 600 000 ms and that is ten minutes.

The `CloseAsync(10000, ct)` the controls were already calling did not bound anything:
`ManagedSession.CloseAsync(int timeout, bool closeChannel, CancellationToken)` ignores both
`timeout` and `closeChannel` and always returns `Good`. That, and the state machine not
cancelling its reconnect on close, are reported upstream as
OPCFoundation/UA-.NETStandard#4364.

Until the SDK cancels the attempt itself, the samples bound the wait and dispose when it
expires - disposing is what cancels the state machine's token and with it the attempt in
flight. The same scenario then costs **2 000 ms of bounded wait plus 17 ms of dispose**.

For reference, the other close timings measured on the way:

| scenario | close |
|---|---|
| server alive, no subscription / with a V2 subscription | 65 / 74 ms |
| server stopped on localhost (connection refused, fails fast) | ~1.9 s |
| server black-holed, `OperationTimeout` 20 s, unbounded | 10 886 ms |
| server black-holed, bounded 2 s + dispose | 2 000 + 17 ms |

Worth noting for anyone chasing the same symptom: the 5 s publish drain in
`Session.CloseAsync` (`PublishRequestCancelDelayOnCloseSession`) is **not** the cause here. It
only affects classic-engine sessions - `AsyncRequestStarted` is called from
`ClassicSubscriptionEngine` only, so a session on the V2 `DefaultSubscriptionEngine` never has a
tracked publish request and skips the wait entirely. In this repository the only remaining
classic sessions are `AggregationNodeManager` and `GlobalDiscoveryServerAliasMerger`, neither of
which is on a window-close path.

### What changed

- `ClientUtils.CloseAndDisposeAsync` carries the bounded close (5 s) followed by
  `DisposeAsync`, with the reasoning in its remarks so the next reader does not have to
  rediscover it.
- `ConnectServerCtrl.InternalDisconnectAsync` - the shared control every WinForms sample client
  disconnects through - uses it, and clears `m_session` before closing so a slow close cannot be
  observed as a live session.
- `ClientForm.DisconnectAsync` and `SessionTreeCtrl` (`ClearAsync`, `DeleteAsync`) in the UA
  Sample Client use it too. `ClearAsync` closes its sessions in a loop, so an unbounded close
  there multiplied by the number of open sessions.
- `TestClient.DisposeAsync` bounds its own teardown the same way, so a test host cannot hang on
  a server which is already gone.

The sessions are now disposed on every one of these paths, which they previously never were.

## Related Issues

- Relates to OPCFoundation/UA-.NETStandard#4364 (the SDK side of the same problem)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines.
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

`SampleClients.Tests` 27/27 and `SampleServers.Tests` 88/88 pass locally, and the whole solution
builds clean.

## Further comments

No regression test ships with this. Reproducing it needs a peer which accepts TCP and never
answers, which means standing up a `TcpListener` on the sample port after stopping the server
and then waiting out a reconnect attempt - about 40 s of wall clock for one assertion, on a
fixture tier which already queues behind the machine-wide sample port lock. The measurements
above were taken with exactly that harness; it was used to confirm the diagnosis and the fix and
then removed rather than added to the suite. If the SDK issue is fixed the sample-side bound
becomes belt and braces, and it is cheap enough to keep either way.

An alternative would have been to lower `OperationTimeout` in the sample client configurations.
That was not done: it would change how long every ordinary service call of a sample may take in
order to fix a teardown, and it would leave the reconnect backoff unbounded anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
