### PR TITLE
Drive the remaining sample clients past connect

### DIFF
--- a/Tests/SampleClients.Tests/SampleClientActionTests.cs
+++ b/Tests/SampleClients.Tests/SampleClientActionTests.cs
@@ -1,0 +1,859 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using NUnit.Framework;
+using Opc.Ua.Client;
+using Opc.Ua.Client.Controls;
+using Opc.Ua.Configuration;
+
+namespace Opc.Ua.Samples.Tests
+{
+    /// <summary>
+    /// Tier 2: the sample clients which are left have to do the thing they exist for, not
+    /// only connect.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="SampleClientTests"/> proves that a client builds its form, connects and
+    /// finishes its post connect logic. A client can pass that and still be wired so that
+    /// every one of its buttons does nothing, and no tier notices - which is exactly what
+    /// happened to the role management client, whose Reset button resolved its method with a
+    /// browse name in namespace zero and answered a synthetic BadNotFound for every account.
+    /// The server was right the whole time, the tier 1.5 fixture resolved the same method
+    /// with the namespace index and passed, and a user found it by pressing the button once.
+    /// </para>
+    /// <para>
+    /// So one test per client, which presses what the sample is for and asserts what it is
+    /// meant to show. <see cref="WorkshopClientSubscriptionTests"/> already does this for the
+    /// six clients whose content is a subscription, and RoleManagement has its own fixture;
+    /// these are the rest.
+    /// </para>
+    /// <para>
+    /// The Empty client is deliberately not here. It is the template a new sample is copied
+    /// from: its form has a connect control, a menu and a status bar, and not one control of
+    /// its own - there is nothing to press, and a test which pressed something would be
+    /// testing the shared controls rather than the sample. Should the template ever grow a
+    /// control, it belongs in this fixture with the others.
+    /// </para>
+    /// </remarks>
+    [TestFixture]
+    [Category("ClientSmoke")]
+    [Category("RequiresDesktop")]
+    [NonParallelizable]
+    public class SampleClientActionTests
+    {
+        /// <summary>
+        /// How long a test gets, including starting its sample server.
+        /// </summary>
+        private const int kTimeout = 120_000;
+
+        /// <summary>
+        /// How long a single service call of a sample client may take.
+        /// </summary>
+        /// <remarks>
+        /// The sample configurations allow ten minutes, which is longer than one of these
+        /// tests may run, so a call which never comes back would surface as a bare harness
+        /// timeout with nothing to point at.
+        /// </remarks>
+        private const int kOperationTimeout = 30_000;
+
+        /// <summary>
+        /// How long a sample gets to answer one press.
+        /// </summary>
+        private static readonly TimeSpan s_step = TimeSpan.FromSeconds(30);
+
+        #region DataTypes
+        /// <summary>
+        /// The data types client has to reach the structured value of the second node set
+        /// through its own browse tree, and show it decoded.
+        /// </summary>
+        /// <remarks>
+        /// What the sample is for: the server serves data types of its own, out of two node
+        /// sets, and a client which knew none of them at compile time loads the type system
+        /// after connecting and can then make sense of a value. The client does that load in
+        /// its ConnectComplete handler and shows what it read in the attribute list of its
+        /// browse control, so walking the tree to the parking lot's structured property and
+        /// reading the attribute list follows the whole chain.
+        /// </remarks>
+        [Test]
+        [CancelAfter(kTimeout)]
+        public Task DataTypesClientShowsAStructuredValue(CancellationToken ct)
+        {
+            return DriveAsync("DataTypes", async (form, session, phase, token) => {
+                phase.Enter("walking its browse tree to the parking lot");
+
+                TreeView tree = SampleFormDriver.BrowseTreeOf(form);
+
+                Assert.That(tree, Is.Not.Null, "The sample no longer hosts the shared browse control.");
+
+                TreeNode root = await RootOfAsync(tree, token).ConfigureAwait(true);
+
+                // the tree of this client is rooted at the Root folder rather than at Objects
+                TreeNode vehicle = await SampleFormDriver.NavigateAsync(
+                    root,
+                    ["Objects", "ParkingLot", "DriverOfTheMonth", "PrimaryVehicle"],
+                    s_step,
+                    token).ConfigureAwait(true);
+
+                Assert.That(
+                    vehicle,
+                    Is.Not.Null,
+                    "The browse tree of the sample does not reach the primary vehicle of the parking lot. " +
+                    $"Below the root it shows: {SampleFormDriver.ChildrenOf(root)}");
+
+                phase.Enter("reading the attributes of the structured value");
+
+                ListView attributes = SampleFormDriver.AttributeListOf(form);
+
+                SampleFormDriver.Select(tree, vehicle);
+
+                bool read = await SampleFormDriver.PumpUntilAsync(
+                    () => SampleFormDriver.AttributeText(attributes, "Value") != null,
+                    s_step,
+                    token).ConfigureAwait(true);
+
+                Assert.That(
+                    read,
+                    Is.True,
+                    "Selecting the primary vehicle did not make the sample read its attributes. " +
+                    $"The attribute list shows: {SampleFormDriver.AttributesSeen(attributes)}");
+
+                string dataType = SampleFormDriver.AttributeText(attributes, "DataType");
+                string value = SampleFormDriver.AttributeText(attributes, "Value");
+
+                await TestContext.Out
+                    .WriteLineAsync($"The client shows DataType '{dataType}' and Value '{value}'")
+                    .ConfigureAwait(true);
+
+                Assert.Multiple(() => {
+                    Assert.That(
+                        dataType,
+                        Is.EqualTo("VehicleType"),
+                        "The property has to be typed with the data type of the other node set. " +
+                        "A node id instead of a name means the type node never arrived.");
+
+                    // the client shows the fields of the structure, so what is asserted is that
+                    // they are there rather than how they are laid out
+                    Assert.That(
+                        value,
+                        Does.Contain("Trek"),
+                        "The value has to arrive decoded into its fields. Anything else means the " +
+                        "client could not make sense of a structure, which is the whole point of " +
+                        "the sample. " +
+                        $"The attribute list shows: {SampleFormDriver.AttributesSeen(attributes)}");
+
+                    // Make and Model come from the vehicle type of the first node set, the
+                    // manufacturer and the gears from the bicycle type of the second. A value
+                    // decoded only as its declared base type would be missing the last two,
+                    // which is a defect the sample would otherwise show without complaining
+                    Assert.That(
+                        value,
+                        Does.Contain("Cube").And.Contain("10"),
+                        "The value has to keep the fields the derived structure adds to the one " +
+                        "the property is declared as, not only the inherited ones. " +
+                        $"It shows '{value}'.");
+                });
+            }, ct);
+        }
+        #endregion
+
+        #region HistoricalAccess
+        /// <summary>
+        /// The historical access client has to read recorded history into its grid.
+        /// </summary>
+        /// <remarks>
+        /// What the sample is for. The form itself is thin - it hands a node and a session to
+        /// the shared history control the way its Select Variable dialog does, and the read is
+        /// the Go button of that control. Connecting proves none of it: the control is only
+        /// usable if the sample gave it the session in its ConnectComplete handler, and the
+        /// read only returns anything if the node it was given is one the server historizes.
+        /// </remarks>
+        [Test]
+        [CancelAfter(kTimeout)]
+        public Task HistoricalAccessClientReadsHistoryIntoItsGrid(CancellationToken ct)
+        {
+            return DriveAsync("HistoricalAccess", async (form, session, phase, token) => {
+                phase.Enter("looking for an archive item to read");
+
+                NodeId item = await ArchiveItemAsync(session, token).ConfigureAwait(true);
+
+                var history = WinFormsHarness.FindControl(form, "ReadCTRL") as HistoryDataListView;
+
+                Assert.That(history, Is.Not.Null, "The sample no longer hosts the shared history control.");
+
+                phase.Enter($"pointing the history control at {item}");
+
+                // what the sample does once its Select Variable dialog comes back with a node
+                await history.ChangeNodeAsync(item, token).ConfigureAwait(true);
+
+                var results = WinFormsHarness.FindField<DataGridView>(history, "ResultsDV");
+
+                Assert.That(results, Is.Not.Null, "The history control no longer has its results grid.");
+
+                phase.Enter("pressing Go");
+
+                Assert.That(
+                    SampleFormDriver.TryInvokeHandler(history, "GoBTN_ClickAsync", null),
+                    Is.True,
+                    "The history control no longer has a Go handler.");
+
+                bool filled = await SampleFormDriver.PumpUntilAsync(
+                    () => results.Rows.Count > 0,
+                    s_step,
+                    token).ConfigureAwait(true);
+
+                Assert.That(
+                    filled,
+                    Is.True,
+                    "A raw read of an archive item has to put its recorded values in the grid. " +
+                    "An empty grid means the read never reached the server, or the sample handed " +
+                    "the control a node which is not historized.");
+
+                string[] values = results.Rows
+                    .Cast<DataGridViewRow>()
+                    .Take(3)
+                    .Select(row => $"{row.Cells[0].Value} = {row.Cells[2].Value}")
+                    .ToArray();
+
+                await TestContext.Out
+                    .WriteLineAsync($"{results.Rows.Count} rows, the first are: {string.Join("; ", values)}")
+                    .ConfigureAwait(true);
+
+                Assert.That(
+                    results.Rows[0].Cells[2].Value?.ToString(),
+                    Is.Not.Null.And.Not.Empty,
+                    "A row of the grid has to carry the value that was recorded, not only a timestamp.");
+            }, ct);
+        }
+        #endregion
+
+        #region PerfTest
+        /// <summary>
+        /// The performance test client has to count the updates it is measuring.
+        /// </summary>
+        /// <remarks>
+        /// What the sample is for: it subscribes to a block of items as soon as it connects
+        /// and reports the throughput it sees. The counters are filled by a WinForms timer
+        /// which reads the tester, so a number above zero is the proof that the subscription
+        /// was created, that notifications arrive on the publish worker and that the timer
+        /// gets them onto the form - none of which a connect shows. Pressing Stop afterwards
+        /// is the other half: the sample has to be able to end the run it started.
+        /// </remarks>
+        [Test]
+        [CancelAfter(kTimeout)]
+        public Task PerfTestClientCountsTheUpdatesItMeasures(CancellationToken ct)
+        {
+            return DriveAsync("PerfTest", async (form, session, phase, token) => {
+                phase.Enter("waiting for the first measured updates");
+
+                var messages = WinFormsHarness.FindControl(form, "MessageCountTB") as TextBox;
+                var updates = WinFormsHarness.FindControl(form, "TotalItemUpdateCountTB") as TextBox;
+
+                Assert.That(messages, Is.Not.Null, "The sample no longer shows a message count.");
+                Assert.That(updates, Is.Not.Null, "The sample no longer shows an item update count.");
+
+                bool counted = await SampleFormDriver.PumpUntilAsync(
+                    () => SampleFormDriver.TryReadNumber(updates.Text, out double seen) && seen > 0,
+                    s_step,
+                    token).ConfigureAwait(true);
+
+                await TestContext.Out
+                    .WriteLineAsync($"The client reports {messages.Text} messages and {updates.Text} item updates")
+                    .ConfigureAwait(true);
+
+                Assert.That(
+                    counted,
+                    Is.True,
+                    "The sample starts its test as soon as it connects, so its item update count " +
+                    $"has to leave zero. It shows '{updates.Text}' after {s_step.TotalSeconds:F0} seconds.");
+
+                Assert.That(
+                    SampleFormDriver.TryReadNumber(messages.Text, out double publishes) && publishes > 0,
+                    Is.True,
+                    $"Item updates arrived but no publish was counted, which cannot be: '{messages.Text}'.");
+
+                phase.Enter("pressing Stop");
+
+                var stop = WinFormsHarness.FindControl(form, "StopBTN") as Button;
+
+                Assert.That(stop, Is.Not.Null, "The sample no longer has a Stop button.");
+
+                // whether the sample is still running is read from its own timer, not from
+                // Button.Visible. The visibility of a control is answered from the whole parent
+                // chain, and on a form the harness never shows every control reports itself
+                // invisible however the sample set the property.
+                var ticker = WinFormsHarness.FindField<System.Windows.Forms.Timer>(form, "UpdateTimer");
+
+                Assert.That(ticker, Is.Not.Null, "The sample no longer has its update timer.");
+                Assert.That(ticker.Enabled, Is.True, "The sample was not running a test to stop.");
+
+                Assert.That(
+                    SampleFormDriver.TryInvokeHandler(form, "StopBTN_ClickAsync", stop),
+                    Is.True,
+                    "The sample no longer has a Stop handler.");
+
+                bool stopped = await SampleFormDriver.PumpUntilAsync(
+                    () => !ticker.Enabled,
+                    s_step,
+                    token).ConfigureAwait(true);
+
+                Assert.That(stopped, Is.True, "Pressing Stop did not end the run the sample had started.");
+            }, ct);
+        }
+        #endregion
+
+        #region Reference
+        /// <summary>
+        /// The reference client has to browse into the address space of its server and read
+        /// the attributes of what it found.
+        /// </summary>
+        /// <remarks>
+        /// The whole client is a browse tree and an attribute list, so this is all of it. A
+        /// connect only proves that the tree was handed a session; the browse of a child node,
+        /// which the control does when the node is expanded, and the read of the attributes,
+        /// which it does when a node is selected, are both service calls the sample makes on
+        /// its own and neither happens before a user touches the tree.
+        /// </remarks>
+        [Test]
+        [CancelAfter(kTimeout)]
+        public Task ReferenceClientBrowsesAndReadsAScalar(CancellationToken ct)
+        {
+            return DriveAsync("Reference", async (form, session, phase, token) => {
+                phase.Enter("walking its browse tree into the static scalars");
+
+                TreeView tree = SampleFormDriver.BrowseTreeOf(form);
+
+                Assert.That(tree, Is.Not.Null, "The sample no longer hosts the shared browse control.");
+
+                TreeNode root = await RootOfAsync(tree, token).ConfigureAwait(true);
+
+                TreeNode scalars = await SampleFormDriver.NavigateAsync(
+                    root,
+                    ["Data", "Static", "Scalar"],
+                    s_step,
+                    token).ConfigureAwait(true);
+
+                Assert.That(
+                    scalars,
+                    Is.Not.Null,
+                    "The browse tree does not reach the static scalars of the reference server. " +
+                    $"Below Objects it shows: {SampleFormDriver.ChildrenOf(root)}");
+
+                Assert.That(
+                    await SampleFormDriver.ExpandAsync(scalars, s_step, token).ConfigureAwait(true),
+                    Is.True,
+                    "Expanding the scalars folder never finished.");
+
+                TreeNode scalar = scalars.Nodes
+                    .Cast<TreeNode>()
+                    .FirstOrDefault(node => (node.Tag as ReferenceDescription)?.NodeClass == NodeClass.Variable);
+
+                Assert.That(
+                    scalar,
+                    Is.Not.Null,
+                    "The static scalars folder of the reference server holds no variable. " +
+                    $"It shows: {SampleFormDriver.ChildrenOf(scalars)}");
+
+                phase.Enter($"reading the attributes of {SampleFormDriver.BrowseNameOf(scalar)}");
+
+                ListView attributes = SampleFormDriver.AttributeListOf(form);
+
+                SampleFormDriver.Select(tree, scalar);
+
+                bool read = await SampleFormDriver.PumpUntilAsync(
+                    () => SampleFormDriver.AttributeText(attributes, "Value") != null,
+                    s_step,
+                    token).ConfigureAwait(true);
+
+                Assert.That(
+                    read,
+                    Is.True,
+                    "Selecting a variable did not make the sample read its attributes. " +
+                    $"The attribute list shows: {SampleFormDriver.AttributesSeen(attributes)}");
+
+                await TestContext.Out
+                    .WriteLineAsync(
+                        $"{SampleFormDriver.BrowseNameOf(scalar)}: " +
+                        SampleFormDriver.AttributesSeen(attributes))
+                    .ConfigureAwait(true);
+
+                Assert.Multiple(() => {
+                    Assert.That(
+                        SampleFormDriver.AttributeText(attributes, "NodeClass"),
+                        Is.EqualTo("Variable"),
+                        "The attributes the sample read are not the ones of the node it was asked about.");
+
+                    // the qualified browse name, which is how the control renders it and also
+                    // what makes this worth asserting: the namespace index has to be the one
+                    // the tree got from the server
+                    Assert.That(
+                        SampleFormDriver.AttributeText(attributes, "BrowseName"),
+                        Is.EqualTo(((ReferenceDescription)scalar.Tag).BrowseName.ToString()),
+                        "The attribute list is showing a different node than the tree selected.");
+                });
+            }, ct);
+        }
+        #endregion
+
+        #region UserAuthentication
+        /// <summary>
+        /// The user authentication client has to be refused what the identity it is holding
+        /// may not do, and say so.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// What the sample is for: the same node looks different depending on who is asking.
+        /// The tier 1.5 fixture proves the server end of that - an anonymous session is told
+        /// the log file path is read only and its write is refused. This is the client end,
+        /// which is a different question: the sample has to read the node after connecting,
+        /// send the write the user asked for, and report the refusal instead of pretending it
+        /// worked.
+        /// </para>
+        /// <para>
+        /// Anonymously, because that needs no account: the successful write is only reachable
+        /// with a real Windows account, which is why the tier 1.5 test for it is gated on two
+        /// environment variables. Changing identity is driven through the user name button
+        /// with an account no machine has, which exercises the same UpdateSession call and
+        /// leaves the session as it was.
+        /// </para>
+        /// </remarks>
+        [Test]
+        [CancelAfter(kTimeout)]
+        public Task UserAuthenticationClientIsRefusedWhatItMayNotDo(CancellationToken ct)
+        {
+            return DriveAsync("UserAuthentication", async (form, session, phase, token) => {
+                phase.Enter("waiting for the log file path the sample reads after connecting");
+
+                var path = WinFormsHarness.FindControl(form, "LogFilePathTB") as TextBox;
+
+                Assert.That(path, Is.Not.Null, "The sample no longer shows the log file path.");
+
+                bool shown = await SampleFormDriver.PumpUntilAsync(
+                    () => !string.IsNullOrEmpty(path.Text),
+                    s_step,
+                    token).ConfigureAwait(true);
+
+                Assert.That(
+                    shown,
+                    Is.True,
+                    "The sample reads the log file path in its ConnectComplete handler, so it has " +
+                    "to be showing one. An empty box means that read never came back.");
+
+                await TestContext.Out
+                    .WriteLineAsync($"The client read the log file path '{path.Text}'")
+                    .ConfigureAwait(true);
+
+                phase.Enter("writing the log file path as an anonymous session");
+
+                path.Text = @".\NotAllowed.txt";
+
+                Assert.That(
+                    SampleFormDriver.TryInvokeHandler(form, "ChangeLogFileBTN_ClickAsync", null),
+                    Is.True,
+                    "The sample no longer has a handler for its change button.");
+
+                bool answered = await SampleFormDriver.PumpUntilAsync(
+                    () => Reported(form).Length > 0,
+                    s_step,
+                    token).ConfigureAwait(true);
+
+                Assert.That(answered, Is.True, "Writing the log file path never reported an outcome.");
+
+                await TestContext.Out
+                    .WriteLineAsync($"The write reported: {Reported(form)}")
+                    .ConfigureAwait(true);
+
+                Assert.That(
+                    Reported(form),
+                    Does.Contain(nameof(StatusCodes.BadUserAccessDenied)),
+                    "The server refuses a write from an anonymous session, and the sample has to " +
+                    "report that refusal rather than swallow it.");
+
+                phase.Enter("changing to an identity the server cannot verify");
+
+                var user = WinFormsHarness.FindControl(form, "UserNameTB") as TextBox;
+                var password = WinFormsHarness.FindControl(form, "PasswordTB") as TextBox;
+
+                Assert.That(user, Is.Not.Null, "The sample no longer takes a user name.");
+                Assert.That(password, Is.Not.Null, "The sample no longer takes a password.");
+
+                user.Text = "no-such-user-8f2c";
+                password.Text = "not the password";
+
+                ClearReport(form);
+
+                Assert.That(
+                    SampleFormDriver.TryInvokeHandler(form, "UserNameImpersonateBTN_Click", null),
+                    Is.True,
+                    "The sample no longer has a handler for its user name impersonate button.");
+
+                bool refused = await SampleFormDriver.PumpUntilAsync(
+                    () => Reported(form).Length > 0,
+                    s_step,
+                    token).ConfigureAwait(true);
+
+                Assert.That(refused, Is.True, "Impersonating never reported an outcome.");
+
+                await TestContext.Out
+                    .WriteLineAsync($"Impersonating reported: {Reported(form)}")
+                    .ConfigureAwait(true);
+
+                Assert.Multiple(() => {
+                    Assert.That(
+                        Reported(form),
+                        Does.Not.Contain("Good"),
+                        "An account the server cannot verify must not be reported as a successful " +
+                        "change of identity.");
+
+                    Assert.That(
+                        session.Identity?.TokenType,
+                        Is.EqualTo(UserTokenType.Anonymous),
+                        "A refused UpdateSession has to leave the session with the identity it had.");
+                });
+            }, ct);
+        }
+        #endregion
+
+        #region Views
+        /// <summary>
+        /// The views client has to browse through a view and see something different.
+        /// </summary>
+        /// <remarks>
+        /// What the sample is for, and the only sample which has it: the server overrides
+        /// IsNodeInView and IsReferenceInView, and the filtering they implement is invisible
+        /// unless a browse actually carries a view. The client is the half that has to put the
+        /// view on the browse, which is what its Change button does - it takes the view the
+        /// user picked and re-browses the selected node with it. Wire that up wrongly, and the
+        /// sample connects, fills its drop down and shows the unfiltered address space forever.
+        /// </remarks>
+        [Test]
+        [CancelAfter(kTimeout)]
+        public Task ViewsClientSeesADifferentAddressSpaceThroughAView(CancellationToken ct)
+        {
+            return DriveAsync("Views", async (form, session, phase, token) => {
+                phase.Enter("walking its browse tree to a flow meter");
+
+                ushort engineering = NamespaceIndexOf(session, Quickstarts.Views.Namespaces.Engineering);
+                ushort operations = NamespaceIndexOf(session, Quickstarts.Views.Namespaces.Operations);
+
+                TreeView tree = SampleFormDriver.BrowseTreeOf(form);
+
+                Assert.That(tree, Is.Not.Null, "The sample no longer hosts the shared browse control.");
+
+                TreeNode root = await RootOfAsync(tree, token).ConfigureAwait(true);
+
+                TreeNode flow = await SampleFormDriver.NavigateAsync(
+                    root,
+                    ["Plant", "Boiler #1", "WaterIn", "Flow"],
+                    s_step,
+                    token).ConfigureAwait(true);
+
+                Assert.That(
+                    flow,
+                    Is.Not.Null,
+                    "The browse tree does not reach the flow meter of the first boiler. " +
+                    $"Below Objects it shows: {SampleFormDriver.ChildrenOf(root)}");
+
+                Assert.That(
+                    await SampleFormDriver.ExpandAsync(flow, s_step, token).ConfigureAwait(true),
+                    Is.True,
+                    "Expanding the flow meter never finished.");
+
+                string[] unfiltered = ChildrenIn(flow, engineering).Concat(ChildrenIn(flow, operations)).ToArray();
+
+                await TestContext.Out
+                    .WriteLineAsync($"Without a view the flow meter shows: {SampleFormDriver.ChildrenOf(flow)}")
+                    .ConfigureAwait(true);
+
+                // the baseline the filtered browse is compared against: if this ever stops
+                // showing both disciplines, the assertion below would pass for the wrong reason
+                Assert.Multiple(() => {
+                    Assert.That(
+                        ChildrenIn(flow, engineering),
+                        Is.Not.Empty,
+                        "Browsing without a view has to show the engineering nodes.");
+
+                    Assert.That(
+                        ChildrenIn(flow, operations),
+                        Is.Not.Empty,
+                        "Browsing without a view has to show the operations nodes.");
+                });
+
+                phase.Enter("changing to the engineering view");
+
+                SampleFormDriver.Select(tree, flow);
+
+                var views = WinFormsHarness.FindControl(form, "ViewCB") as ComboBox;
+
+                Assert.That(views, Is.Not.Null, "The sample no longer offers a view to pick.");
+
+                object view = views.Items
+                    .Cast<object>()
+                    .FirstOrDefault(item => (item as ReferenceDescription)?.BrowseName.Name == "Engineering");
+
+                Assert.That(
+                    view,
+                    Is.Not.Null,
+                    "The sample did not list the engineering view after connecting. " +
+                    $"It offers: {string.Join(", ", views.Items.Cast<object>().Select(item => item.ToString()))}");
+
+                views.SelectedItem = view;
+
+                Assert.That(
+                    SampleFormDriver.TryInvokeHandler(form, "ChangeViewBTN_Click", null),
+                    Is.True,
+                    "The sample no longer has a handler for its Change button.");
+
+                bool rebrowsed = await SampleFormDriver.PumpUntilAsync(
+                    () => ChildrenIn(flow, engineering).Length > 0 || flow.Nodes.Count == 0,
+                    s_step,
+                    token).ConfigureAwait(true);
+
+                Assert.That(rebrowsed, Is.True, "Changing the view never re-browsed the flow meter.");
+
+                await TestContext.Out
+                    .WriteLineAsync(
+                        $"Through the engineering view it shows: {SampleFormDriver.ChildrenOf(flow)}")
+                    .ConfigureAwait(true);
+
+                Assert.Multiple(() => {
+                    Assert.That(
+                        ChildrenIn(flow, operations),
+                        Is.Empty,
+                        "The engineering view suppresses the operations nodes, so a client which " +
+                        "put the view on its browse must not see them any more. Seeing them means " +
+                        "the browse went out without the view. " +
+                        $"Unfiltered it showed: {string.Join(", ", unfiltered)}");
+
+                    Assert.That(
+                        ChildrenIn(flow, engineering),
+                        Is.Not.Empty,
+                        "The engineering view keeps the engineering nodes, so an empty tree means " +
+                        "the re-browse failed rather than filtered.");
+                });
+            }, ct);
+        }
+        #endregion
+
+        #region Helpers
+        /// <summary>
+        /// Starts the sample's server, builds the client's real main form, connects it and
+        /// runs the body.
+        /// </summary>
+        /// <remarks>
+        /// The body runs on the STA thread of the harness with a message loop pumping, which
+        /// is what lets the <c>async void</c> handlers of a sample get anywhere.
+        /// </remarks>
+        private static async Task DriveAsync(
+            string sampleName,
+            Func<Form, ISession, ClientPhase, CancellationToken, Task> body,
+            CancellationToken ct)
+        {
+            SampleClientUnderTest client = SampleClientFactories.All
+                .Single(entry => entry.Sample.Name == sampleName);
+
+            SampleServerUnderTest server = SampleServerFactories.All
+                .Single(entry => entry.Sample.Name == sampleName);
+
+            await using SampleServerHost host = await SampleServerHost
+                .StartAsync(sampleName, server.Sample.ServerConfig, server.CreateServer, ct)
+                .ConfigureAwait(false);
+
+            DialogWatchdog watchdog = null;
+            var phase = new ClientPhase();
+
+            try
+            {
+                await WinFormsHarness.RunAsync(
+                    async dialogs => {
+                        watchdog = dialogs;
+
+                        await ConnectAndRunAsync(client, host.EndpointUrl, body, phase, ct).ConfigureAwait(true);
+                    },
+                    TimeSpan.FromMilliseconds(kTimeout) - TimeSpan.FromSeconds(20))
+                    .ConfigureAwait(false);
+            }
+            catch (TimeoutException expired)
+            {
+                throw phase.Explain(expired);
+            }
+
+            if (watchdog?.DuringTeardown.Count > 0)
+            {
+                await TestContext.Out.WriteLineAsync(
+                    $"{sampleName}: while the form was being disposed - " +
+                    string.Join("; ", watchdog.DuringTeardown))
+                    .ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Runs on the STA thread of the harness, with a message loop pumping.
+        /// </summary>
+        private static async Task ConnectAndRunAsync(
+            SampleClientUnderTest client,
+            string endpointUrl,
+            Func<Form, ISession, ClientPhase, CancellationToken, Task> body,
+            ClientPhase phase,
+            CancellationToken ct)
+        {
+            phase.Enter("loading the configuration of the sample");
+
+            using var pki = new TemporaryPki($"client-{client.Sample.Name}");
+
+            ApplicationConfiguration configuration = await SampleConfigurationLoader
+                .LoadAsync(client.Sample.ClientConfig, pki, ct)
+                .ConfigureAwait(true);
+
+            configuration.TransportQuotas.OperationTimeout = kOperationTimeout;
+
+            await using var application = new ApplicationInstance(configuration, NullTelemetry.Instance);
+
+            phase.Enter("creating its client certificate");
+
+            Assert.That(
+                await application.CheckApplicationInstanceCertificatesAsync(true, null, ct).ConfigureAwait(true),
+                Is.True,
+                "The client certificate of the sample could not be created.");
+
+            phase.Enter("building its main form");
+
+            using Form form = client.CreateMainForm(configuration, NullTelemetry.Instance);
+
+            // handles for the whole form, not only for the form itself: a tree or a list which
+            // never got one silently drops what a test does to it
+            SampleFormDriver.CreateHandles(form);
+
+            ConnectServerCtrl connect = WinFormsHarness.GetConnectControl(form);
+
+            phase.Enter($"connecting to {endpointUrl}");
+
+            ISession session = await connect
+                .ConnectAsync(NullTelemetry.Instance, endpointUrl, false, 30_000, ct)
+                .ConfigureAwait(true);
+
+            Assert.That(session, Is.Not.Null, "The sample did not connect.");
+
+            try
+            {
+                await body(form, session, phase, ct).ConfigureAwait(true);
+            }
+            finally
+            {
+                phase.Enter("disconnecting");
+
+                // awaited, not the synchronous Disconnect: that one blocks the UI thread on
+                // work which needs the same message loop, and the fixture deadlocks
+                await connect.DisconnectAsync(CancellationToken.None).ConfigureAwait(true);
+            }
+        }
+
+        /// <summary>
+        /// The root of the browse tree, once the sample's post connect logic has put it there.
+        /// </summary>
+        private static async Task<TreeNode> RootOfAsync(TreeView tree, CancellationToken ct)
+        {
+            bool rooted = await SampleFormDriver.PumpUntilAsync(
+                () => tree.Nodes.Count > 0,
+                s_step,
+                ct).ConfigureAwait(true);
+
+            Assert.That(
+                rooted,
+                Is.True,
+                "The sample never rooted its browse tree, so its post connect logic did not run.");
+
+            return tree.Nodes[0];
+        }
+
+        /// <summary>
+        /// The browse names of the children of a tree node which are in one namespace.
+        /// </summary>
+        private static string[] ChildrenIn(TreeNode node, ushort namespaceIndex)
+        {
+            return node.Nodes
+                .Cast<TreeNode>()
+                .Select(child => child.Tag as ReferenceDescription)
+                .Where(reference => reference != null && reference.BrowseName.NamespaceIndex == namespaceIndex)
+                .Select(reference => reference.BrowseName.Name)
+                .ToArray();
+        }
+
+        private static ushort NamespaceIndexOf(ISession session, string namespaceUri)
+        {
+            int index = session.NamespaceUris.GetIndex(namespaceUri);
+
+            Assert.That(
+                index,
+                Is.GreaterThanOrEqualTo(0),
+                $"The server does not serve the namespace '{namespaceUri}'. It serves: " +
+                string.Join(", ", session.NamespaceUris.ToArray()));
+
+            return (ushort)index;
+        }
+
+        /// <summary>
+        /// What the user authentication client last reported in its status bar.
+        /// </summary>
+        private static string Reported(Form form)
+        {
+            return SampleFormDriver.StatusText(form, "StatusBar", "ActionStatusLB");
+        }
+
+        private static void ClearReport(Form form)
+        {
+            var status = WinFormsHarness.FindControl(form, "StatusBar") as StatusStrip;
+
+            ToolStripItem label = status?.Items
+                .Cast<ToolStripItem>()
+                .FirstOrDefault(item => item.Name == "ActionStatusLB");
+
+            if (label != null)
+            {
+                label.Text = string.Empty;
+            }
+        }
+
+        /// <summary>
+        /// The archive item of the historical access server the read is driven against.
+        /// </summary>
+        /// <remarks>
+        /// The double item of the fixed Sample archive, which is the one the tier 1.5 fixture
+        /// reads too: it is recorded rather than still being collected, so a raw read of it
+        /// returns the same values every run.
+        /// </remarks>
+        private static async Task<NodeId> ArchiveItemAsync(ISession session, CancellationToken ct)
+        {
+            ushort ns = NamespaceIndexOf(session, Quickstarts.HistoricalAccessServer.Namespaces.HistoricalAccess);
+
+            IReadOnlyList<ReferenceDescription> items = await SessionOps
+                .BrowseAsync(session, new NodeId("Sample", ns), ct)
+                .ConfigureAwait(true);
+
+            ReferenceDescription item = items.FirstOrDefault(child =>
+                child.NodeClass == NodeClass.Variable
+                && child.BrowseName.Name.Contains("Double", StringComparison.Ordinal));
+
+            Assert.That(
+                item,
+                Is.Not.Null,
+                "The Sample folder of the archive holds no Double item. It holds: " +
+                string.Join(", ", items.Select(child => child.BrowseName.Name)));
+
+            return ExpandedNodeId.ToNodeId(item.NodeId, session.NamespaceUris);
+        }
+        #endregion
+    }
+}

--- a/Tests/SampleClients.Tests/SampleClientActionTests.cs
+++ b/Tests/SampleClients.Tests/SampleClientActionTests.cs
@@ -80,12 +80,20 @@ namespace Opc.Ua.Samples.Tests
         /// through its own browse tree, and show it decoded.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// What the sample is for: the server serves data types of its own, out of two node
-        /// sets, and a client which knew none of them at compile time loads the type system
-        /// after connecting and can then make sense of a value. The client does that load in
-        /// its ConnectComplete handler and shows what it read in the attribute list of its
-        /// browse control, so walking the tree to the parking lot's structured property and
-        /// reading the attribute list follows the whole chain.
+        /// sets loaded into one namespace table, and the client browses to an instance which
+        /// uses them and displays the value. That path - expand, select, read, render - is
+        /// entirely the client's, and none of it runs before a user touches the tree.
+        /// </para>
+        /// <para>
+        /// What it does not pin down is the complex type system the client loads in its
+        /// ConnectComplete handler. Taking that load away does not fail this test, because the
+        /// client links the generated model as well, and in a tier 2 run the server is in the
+        /// same process on top of that - so the structure decodes either way. The load is
+        /// there for a client which has neither, and proving it would need a test which has
+        /// neither. What is asserted here is what the sample puts on the screen.
+        /// </para>
         /// </remarks>
         [Test]
         [CancelAfter(kTimeout)]

--- a/Tests/Samples.Tests.WinForms/SampleFormDriver.cs
+++ b/Tests/Samples.Tests.WinForms/SampleFormDriver.cs
@@ -1,0 +1,360 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using Opc.Ua.Client.Controls;
+
+namespace Opc.Ua.Samples.Tests
+{
+    /// <summary>
+    /// Presses the controls of a sample client which is never shown.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A form the harness runs but never displays does not behave like one a user is looking
+    /// at, and every helper here exists because of one of the ways it differs. None of them
+    /// assert: they report what happened and leave the wording of the failure to the fixture,
+    /// the same way <see cref="WinFormsHarness"/> does.
+    /// </para>
+    /// <para>
+    /// One thing no helper can paper over: <c>Control.Visible</c> is answered from the whole
+    /// parent chain, so on a form which is never shown every control reports itself invisible
+    /// however the sample set the property. A test which wants to know whether a sample showed
+    /// or hid something has to read the state the sample keeps instead. <c>Enabled</c> is not
+    /// affected and can be read as it is.
+    /// </para>
+    /// </remarks>
+    public static class SampleFormDriver
+    {
+        /// <summary>
+        /// Creates the window handles of a form and everything in it, without showing it.
+        /// </summary>
+        /// <remarks>
+        /// The samples marshal their callbacks back with <c>BeginInvoke</c>, which needs a
+        /// handle, and a tree or a list which never got one silently drops what is done to it.
+        /// </remarks>
+        public static void CreateHandles(Control root)
+        {
+            ArgumentNullException.ThrowIfNull(root);
+
+            _ = root.Handle;
+
+            foreach (Control control in Descendants(root))
+            {
+                _ = control.Handle;
+            }
+        }
+
+        /// <summary>
+        /// Every control under the given one.
+        /// </summary>
+        public static IEnumerable<Control> Descendants(Control parent)
+        {
+            ArgumentNullException.ThrowIfNull(parent);
+
+            foreach (Control child in parent.Controls)
+            {
+                yield return child;
+
+                foreach (Control grandChild in Descendants(child))
+                {
+                    yield return grandChild;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Presses a button of a sample by running its handler.
+        /// </summary>
+        /// <remarks>
+        /// Not through <see cref="Button.PerformClick"/>: that one is gated on
+        /// <c>CanSelect</c>, which is false while no parent of the control is visible, so on a
+        /// form the harness never shows it does nothing at all - no handler runs, and nothing
+        /// fails either. The handler is invoked directly instead.
+        /// </remarks>
+        /// <param name="owner">The form or control which declares the handler.</param>
+        /// <param name="handlerName">The name of the handler method.</param>
+        /// <param name="sender">What to pass as the sender, usually the button.</param>
+        /// <returns>False when the sample has no such handler any more.</returns>
+        public static bool TryInvokeHandler(object owner, string handlerName, object sender)
+        {
+            ArgumentNullException.ThrowIfNull(owner);
+
+            for (Type type = owner.GetType(); type != null; type = type.BaseType)
+            {
+                MethodInfo handler = type.GetMethod(
+                    handlerName,
+                    BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.DeclaredOnly);
+
+                if (handler != null)
+                {
+                    handler.Invoke(owner, [sender, EventArgs.Empty]);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Selects a row of a list the way a click would.
+        /// </summary>
+        /// <remarks>
+        /// Through <c>SelectedIndices</c> rather than <c>ListViewItem.Selected</c>: on a list
+        /// which has never been displayed the item level property does not reliably reach the
+        /// control, which leaves the sample's handler looking at an empty selection and
+        /// returning without doing anything.
+        /// </remarks>
+        /// <returns>False when the selection did not take.</returns>
+        public static bool TrySelectRow(ListView list, int index)
+        {
+            ArgumentNullException.ThrowIfNull(list);
+
+            if (index < 0 || index >= list.Items.Count)
+            {
+                return false;
+            }
+
+            list.Focus();
+            list.SelectedIndices.Clear();
+            list.SelectedIndices.Add(index);
+
+            return list.SelectedItems.Count == 1;
+        }
+
+        /// <summary>
+        /// Reads a number a sample displayed.
+        /// </summary>
+        /// <remarks>
+        /// Never compare a displayed number as text: how a <c>Double</c> renders depends on
+        /// the culture of the machine the test runs on, and these tests also run on a German
+        /// one. The current culture is tried first because that is what the sample formatted
+        /// with, and the invariant one after it for a value which was not formatted at all.
+        /// </remarks>
+        public static bool TryReadNumber(string shown, out double value)
+        {
+            value = 0;
+
+            return !string.IsNullOrWhiteSpace(shown)
+                && (double.TryParse(shown, NumberStyles.Any, CultureInfo.CurrentCulture, out value)
+                    || double.TryParse(shown, NumberStyles.Any, CultureInfo.InvariantCulture, out value));
+        }
+
+        /// <summary>
+        /// Pumps the message loop until the condition holds.
+        /// </summary>
+        /// <remarks>
+        /// The samples do their work in <c>async void</c> handlers, so there is nothing to
+        /// await: the only way to let one finish is to keep the loop turning and watch what it
+        /// puts on the screen.
+        /// </remarks>
+        /// <returns>False when the condition never held.</returns>
+        public static async Task<bool> PumpUntilAsync(
+            Func<bool> condition,
+            TimeSpan timeout,
+            CancellationToken ct)
+        {
+            ArgumentNullException.ThrowIfNull(condition);
+
+            DateTime deadline = DateTime.UtcNow.Add(timeout);
+
+            while (!condition())
+            {
+                if (DateTime.UtcNow > deadline)
+                {
+                    return false;
+                }
+
+                ct.ThrowIfCancellationRequested();
+
+                Application.DoEvents();
+
+                await Task.Delay(100, ct).ConfigureAwait(true);
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// The text of a label of the status bar of a sample.
+        /// </summary>
+        public static string StatusText(Form form, string statusStripName, string labelName)
+        {
+            var status = WinFormsHarness.FindControl(form, statusStripName) as StatusStrip;
+
+            ToolStripItem label = status?.Items
+                .Cast<ToolStripItem>()
+                .FirstOrDefault(item => item.Name == labelName);
+
+            return label?.Text ?? string.Empty;
+        }
+
+        #region Browse Tree
+        /// <summary>
+        /// The shared browse control a sample hosts, found by its designer field on the form.
+        /// </summary>
+        public static BrowseNodeCtrl BrowseControlOf(Form form, string browseControlName = "BrowseCTRL")
+        {
+            return WinFormsHarness.FindControl(form, browseControlName) as BrowseNodeCtrl;
+        }
+
+        /// <summary>
+        /// The tree of the shared browse control a sample hosts.
+        /// </summary>
+        public static TreeView BrowseTreeOf(Form form, string browseControlName = "BrowseCTRL")
+        {
+            return BrowseControlOf(form, browseControlName)?.BrowseCTRL?.BrowseTV;
+        }
+
+        /// <summary>
+        /// The attribute list of the shared browse control, which is where the control puts
+        /// what it read for the node the user selected in the tree.
+        /// </summary>
+        public static ListView AttributeListOf(Form form, string browseControlName = "BrowseCTRL")
+        {
+            AttributesListViewCtrl attributes = BrowseControlOf(form, browseControlName)?.AttributesCTRL;
+
+            return attributes == null ? null : WinFormsHarness.FindField<ListView>(attributes, "AttributesLV");
+        }
+
+        /// <summary>
+        /// What the attribute list shows for one attribute, or null when it has no row for it.
+        /// </summary>
+        public static string AttributeText(ListView attributes, string attributeName)
+        {
+            ListViewItem row = attributes?.Items
+                .Cast<ListViewItem>()
+                .FirstOrDefault(item => string.Equals(item.Text, attributeName, StringComparison.Ordinal));
+
+            return row != null && row.SubItems.Count > 2 ? row.SubItems[2].Text : null;
+        }
+
+        /// <summary>
+        /// Everything the attribute list shows, for a failure message.
+        /// </summary>
+        public static string AttributesSeen(ListView attributes)
+        {
+            if (attributes == null)
+            {
+                return "<no attribute list>";
+            }
+
+            return string.Join(
+                ", ",
+                attributes.Items
+                    .Cast<ListViewItem>()
+                    .Select(item => $"{item.Text}={(item.SubItems.Count > 2 ? item.SubItems[2].Text : string.Empty)}"));
+        }
+
+        /// <summary>
+        /// The browse name of the node a tree node stands for, or null for the placeholder the
+        /// control puts under a node it has not browsed yet.
+        /// </summary>
+        public static string BrowseNameOf(TreeNode node)
+        {
+            return (node?.Tag as ReferenceDescription)?.BrowseName.Name;
+        }
+
+        /// <summary>
+        /// The browse names of the children of a tree node, for a failure message.
+        /// </summary>
+        public static string ChildrenOf(TreeNode node)
+        {
+            if (node == null)
+            {
+                return "<no node>";
+            }
+
+            return string.Join(
+                ", ",
+                node.Nodes.Cast<TreeNode>().Select(child => BrowseNameOf(child) ?? $"'{child.Text}'"));
+        }
+
+        /// <summary>
+        /// Expands a node of the browse tree and waits for its real children.
+        /// </summary>
+        /// <remarks>
+        /// The control answers <c>BeforeExpand</c> in an <c>async void</c> handler which
+        /// browses the server and only then replaces the placeholder child with the real ones,
+        /// so expanding is not done when <c>Expand</c> returns. A node which turns out to have
+        /// no children at all ends up with none, which is why the wait is for the placeholder
+        /// to be gone rather than for a child to appear.
+        /// </remarks>
+        public static async Task<bool> ExpandAsync(TreeNode node, TimeSpan timeout, CancellationToken ct)
+        {
+            ArgumentNullException.ThrowIfNull(node);
+
+            node.Expand();
+
+            return await PumpUntilAsync(() => !HasPlaceholder(node), timeout, ct).ConfigureAwait(true);
+        }
+
+        /// <summary>
+        /// Walks the browse tree down a path of browse names, expanding as it goes.
+        /// </summary>
+        /// <returns>
+        /// The node the path ends at, or null when a step of it is not in the tree - the
+        /// caller reports where it stopped with <see cref="ChildrenOf"/>.
+        /// </returns>
+        public static async Task<TreeNode> NavigateAsync(
+            TreeNode start,
+            IReadOnlyList<string> browseNames,
+            TimeSpan timeout,
+            CancellationToken ct)
+        {
+            ArgumentNullException.ThrowIfNull(browseNames);
+
+            TreeNode current = start;
+
+            foreach (string name in browseNames)
+            {
+                if (current == null || !await ExpandAsync(current, timeout, ct).ConfigureAwait(true))
+                {
+                    return null;
+                }
+
+                current = current.Nodes
+                    .Cast<TreeNode>()
+                    .FirstOrDefault(child => string.Equals(BrowseNameOf(child), name, StringComparison.Ordinal));
+            }
+
+            return current;
+        }
+
+        /// <summary>
+        /// Selects a node of the browse tree, which is what makes the control read its
+        /// attributes.
+        /// </summary>
+        public static void Select(TreeView tree, TreeNode node)
+        {
+            ArgumentNullException.ThrowIfNull(tree);
+
+            tree.SelectedNode = node;
+        }
+
+        /// <summary>
+        /// True while the control still shows the empty child it puts under a node it has not
+        /// browsed yet.
+        /// </summary>
+        private static bool HasPlaceholder(TreeNode node)
+        {
+            return node.Nodes.Count == 1
+                && node.Nodes[0].Tag == null
+                && string.IsNullOrEmpty(node.Nodes[0].Text);
+        }
+        #endregion
+    }
+}

--- a/Workshop/UserAuthentication/Client/MainForm.Designer.cs
+++ b/Workshop/UserAuthentication/Client/MainForm.Designer.cs
@@ -65,6 +65,7 @@ namespace Quickstarts.UserAuthenticationClient
             this.HelpMI = new System.Windows.Forms.ToolStripMenuItem();
             this.Help_ContentsMI = new System.Windows.Forms.ToolStripMenuItem();
             this.StatusBar = new System.Windows.Forms.StatusStrip();
+            this.ActionStatusLB = new System.Windows.Forms.ToolStripStatusLabel();
             this.MainPN = new System.Windows.Forms.Panel();
             this.AccessControlCheckGB = new System.Windows.Forms.GroupBox();
             this.LogFilePathLB = new System.Windows.Forms.Label();
@@ -169,11 +170,18 @@ namespace Quickstarts.UserAuthenticationClient
             // 
             // StatusBar
             // 
+            this.StatusBar.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.ActionStatusLB});
             this.StatusBar.Location = new System.Drawing.Point(0, 422);
             this.StatusBar.Name = "StatusBar";
             this.StatusBar.Size = new System.Drawing.Size(809, 22);
             this.StatusBar.TabIndex = 2;
-            // 
+            //
+            // ActionStatusLB
+            //
+            this.ActionStatusLB.Name = "ActionStatusLB";
+            this.ActionStatusLB.Size = new System.Drawing.Size(0, 17);
+            //
             // MainPN
             // 
             this.MainPN.Controls.Add(this.AccessControlCheckGB);
@@ -600,6 +608,7 @@ namespace Quickstarts.UserAuthenticationClient
 
         private System.Windows.Forms.MenuStrip MenuBar;
         private System.Windows.Forms.StatusStrip StatusBar;
+        private System.Windows.Forms.ToolStripStatusLabel ActionStatusLB;
         private System.Windows.Forms.ToolStripMenuItem ServerMI;
         private System.Windows.Forms.ToolStripMenuItem Server_DiscoverMI;
         private System.Windows.Forms.ToolStripMenuItem Server_ConnectMI;

--- a/Workshop/UserAuthentication/Client/MainForm.cs
+++ b/Workshop/UserAuthentication/Client/MainForm.cs
@@ -40,6 +40,7 @@ using Opc.Ua.Client.Controls;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Text;
+using Microsoft.Extensions.Logging;
 
 namespace Quickstarts.UserAuthenticationClient
 {
@@ -347,11 +348,11 @@ namespace Quickstarts.UserAuthenticationClient
                 string[] preferredLocales = PreferredLocalesTB.Text.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
                 await m_session.UpdateSessionAsync(identity, preferredLocales);
 
-                MessageBox.Show("User identity changed.", "Impersonate User", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                Report($"Impersonating '{UserNameTB.Text}'", StatusCodes.Good);
             }
             catch (Exception exception)
             {
-                ClientUtils.HandleException(m_telemetry, this.Text, exception);
+                Report($"Impersonating '{UserNameTB.Text}'", exception);
             }
             finally
             {
@@ -385,11 +386,11 @@ namespace Quickstarts.UserAuthenticationClient
                 string[] preferredLocales = PreferredLocalesTB.Text.Split([','], StringSplitOptions.RemoveEmptyEntries);
                 await m_session.UpdateSessionAsync(identity, preferredLocales);
 
-                MessageBox.Show("User identity changed.", "Impersonate User", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                Report("Impersonating with a certificate", StatusCodes.Good);
             }
             catch (Exception exception)
             {
-                ClientUtils.HandleException(m_telemetry, this.Text, exception);
+                Report("Impersonating with a certificate", exception);
             }
             finally
             {
@@ -414,11 +415,11 @@ namespace Quickstarts.UserAuthenticationClient
                 await m_session.UpdateSessionAsync(new UserIdentity(new AnonymousIdentityToken()), preferredLocales);
 #pragma warning restore CA2000
 
-                MessageBox.Show("User identity changed.", "Impersonate User", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                Report("Impersonating anonymously", StatusCodes.Good);
             }
             catch (Exception exception)
             {
-                ClientUtils.HandleException(m_telemetry, this.Text, exception);
+                Report("Impersonating anonymously", exception);
             }
             finally
             {
@@ -444,11 +445,11 @@ namespace Quickstarts.UserAuthenticationClient
                 string[] preferredLocales = PreferredLocalesTB.Text.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
                 await m_session.UpdateSessionAsync(identity, preferredLocales);
 
-                MessageBox.Show("User identity changed.", "Impersonate User", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                Report("Impersonating with a Kerberos token", StatusCodes.Good);
             }
             catch (Exception exception)
             {
-                ClientUtils.HandleException(m_telemetry, this.Text, exception);
+                Report("Impersonating with a Kerberos token", exception);
             }
             finally
             {
@@ -541,19 +542,54 @@ namespace Quickstarts.UserAuthenticationClient
                 ClientBase.ValidateResponse(results, valuesToWrite);
                 ClientBase.ValidateDiagnosticInfos(diagnosticInfos, valuesToWrite);
 
+                // the refusal is the interesting outcome here, not an error: the node manager
+                // answers the user access level per session, and an identity which may not
+                // write is told so by the write handler as well
+                Report("Writing the log file path", results[0]);
+
                 if (StatusCode.IsBad(results[0]))
                 {
-                    throw ServiceResultException.Create(results[0], 0, diagnosticInfos, responseHeader.StringTable);
+                    return;
                 }
             }
             catch (Exception exception)
             {
-                ClientUtils.HandleException(m_telemetry, this.Text, exception);
+                Report("Writing the log file path", exception);
             }
             finally
             {
                 m_session.ReturnDiagnostics = DiagnosticsMasks.None;
             }
+        }
+
+        /// <summary>
+        /// Reports what the server answered to an operation the user asked for.
+        /// </summary>
+        /// <remarks>
+        /// The status bar rather than a message box: the whole point of this sample is to try
+        /// the same operation as one identity after another and compare what the server says,
+        /// and a modal dialog between every click makes that tedious. It also keeps the
+        /// buttons drivable from a test, which a modal dialog does not.
+        /// </remarks>
+        private void Report(string what, StatusCode status)
+        {
+            ActionStatusLB.Text = $"{what} answered {status}";
+            ActionStatusLB.ForeColor = StatusCode.IsGood(status) ? Color.Empty : Color.Red;
+        }
+
+        /// <summary>
+        /// Reports an operation which did not get through, with the status code it failed with
+        /// where the stack gave one.
+        /// </summary>
+        private void Report(string what, Exception exception)
+        {
+            Report(
+                what,
+                exception is ServiceResultException refused
+                    ? refused.StatusCode
+                    : (StatusCode)StatusCodes.Bad);
+
+            m_telemetry.CreateLogger<MainForm>().LogInformation(exception, "{What} did not get through.", what);
         }
         #endregion
     }

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -400,9 +400,9 @@ since the server started.
 
 ## What Tier 2 checks today
 
-29 test cases, about a minute and a half, Windows only. For each WinForms sample client the test
-starts its sample server in process, then on a dedicated STA thread with a running message
-loop - but without ever showing a window:
+50 test cases, about two and a half minutes, Windows only. For each WinForms sample client
+the test starts its sample server in process, then on a dedicated STA thread with a running
+message loop - but without ever showing a window:
 
 - builds the client's real `MainForm` from the client's own configuration file
 - reaches the shared `ConnectServerCtrl` through its designer field and connects it to the
@@ -413,6 +413,69 @@ loop - but without ever showing a window:
   the proof that the sample's own logic ran, not just the shared control
 - disconnects and asserts the session was released
 
+### Every client is now driven past connect
+
+A connect is not enough for any of these samples. A client can build its form, open its
+session and finish its post connect logic while every one of its buttons does nothing, and
+until recently no tier would have noticed. That is not hypothetical. The Reset button of the
+role management client, a sample being added on its own branch, **shipped broken for every
+account**: it resolved its method with a browse path built from a bare string, and a
+`QualifiedName` made from a bare string is in namespace zero while the method's browse name
+is in the model's namespace, so the path resolved to nothing and the button answered the
+sample's own `BadNotFound`. Measured against the running server, `ns=0 Reset` did not resolve
+and `ns=2 Reset` gave `ns=2;i=6` - the server was right the whole time. Tier 0, 1 and 1.5 all
+passed, the tier 1.5 fixture because it resolves the same method *with* the namespace index,
+and tier 2 because it only asked whether the client connects. A user found it by pressing the
+button once.
+
+So every sample client which has a control now has one test which presses it and asserts what
+the sample exists to show:
+
+| Client | What is driven | What is asserted | Where |
+|--------|----------------|------------------|-------|
+| AlarmCondition | opens the audit event window | a condition reaches the display | `WorkshopClientSubscriptionTests` |
+| Boiler | connects | the drum level of the selected boiler arrives | `WorkshopClientSubscriptionTests` |
+| DataAccess | monitors a value | the value column of the monitored item list fills | `WorkshopClientSubscriptionTests` |
+| DataTypes | walks the browse tree to the parking lot's primary vehicle and selects it | the value shows the structure decoded into its fields, the ones the *derived* type adds included | `SampleClientActionTests` |
+| FileTransfer | selects and expands a directory, then reports a completed reconnect | the selected node is still the same node object and the tree did not change size | `FileTransferClientTests` |
+| Gds | connects both of its clients, registers with the directory and reads the registration back | the registration round trips and the server status panel fills itself | `GdsClientTests` |
+| HistoricalAccess | points the history control at a recorded archive item and presses Go | the grid fills with the recorded values | `SampleClientActionTests` |
+| HistoricalEvents | connects | a live event reaches the list | `WorkshopClientSubscriptionTests` |
+| Methods | connects | the current state of the process arrives | `WorkshopClientSubscriptionTests` |
+| PerfTest | connects, then presses Stop | the item update count leaves zero, and Stop ends the run | `SampleClientActionTests` |
+| Reference | browses into the static scalars and selects one | the attribute list holds the attributes of the node the tree selected | `SampleClientActionTests` |
+| Sample | opens a session through the modal dialog | a `ManagedSession` on the V2 engine, and a filled browse tree | `SampleClientFormTests` |
+| SimpleEvents | connects | an event reaches the list | `WorkshopClientSubscriptionTests` |
+| StateMachines | powers the machine on and starts it | a transition of the machine it powered on reaches the list | `WorkshopClientSubscriptionTests` |
+| UserAuthentication | writes the log file path anonymously, then impersonates an unknown account | the write is refused with `BadUserAccessDenied` and the sample reports it; the refused impersonation leaves the session's identity alone | `SampleClientActionTests` |
+| Views | selects the engineering view and presses Change | the operations nodes are gone from the re-browse and the engineering ones are still there | `SampleClientActionTests` |
+
+Aggregation is the one client still uncovered at any depth: it needs more than one server and
+is a declared gap in `SampleClientTests.UncoveredClientSamplesAreDeclared`.
+
+**Empty is deliberately uncovered.** It is the template a new sample is copied from: its form
+has the shared connect control, a menu and a status bar, and not one control of its own.
+There is nothing to press, and a test which pressed something would be testing the shared
+controls rather than the sample. `SampleClientActionTests` says so in its remarks, so the
+omission cannot be mistaken for an oversight. Should the template ever grow a control, its
+case belongs in that fixture with the others.
+
+Two things about driving a form the harness never shows, which cost a run each to find and
+are collected in `SampleFormDriver`:
+
+- `Button.PerformClick()` is **inert**. It is gated on `CanSelect`, which is false while no
+  parent of the control is visible, so no handler runs and nothing fails either. The handler
+  is invoked by reflection instead.
+- `Control.Visible` is answered from the whole parent chain, so **every** control reports
+  itself invisible however the sample set the property. Whether a sample showed or hid
+  something has to be read from the state the sample keeps - which is why the PerfTest case
+  watches the update timer rather than the Stop button. `Enabled` is not affected.
+
+Two more, which apply to any fixture here: the synchronous `connect.Disconnect()` deadlocks
+because it blocks the UI thread on work which needs the same message loop, so every fixture
+awaits `connect.DisconnectAsync(ct)`; and `ListViewItem.Selected` does not reliably reach a
+list which was never displayed, so a row is selected through `SelectedIndices`.
+
 `SubscribeControlTests` covers what a connect alone does not: it drives the subscription
 wizard of the shared `SubscribeDataListViewCtrl` against the Reference server the way a user
 would - create the subscription, add `Server_ServerStatus_CurrentTime`, step to apply and then
@@ -422,15 +485,18 @@ reconnect fails a test, and it proves that the V2 notification handler of a cont
 reaches the user interface.
 
 `WorkshopClientSubscriptionTests` asks the same question of the Workshop clients that
-subscribe, and asks it of the sample itself rather than of a shared control. Six clients
+subscribe, and asks it of the sample itself rather than of a shared control. Seven clients
 connect to their own server and the test waits for a notification to reach the place the
 sample displays it: the drum level of the Boiler client, the process state of the Methods
 client, the value column of the DataAccess client's monitored item list, a condition in the
-AlarmCondition client, an event in the SimpleEvents client and a live event in the
-HistoricalEvents client. That covers both halves of the V2 engine - the callback based
-`ISubscriptionNotificationHandler` for the first four, the streaming `IStreamingSubscription`
-for the last two - and the AlarmCondition case also opens the audit event window, whose whole
-job is a streaming subscription that starts when it opens and ends when it closes.
+AlarmCondition client, an event in the SimpleEvents client, a transition in the StateMachines
+client and a live event in the HistoricalEvents client. That covers both halves of the V2
+engine - the callback based `ISubscriptionNotificationHandler` for the first four, the
+streaming `IStreamingSubscription` for the last three - and two of them press something
+first: the AlarmCondition case opens the audit event window, whose whole job is a streaming
+subscription that starts when it opens and ends when it closes, and the StateMachines case
+has to power its machine on, because a state machine nobody drives never has a transition to
+report.
 
 This is the part a connect test cannot reach: the handler is fixed when the subscription is
 created, an item is identified by name rather than by a mutable object, and the callback


### PR DESCRIPTION
## The gap

Tier 2 proved that every WinForms sample client builds its main form, connects to its own
sample server and finishes its post connect logic. A client can pass all of that and still be
wired so that not one of its buttons does anything, and no tier would notice.

## The evidence that it was real

The Reset button of the role management client (added on `romanett/opc-ua-server-client-310ffd`,
not yet on master) **shipped broken for every account**. It resolved its method with a browse
path built from a bare string, and a `QualifiedName` made from a bare string is in namespace
zero, while the method's browse name is in the model's namespace. The path resolved to nothing
and the button answered the sample's own synthetic `BadNotFound`.

Measured against the running server:

```
ns=0 Reset = <unresolved>
ns=2 Reset = ns=2;i=6
```

The server was right the whole time. Tier 0, 1 and 1.5 all passed — the tier 1.5 fixture
because it resolves the same method *with* the namespace index — and tier 2 passed because it
only asked whether the client connects. A user found it in seconds by pressing the button.
That asymmetry is what this closes.

## What is now asserted, per client

`WorkshopClientSubscriptionTests` already drove the seven clients whose content is a
subscription, and `FileTransferClientTests` the file transfer client. These are the rest:

| Client | What is driven | What is asserted |
|--------|----------------|------------------|
| **DataTypes** | walks the browse tree to `ParkingLot/DriverOfTheMonth/PrimaryVehicle` and selects it | the value shows the structure decoded into its fields — `{Trek\|Compact\|5\|Cube\|10}` — including the two the *derived* `BicycleType` adds to the declared `VehicleType`, so a decode which silently fell back to the base type fails |
| **HistoricalAccess** | points the shared history control at a recorded archive item the way the sample's Select Variable dialog does, presses Go | the grid fills with the recorded values (9 rows, `13:00:10.000 = 10` …) and the first row carries a value, not just a timestamp |
| **PerfTest** | connects, which starts the run, then presses Stop | the item update count leaves zero (5 publishes, 5000 item updates) and Stop ends the run |
| **Reference** | browses `Objects/Data/Static/Scalar`, selects the first variable | the attribute list holds the attributes of the node the tree selected, qualified browse name included |
| **UserAuthentication** | writes the log file path as an anonymous session, then impersonates an account no machine has | the write is refused `BadUserAccessDenied` **and the sample reports it**; the refused impersonation leaves the session's identity `Anonymous` |
| **Views** | selects the engineering view and presses Change | the operations nodes are gone from the re-browse (`Measurement`, `SetPoint`) and the engineering ones remain (`Manufacturer`, `SerialNumber`) |

**Empty is deliberately not covered**, and the fixture says so in its remarks. It is the
template a new sample is copied from: its form has the shared connect control, a menu and a
status bar, and not one control of its own. A test which pressed something there would be
testing the shared controls, not the sample.

`docs/TESTING.md` now carries the full per-client table, this one plus the clients the
existing fixtures already drive.

## The one sample change

`Workshop/UserAuthentication/Client` reported through modal dialogs — a message box on the way
through, the shared exception dialog on the way out. That is the same change the role
management client already got, for the same reason: the whole content of this sample is trying
the same operation as one identity after another and comparing what the server answers, and a
dialog to click away between every attempt makes that tedious. It also put the *interesting*
outcome — a refusal, which is the thing the sample exists to show — into the same dialog as a
broken connection. The buttons now write the status code into the status bar, red when bad;
the exception is still logged. A modal dialog also cannot be driven from a test at all.

It is its own commit, so it can be taken or left independently of the tests.

## Proof that the tests can fail

Every case was broken deliberately and watched go red with a message naming the real cause,
then restored and watched go green. A regression test that has never failed proves nothing.

| Break | What the test said |
|-------|--------------------|
| DataTypes: browse tree rooted at `TypesFolder` | *does not reach the primary vehicle of the parking lot. Below the root it shows: DataTypes, EventTypes, …* |
| DataTypes: the value renders as its type rather than its content | *Expected: String containing "Trek" / But was: "ExtensionObject"* |
| HistoricalAccess: `ChangeNodeAsync` forgets `m_nodeId` | *A raw read of an archive item has to put its recorded values in the grid…* |
| PerfTest: `UpdateTimer.Enabled = true` removed | *its item update count has to leave zero. It shows '' after 30 seconds* |
| Reference: browse tree rooted at `TypesFolder` | *does not reach the static scalars… Below Objects it shows: DataTypes, EventTypes, …* |
| UserAuthentication: the write reports `Good` whatever the server said | *Expected: String containing "BadUserAccessDenied" / But was: "…answered Good \[0x00000000\]"* |
| Views: `BrowseCTRL.View = view` removed | *Seeing them means the browse went out without the view. / But was: < "Measurement", "SetPoint" >* |

One honest note, recorded in the fixture's remarks rather than glossed over: removing the
complex type system load from the DataTypes client does **not** fail its test, because the
client links the generated model and in a tier 2 run the server is in the same process. That
case covers the client's display path, not the dynamic type load; proving the load would need
a client which has neither.

## Driving a form that is never shown

Four traps, now collected in `SampleFormDriver` and written down in `docs/TESTING.md`:

- `Button.PerformClick()` is **inert** — gated on `CanSelect`, false while no parent is
  visible, so no handler runs *and nothing fails*. Handlers are invoked by reflection.
- `Control.Visible` is answered from the whole parent chain, so **every** control reports
  itself invisible however the sample set it. What a sample showed or hid has to be read from
  the state the sample keeps — which is why the PerfTest case watches the update timer rather
  than the Stop button. `Enabled` is unaffected.
- The synchronous `connect.Disconnect()` deadlocks; every fixture awaits `DisconnectAsync`.
- `ListViewItem.Selected` does not reliably reach a list which was never displayed.

## Verification

Rebased onto master after #831 and #832 landed, and re-measured there:

| Tier | Result |
|------|--------|
| 0 — Configuration | **159 passed**, 0 failed, 3 s |
| 2 — Client smoke | **50 passed**, 0 failed, 2 m 17 s |

No tier 1.5 fixture is touched — no server or node manager code changed.

Two documentation corrections came with the rebase. The tier 2 count said 29 where the
assembly runs 50 (44 before this change), and the `WorkshopClientSubscriptionTests` paragraph
still said six clients after the state machines sample joined it. Both are fixed here. The
tier 0 count is also stale — it says 151 where the runner reports 159 — but that is a section
this change does not otherwise touch, so it is left for whoever owns it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
