### PR TITLE
Stop the sample clients from freezing on Server > Disconnect

### DIFF
--- a/Samples/ClientControls.Net4/ClientUtils.cs
+++ b/Samples/ClientControls.Net4/ClientUtils.cs
@@ -1307,7 +1307,7 @@ namespace Opc.Ua.Client.Controls
                 using var bounded = CancellationTokenSource.CreateLinkedTokenSource(ct);
                 bounded.CancelAfter(timeout);
 
-                await session.CloseAsync((int)timeout.TotalMilliseconds, bounded.Token);
+                await session.CloseAsync((int)timeout.TotalMilliseconds, bounded.Token).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
@@ -1321,8 +1321,32 @@ namespace Opc.Ua.Client.Controls
             }
             finally
             {
-                await session.DisposeAsync();
+                await session.DisposeAsync().ConfigureAwait(false);
             }
+        }
+
+        /// <summary>
+        /// Runs an asynchronous teardown from a synchronous callback and waits for it.
+        /// </summary>
+        /// <remarks>
+        /// FormClosing and Dispose cannot await, so a sample which releases something
+        /// asynchronously on its way out has to wait for it. Awaiting it on the UI thread
+        /// would deadlock: the continuation is posted back to the message loop which the
+        /// wait is blocking, and neither side moves again. Running the teardown on a thread
+        /// pool thread, where there is no synchronization context to post back to, is what
+        /// lets the wait complete.
+        ///
+        /// The teardown therefore runs off the UI thread and must not touch any control.
+        /// </remarks>
+        /// <param name="teardown">The teardown to run.</param>
+        public static void WaitForTeardown(Func<Task> teardown)
+        {
+            if (teardown == null)
+            {
+                throw new ArgumentNullException(nameof(teardown));
+            }
+
+            Task.Run(teardown).GetAwaiter().GetResult();
         }
         #endregion
 

--- a/Samples/ClientControls.Net4/Common/Client/ConnectServerCtrl.cs
+++ b/Samples/ClientControls.Net4/Common/Client/ConnectServerCtrl.cs
@@ -497,24 +497,11 @@ namespace Opc.Ua.Client.Controls
         }
 
         /// <summary>
-        /// Disconnects from the server.
+        /// Disconnects from the server and reports it.
         /// </summary>
         private async Task InternalDisconnectAsync(CancellationToken ct = default)
         {
-            // disconnect any existing session. Closing the managed session also stops its
-            // connection state machine, so there is no separate reconnect handler to cancel.
-            // The close is bounded: a session which is in the middle of a reconnect attempt
-            // against a server that is gone cannot close until that attempt has run out, and
-            // the sample must not wait for that. See ClientUtils.CloseAndDisposeAsync.
-            if (m_session != null)
-            {
-                DetachSession();
-
-                ISession session = m_session;
-                m_session = null;
-
-                await ClientUtils.CloseAndDisposeAsync(session, ct);
-            }
+            await CloseSessionAsync(ct).ConfigureAwait(false);
 
             // raise an event.
             DoConnectComplete(null);
@@ -523,12 +510,54 @@ namespace Opc.Ua.Client.Controls
         /// <summary>
         /// Disconnects from the server.
         /// </summary>
+        /// <remarks>
+        /// The synchronous entry point exists for the callers which cannot await: the
+        /// Disconnect menu item of the samples, and their FormClosing handler, which the
+        /// event signature keeps synchronous. Both run on the UI thread.
+        /// </remarks>
         public void Disconnect()
         {
             UpdateStatus(false, DateTime.UtcNow, "Disconnected");
 
-            // stop any reconnect operation.
-            InternalDisconnectAsync().GetAwaiter().GetResult();
+            // Waiting for the close on the calling thread only works if the close does not
+            // need that thread to finish. Awaited here, it would: closing a session goes to
+            // the server, and the continuation of that await is posted back to the message
+            // loop which this very call is blocking, so neither side would ever move again.
+            // Task.Run puts the close on a thread pool thread, where there is no
+            // synchronization context to post back to, and the wait can complete.
+            Task.Run(() => CloseSessionAsync()).GetAwaiter().GetResult();
+
+            // reported here, on the thread of the caller, rather than from inside the task:
+            // the samples clear their display from this event and their FormClosing handler
+            // is already on the way out, so an event which is only marshalled back would
+            // arrive at a form which has gone. DoConnectComplete sees no marshalling is
+            // needed and raises it directly.
+            DoConnectComplete(null);
+        }
+
+        /// <summary>
+        /// Closes and releases the session of the control, without reporting it.
+        /// </summary>
+        /// <remarks>
+        /// Closing the managed session also stops its connection state machine, so there is
+        /// no separate reconnect handler to cancel. The close is bounded: a session which is
+        /// in the middle of a reconnect attempt against a server that is gone cannot close
+        /// until that attempt has run out, and the sample must not wait for that. See
+        /// ClientUtils.CloseAndDisposeAsync.
+        ///
+        /// Nothing here touches the controls, so it is safe to run off the UI thread.
+        /// </remarks>
+        private async Task CloseSessionAsync(CancellationToken ct = default)
+        {
+            if (m_session != null)
+            {
+                DetachSession();
+
+                ISession session = m_session;
+                m_session = null;
+
+                await ClientUtils.CloseAndDisposeAsync(session, ct).ConfigureAwait(false);
+            }
         }
 
         /// <summary>

--- a/Tests/SampleClients.Tests/SampleClientTests.cs
+++ b/Tests/SampleClients.Tests/SampleClientTests.cs
@@ -65,6 +65,17 @@ namespace Opc.Ua.Samples.Tests
         private static readonly TimeSpan s_postConnectGrace = TimeSpan.FromSeconds(2);
 
         /// <summary>
+        /// How long the user interface of a sample gets to react after a disconnect.
+        /// </summary>
+        /// <remarks>
+        /// Generous on purpose: this tells a message loop which still runs apart from one
+        /// which is deadlocked, it does not measure how quick a sample is. A sample which
+        /// handles ConnectComplete with an await of its own needs a few messages to get
+        /// through it.
+        /// </remarks>
+        private static readonly TimeSpan s_responsiveWithin = TimeSpan.FromSeconds(10);
+
+        /// <summary>
         /// Clients whose sample server does not start, so the client cannot be tested either.
         /// </summary>
         /// <remarks>
@@ -177,6 +188,106 @@ namespace Opc.Ua.Samples.Tests
                 "A known issue for a sample which no test drives is dead weight.");
         }
 
