### PR TITLE
Press the state machine cause the tier 2 test meant to press

### DIFF
--- a/Tests/SampleClients.Tests/WorkshopClientSubscriptionTests.cs
+++ b/Tests/SampleClients.Tests/WorkshopClientSubscriptionTests.cs
@@ -345,8 +345,15 @@ namespace Opc.Ua.Samples.Tests
                 Is.False,
                 "Start is not declared for Off, so the client must not offer it there.");
 
-            // the click handler is an async void event handler, so there is nothing to await
-            powerOn.PerformClick();
+            // not through Button.PerformClick: that one is gated on CanSelect, which is false
+            // while no parent of the control is visible, so on the form this harness never
+            // shows it does nothing at all - no handler runs, and nothing fails either. The
+            // handler is an async void event handler, so there is nothing to await either way.
+            Assert.That(
+                SampleFormDriver.TryInvokeHandler(form, "OperationCauseBTN_ClickAsync", powerOn),
+                Is.True,
+                "The StateMachines client no longer has an 'OperationCauseBTN_ClickAsync'. " +
+                "Rename it here too.");
 
             // and once the machine is Idle the same button has to become available. The click
             // handler re-reads the attributes after its call returns, so this is a wait on the

--- a/Workshop/StateMachines/Client/MainForm.Designer.cs
+++ b/Workshop/StateMachines/Client/MainForm.Designer.cs
@@ -474,7 +474,7 @@ namespace Quickstarts.StateMachines.Client
             this.ConnectServerCTRL.UseSecurity = true;
             this.ConnectServerCTRL.ConnectComplete += new System.EventHandler(this.Server_ConnectCompleteAsync);
             this.ConnectServerCTRL.ReconnectStarting += new System.EventHandler(this.Server_ReconnectStarting);
-            this.ConnectServerCTRL.ReconnectComplete += new System.EventHandler(this.Server_ReconnectComplete);
+            this.ConnectServerCTRL.ReconnectComplete += new System.EventHandler(this.Server_ReconnectCompleteAsync);
             //
             // clientHeaderBranding1
             //

--- a/Workshop/StateMachines/Client/MainForm.cs
+++ b/Workshop/StateMachines/Client/MainForm.cs
@@ -203,7 +203,7 @@ namespace Quickstarts.StateMachines.Client
         /// <summary>
         /// Updates the application after reconnecting to the server.
         /// </summary>
-        private void Server_ReconnectComplete(object sender, EventArgs e)
+        private async void Server_ReconnectCompleteAsync(object sender, EventArgs e)
         {
             try
             {
@@ -212,6 +212,12 @@ namespace Quickstarts.StateMachines.Client
                 // keep running and there is nothing to re-create here.
                 m_session = ConnectServerCTRL.Session;
                 EnableControls(true);
+
+                // EnableControls only knows that there is a session again, so it offers every
+                // cause. Which of them the machines actually permit has to be read back before
+                // the user can press one, or this client offers a cause the server refuses -
+                // and the machine may well have moved while the connection was down.
+                await RefreshPermittedCausesAsync();
             }
             catch (Exception exception)
             {


### PR DESCRIPTION
## Proposed changes

`ClientReceivesItsNotifications(StateMachines)` fails on `master`. It stops on the assertion that
Start becomes available once the machine is Idle — but the machine was still in Off, because the
button was never actually pressed.

`Button.PerformClick` is gated on `CanSelect`, which is answered from the whole parent chain, and
the harness gives its forms window handles but never shows them. On those forms the call does
**nothing at all**: no handler runs, no exception, nothing fails. The test then waited out its 45
seconds on a client it had never asked to do anything, which reads exactly like a service call that
hung — the first guess was a `CallAsync` deadlock on a `ManagedSession` with a live V2 subscription.
It is not. Tracing the top of `OperationCauseBTN_ClickAsync` shows it is never entered; with the
handler invoked, that same call returns in milliseconds and the case passes in 7 s instead of
failing after 45.

`SampleFormDriver.TryInvokeHandler` exists for exactly this and documents the trap; the fixture just
did not use it. It does now, and asserts that the handler was found, so a rename fails loudly rather
than silently skipping the step. (`ToolStripItem.PerformClick` is *not* gated, which is why the menu
item clicks in the neighbouring fixtures work.)

### Why this only surfaced on preview.4

On `2.0.0-preview.2` the case passed without ever pressing anything. Tracing it there shows the
machine sitting in Off for the whole run and every `UserExecutable` read answering `Start=False` —
and `StartBTN` turning enabled anyway, seven seconds after the no-op click, with no read in between.
`StartBTN.Enabled` has exactly two writers, so that was `EnableControls(true)`, and the one in
`StartWatchingAsync` was long done by then: it came from `Server_ReconnectComplete`. A reconnect
re-enabled all six causes and the test read that as Start being offered.

That gap is real outside the test, so the sample is fixed too. `EnableControls` only knows that
there is a session again and offers every cause, which is the refusal this client was taught to
avoid in #831 — and the machine may well have moved while the connection was down. The reconnect
handler now re-reads the permitted causes after re-enabling the controls, and is renamed
`Server_ReconnectCompleteAsync` to match the other Workshop clients.

Nothing here is a client stack defect, so there is no upstream report and no `KnownIssue`.

## Related Issues

- Fixes #

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [x] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [x] I fixed all failing tests in the CI pipelines.
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

Verified locally:

- `dotnet build "UA Samples.slnx"` — 0 errors.
- `dotnet test Tests/SampleClients.Tests` — 59 passed, including all 7 subscription cases.
- `dotnet test Tests/SampleNodeManagers.Tests` — 153 passed, 1 pre-existing skip; the 10
  StateMachines tier 1.5 cases are unaffected.
- Drove the client through the full Operation cycle by hand: Off offers PowerOn only, Idle offers
  PowerOff and Start, Running offers Stop and Fault, and a cause forced in a state which does not
  declare it is refused rather than taken.

Worth a reviewer's attention: `PerformClick` on a `Button` is used in one other place in the tiers
(`SampleClientTests` line 271), on a `ToolStripMenuItem` — that one is fine, `ToolStripItem` does
not gate on `CanSelect`, and its fixture says so. No other `Button.PerformClick` remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