+        /// <summary>
+        /// What a user does: click Server, Disconnect.
+        /// </summary>
+        /// <remarks>
+        /// The loop above drives the connect control directly, which is the part every sample
+        /// shares. This goes through the menu item of one of them instead, so that the click
+        /// handler of the sample - which disposes its subscription first and only then asks
+        /// the control to disconnect - is on the path as well.
+        ///
+        /// The window is not shown here either. What froze was the message loop, not the
+        /// painting: a callback posted to a loop which is blocked is never dispatched whether
+        /// there is a window on screen or not, and AssertMessageLoopRunsAsync asks exactly
+        /// that. Unlike Button.PerformClick, ToolStripItem.PerformClick is not gated on
+        /// CanSelect, so the menu item can be clicked on a form which was never shown.
+        /// </remarks>
+        [Test]
+        [CancelAfter(kTimeout)]
+        public async Task DisconnectMenuItemLeavesTheWindowReacting(CancellationToken ct)
+        {
+            SampleClientUnderTest client = SampleClientFactories.All
+                .Single(entry => entry.Sample.Name == "Boiler");
+
+            SampleServerUnderTest server = SampleServerFactories.All
+                .Single(entry => entry.Sample.Name == client.Sample.Name);
+
+            await using SampleServerHost host = await SampleServerHost
+                .StartAsync(client.Sample.Name, server.Sample.ServerConfig, server.CreateServer, ct)
+                .ConfigureAwait(false);
+
+            await WinFormsHarness.RunAsync(
+                _ => ClickDisconnectAsync(client, host.EndpointUrl, ct),
+                TimeSpan.FromMilliseconds(kTimeout) - TimeSpan.FromSeconds(15))
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Runs on the STA thread of the harness, with a message loop pumping.
+        /// </summary>
+        private static async Task ClickDisconnectAsync(
+            SampleClientUnderTest client,
+            string endpointUrl,
+            CancellationToken ct)
+        {
+            using var pki = new TemporaryPki($"menu-{client.Sample.Name}");
+
+            ApplicationConfiguration configuration = await SampleConfigurationLoader
+                .LoadAsync(client.Sample.ClientConfig, pki, ct)
+                .ConfigureAwait(true);
+
+            configuration.TransportQuotas.OperationTimeout = kOperationTimeout;
+
+            await using var application = new ApplicationInstance(configuration, NullTelemetry.Instance);
+
+            Assert.That(
+                await application.CheckApplicationInstanceCertificatesAsync(true, null, ct).ConfigureAwait(true),
+                Is.True,
+                "The client certificate of the sample could not be created.");
+
+            using Form form = client.CreateMainForm(configuration, NullTelemetry.Instance);
+
+            // as in the loop above: a handle without a window, so the sample can marshal its
+            // callbacks back and the test can post to the message loop
+            _ = form.Handle;
+
+            ConnectServerCtrl connect = WinFormsHarness.GetConnectControl(form);
+
+            ISession session = await connect
+                .ConnectAsync(NullTelemetry.Instance, endpointUrl, false, 30_000, ct)
+                .ConfigureAwait(true);
+
+            Assert.That(session, Is.Not.Null, "The sample client did not create a session.");
+
+            await Task.Delay(s_postConnectGrace, ct).ConfigureAwait(true);
+
+            var disconnect = WinFormsHarness.FindField<ToolStripMenuItem>(form, "Server_DisconnectMI");
+
+            Assert.That(disconnect, Is.Not.Null, "The sample has no 'Server_DisconnectMI' menu item to click.");
+
+            // what the menu does. The handler of the sample is async void, so this comes back
+            // at its first await and everything below is what the click actually led to
+            disconnect.PerformClick();
+
+            await AssertMessageLoopRunsAsync(form, ct).ConfigureAwait(true);
+
+            Assert.That(
+                await WaitUntilAsync(() => connect.Session == null, ct).ConfigureAwait(true),
+                Is.True,
+                "Clicking Disconnect did not release the session of the sample client.");
+
+            Control display = WinFormsHarness.FindControl(form, client.EnabledAfterConnect);
+
+            Assert.That(
+                await WaitUntilAsync(() => !display.Enabled, ct).ConfigureAwait(true),
+                Is.True,
+                $"Clicking Disconnect left '{client.EnabledAfterConnect}' enabled, so the sample never " +
+                "cleared its display: the connect control did not report the disconnect.");
+
+            form.Close();
+        }
+
         private static async Task SmokeTestAsync(SampleClientUnderTest client, CancellationToken ct)
         {
             SampleServerUnderTest server = SampleServerFactories.All
@@ -287,11 +398,86 @@ namespace Opc.Ua.Samples.Tests
 
             phase.Enter("disconnecting");
 
-            await connect.DisconnectAsync(ct).ConfigureAwait(true);
+            // the synchronous entry point on purpose. It is the one the Disconnect menu item
+            // and the FormClosing handler of every sample use, and waiting there for a close
+            // which needs this very thread to finish deadlocked the message loop: the window
+            // disconnected and then froze. The asynchronous entry point never had that
+            // problem and is covered by the fixtures which drive a single client.
+            connect.Disconnect();
 
             Assert.That(connect.Session, Is.Null, "The sample client did not release its session on disconnect.");
 
+            phase.Enter("checking that its window still reacts");
+
+            await AssertMessageLoopRunsAsync(form, ct).ConfigureAwait(true);
+
+            if (client.EnabledAfterConnect != null)
+            {
+                Control control = WinFormsHarness.FindControl(form, client.EnabledAfterConnect);
+
+                // the samples clear their display from ConnectComplete, so the control going
+                // disabled again is what proves the disconnect got all the way through and
+                // did not stop at the close. A sample which handles the event with an await
+                // of its own gets there a message later, hence the wait rather than a look.
+                Assert.That(
+                    await WaitUntilAsync(() => !control.Enabled, ct).ConfigureAwait(true),
+                    Is.True,
+                    $"The sample did not disable '{client.EnabledAfterConnect}' again after disconnecting, " +
+                    "so the connect control never reported the disconnect and the display still shows a " +
+                    "session which is gone.");
+            }
+
+            phase.Enter("closing its main form");
+
+            // the other caller of the synchronous disconnect, and the one a user reaches by
+            // closing the window. FormClosing cannot await, so everything a sample tears down
+            // there has to come back without blocking this thread. If it does not, this call
+            // never returns and the harness reports the timeout against this phase.
+            form.Close();
+
             phase.Enter("shutting down");
+        }
+
+        /// <summary>
+        /// Checks that the message loop of the sample still dispatches what is posted to it,
+        /// which is what a user sees as a window that still reacts.
+        /// </summary>
+        private static async Task AssertMessageLoopRunsAsync(Form form, CancellationToken ct)
+        {
+            var pumped = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            form.BeginInvoke(new Action(() => pumped.TrySetResult(true)));
+
+            Task finished = await Task
+                .WhenAny(pumped.Task, Task.Delay(s_responsiveWithin, ct))
+                .ConfigureAwait(true);
+
+            Assert.That(
+                finished,
+                Is.SameAs(pumped.Task),
+                "The message loop of the sample did not dispatch a posted callback within " +
+                $"{s_responsiveWithin.TotalSeconds:F0} seconds, so its window is frozen.");
+        }
+
+        /// <summary>
+        /// Waits for a condition of the user interface, letting the message loop run while
+        /// it does.
+        /// </summary>
+        private static async Task<bool> WaitUntilAsync(Func<bool> condition, CancellationToken ct)
+        {
+            DateTime deadline = DateTime.UtcNow + s_responsiveWithin;
+
+            while (!condition())
+            {
+                if (DateTime.UtcNow > deadline)
+                {
+                    return false;
+                }
+
+                await Task.Delay(50, ct).ConfigureAwait(true);
+            }
+
+            return true;
         }
     }
 }

--- a/Workshop/AlarmCondition/Client/MainForm.cs
+++ b/Workshop/AlarmCondition/Client/MainForm.cs
@@ -297,7 +297,7 @@ namespace Quickstarts.AlarmConditionClient
         /// </summary>
         private void MainForm_FormClosing(object sender, FormClosingEventArgs e)
         {
-            DeleteSubscriptionAsync().GetAwaiter().GetResult();
+            ClientUtils.WaitForTeardown(DeleteSubscriptionAsync);
             ConnectServerCTRL.Disconnect();
         }
 

--- a/Workshop/Boiler/Client/MainForm.cs
+++ b/Workshop/Boiler/Client/MainForm.cs
@@ -248,7 +248,7 @@ namespace Quickstarts.Boiler.Client
         /// </summary>
         private void MainForm_FormClosing(object sender, FormClosingEventArgs e)
         {
-            DeleteSubscriptionAsync().GetAwaiter().GetResult();
+            ClientUtils.WaitForTeardown(DeleteSubscriptionAsync);
             ConnectServerCTRL.Disconnect();
         }
         #endregion

--- a/Workshop/DataAccess/Client/MainForm.cs
+++ b/Workshop/DataAccess/Client/MainForm.cs
@@ -257,7 +257,7 @@ namespace Quickstarts.DataAccessClient
         /// </summary>
         private void MainForm_FormClosing(object sender, FormClosingEventArgs e)
         {
-            DeleteSubscriptionAsync().GetAwaiter().GetResult();
+            ClientUtils.WaitForTeardown(DeleteSubscriptionAsync);
             ConnectServerCTRL.Disconnect();
         }
         #endregion

--- a/Workshop/Methods/Client/MainForm.cs
+++ b/Workshop/Methods/Client/MainForm.cs
@@ -289,7 +289,7 @@ namespace Quickstarts.MethodsClient
         /// </summary>
         private void MainForm_FormClosing(object sender, FormClosingEventArgs e)
         {
-            DeleteSubscriptionAsync().GetAwaiter().GetResult();
+            ClientUtils.WaitForTeardown(DeleteSubscriptionAsync);
             ConnectServerCTRL.Disconnect();
         }
         #endregion

--- a/Workshop/NodeManagement/Client/MainForm.cs
+++ b/Workshop/NodeManagement/Client/MainForm.cs
@@ -269,7 +269,7 @@ namespace Quickstarts.NodeManagement.Client
         {
             // the subscription goes first: closing a session which still carries one waits
             // for the publish pipeline to drain
-            DeleteSubscriptionAsync().GetAwaiter().GetResult();
+            ClientUtils.WaitForTeardown(DeleteSubscriptionAsync);
 
             ConnectServerCTRL.Disconnect();
         }

--- a/Workshop/SimpleEvents/Client/MainForm.cs
+++ b/Workshop/SimpleEvents/Client/MainForm.cs
@@ -218,7 +218,7 @@ namespace Quickstarts.SimpleEvents.Client
         /// </summary>
         private void MainForm_FormClosing(object sender, FormClosingEventArgs e)
         {
-            DeleteSubscriptionAsync().GetAwaiter().GetResult();
+            ClientUtils.WaitForTeardown(DeleteSubscriptionAsync);
             ConnectServerCTRL.Disconnect();
         }
         #endregion

--- a/Workshop/StateMachines/Client/MainForm.cs
+++ b/Workshop/StateMachines/Client/MainForm.cs
@@ -224,7 +224,7 @@ namespace Quickstarts.StateMachines.Client
         /// </summary>
         private void MainForm_FormClosing(object sender, FormClosingEventArgs e)
         {
-            StopWatchingAsync().GetAwaiter().GetResult();
+            ClientUtils.WaitForTeardown(StopWatchingAsync);
             ConnectServerCTRL.Disconnect();
         }
         #endregion

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -402,7 +402,7 @@ since the server started.
 
 ## What Tier 2 checks today
 
-54 test cases, about two and a half minutes, Windows only. For each WinForms sample client
+55 test cases, about two and a half minutes, Windows only. For each WinForms sample client
 the test starts its sample server in process, then on a dedicated STA thread with a running
 message loop - but without ever showing a window:
 
@@ -413,7 +413,20 @@ message loop - but without ever showing a window:
 - waits two seconds so the sample's `async void` ConnectComplete handler can run, and for
   the samples that have one, asserts the control it enables afterwards is enabled - which is
   the proof that the sample's own logic ran, not just the shared control
-- disconnects and asserts the session was released
+- disconnects through the **synchronous** `connect.Disconnect()`, which is the entry point
+  the samples themselves use, and asserts the session was released
+- asserts the message loop still dispatches a callback posted to it, and that the control the
+  sample enabled after connecting is disabled again - which is the proof the disconnect was
+  reported and not just performed
+- closes the form, so that the `FormClosing` handler of the sample, the other caller which
+  cannot await, is covered as well
+
+One case, `DisconnectMenuItemLeavesTheWindowReacting`, goes one step further out and clicks
+the sample's own `Server_DisconnectMI` rather than driving the control, so that the click
+handler of the sample - which disposes its subscription first and only then asks the control
+to disconnect - is on the path too. It uses the Boiler client, and `ToolStripItem.PerformClick`
+works on a form which was never shown because, unlike `Button.PerformClick`, it is not gated
+on `CanSelect`.
 
 ### Every client is now driven past connect
 
@@ -475,10 +488,19 @@ are collected in `SampleFormDriver`:
   something has to be read from the state the sample keeps - which is why the PerfTest case
   watches the update timer rather than the Stop button. `Enabled` is not affected.
 
-Two more, which apply to any fixture here: the synchronous `connect.Disconnect()` deadlocks
-because it blocks the UI thread on work which needs the same message loop, so every fixture
-awaits `connect.DisconnectAsync(ct)`; and `ListViewItem.Selected` does not reliably reach a
-list which was never displayed, so a row is selected through `SelectedIndices`.
+One more, which applies to any fixture here: `ListViewItem.Selected` does not reliably reach
+a list which was never displayed, so a row is selected through `SelectedIndices`.
+
+The synchronous `connect.Disconnect()` used to be on that list. It blocked the UI thread on a
+close whose continuation was posted back to the very message loop it was blocking, so every
+fixture awaited `connect.DisconnectAsync(ct)` instead - and that is precisely why no test ever
+saw the bug the samples were shipping. The menu item and the `FormClosing` handler of all of
+them call the synchronous one, and neither can await, so clicking Server, Disconnect
+disconnected the session and then froze the window for good. It is fixed in the control now
+rather than avoided here: `Disconnect()` runs the close on a thread pool thread, where there
+is no synchronization context to post a continuation back to, and raises ConnectComplete on
+the thread of the caller so the sample still clears its display on the UI thread. Tier 2
+drives that entry point on purpose, and closes the form afterwards.
 
 `SubscribeControlTests` covers what a connect alone does not: it drives the subscription
 wizard of the shared `SubscribeDataListViewCtrl` against the Reference server the way a user


### PR DESCRIPTION
## Proposed changes

Clicking **Server → Disconnect** in any of the WinForms sample clients disconnected the session and then froze the window permanently — it had to be killed. Reported against the AliasNames client, but it reproduces in all of them, because the defect is in the shared `ConnectServerCtrl`.

`ConnectServerCtrl.Disconnect()` blocked the UI thread on `InternalDisconnectAsync()`. Closing a session goes to the server, so that await went genuinely asynchronous and its continuation was posted to the WinForms `SynchronizationContext` — the very message loop the blocking wait was holding. Neither side could move again. The close itself usually reached the server, which is why the session did go away; only the rest of the method never ran, including the `DoConnectComplete` that tells the sample to clear its display.

`Disconnect()` now runs the close with `Task.Run`, on a thread pool thread where there is no synchronization context to post a continuation back to, and raises `ConnectComplete` afterwards **on the thread of the caller**.

Both halves matter, and it is worth saying why rather than taking it on faith:

- `ConfigureAwait(false)`, which this PR also adds through the disconnect path, turns out to be sufficient on its own today — the SDK does not capture the UI context inside `CloseAsync`/`DisposeAsync`. I measured that: with `Task.Run` removed but `ConfigureAwait(false)` kept, the new guard test passes in 6 s. But it only governs *our* awaits, so a change deeper in the SDK would silently bring the deadlock back. `Task.Run` cannot be undone that way, so both are kept.
- Raising `ConnectComplete` on the caller's thread keeps `DoConnectComplete` on its existing direct (`InvokeRequired == false`) path. An event that is only marshalled back with `BeginInvoke` would arrive at a form that `FormClosing` has already taken down.

**The same anti-pattern sat on the same path in the samples themselves.** `MainForm_FormClosing` in seven clients waited on `DeleteSubscriptionAsync()` (`StopWatchingAsync()` in StateMachines) *before* calling `Disconnect()`, so closing the window deadlocked before it ever reached the control. Fixing only the control would not have made window-close hang-free. Those now go through a new `ClientUtils.WaitForTeardown(Func<Task>)`; I checked each of those teardowns first, and none of them touch a control, so running them off the UI thread is safe.

## Related Issues

No issue number was filed for this one; it came in as a bug report against the AliasNames client. Note `Workshop/AliasNames` itself is not on this branch (it is part of #849), so its `ReleaseResolver()`, which has the same latent pattern, is untouched here.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Test enhancement (non-breaking change to increase test coverage)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines.
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.

## Further comments

### Why no test caught this, which is the part worth reviewing

Tier 2 only ever drove `connect.DisconnectAsync(ct)`, which is safe by way of its own `Task.Run`. Worse, `docs/TESTING.md` **documented the deadlock as a fixture convention** — "the synchronous `connect.Disconnect()` deadlocks … so every fixture awaits `connect.DisconnectAsync(ct)`". The workaround was written down as a testing rule instead of raised as a defect, which is exactly how a broken menu item shipped in eighteen sample clients.

Since `DisconnectAsync` is independently covered by six other fixtures, the per-client smoke test now drives the **synchronous** entry point the samples actually use. That costs no extra runtime — it is the same close, just a different entry point — and it additionally asserts that the message loop still dispatches a posted callback, that the sample re-disabled the control it enables after connecting (which is what proves `DoConnectComplete` ran), and then closes the form so the `FormClosing` path is covered as well. A new case, `DisconnectMenuItemLeavesTheWindowReacting`, clicks the sample's own `Server_DisconnectMI` so the sample's click handler is on the path too.

### The guard test is falsified, not merely green

A regression test that would also pass against the broken code is worthless, so I checked. Reverting the whole fix (`git checkout HEAD --` on the source files, keeping the test and doc changes) makes `DisconnectMenuItemLeavesTheWindowReacting` **fail at the 76 s harness timeout**; with the fix it passes in 6 s.

My first attempt at that check was invalid and is worth flagging for anyone repeating it: I had reverted only the `Task.Run` and left `ConfigureAwait(false)` in place, and the test passed for the wrong reason. Reverting a fix piecemeal can leave an independent half of it standing.

### Verification

- `dotnet build "UA Samples.slnx"` — 0 errors.
- `dotnet test Tests/SampleClients.Tests` — 55/55 passed, 2 m 32 s.
- Real GUI run: the actual Boiler client against the actual Boiler server, driven through UI Automation, with responsiveness judged by `SendMessageTimeout` + `SMTO_ABORTIFHUNG` (how Windows itself decides a window is hung):

```
after connect       responds=True  status='Connected [opc.tcp://localhost:62567/...]'  BoilerCB=enabled:True
after disconnect    responds=True  status='Disconnected'                               BoilerCB=enabled:False
5s later            responds=True  status='Disconnected'                               BoilerCB=enabled:False
closed cleanly = True
```

`BoilerCB` flipping to disabled is `DoConnectComplete` running, i.e. the display actually clearing.

### Left deliberately out of scope

The GDS client has its own cluster of five `GetAwaiter().GetResult()` calls, including one in `FormClosing`. It is a separate client with its own fixture and no `ConnectServerCtrl`, and widening into it would have muddied this change. Worth a follow-up, along with the AliasNames `ReleaseResolver()` once #849 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
