### PR TITLE
Let both OnboardingClient generations call the hand-built GDS registrar

### DIFF
--- a/Samples/GDS/Common/DeviceRegistrarNodeManager.cs
+++ b/Samples/GDS/Common/DeviceRegistrarNodeManager.cs
@@ -74,10 +74,28 @@ namespace Opc.Ua.Gds.Server
             "http://opcfoundation.org/UA-.NETStandard-Samples/GDS/Onboarding/";
 
         /// <summary>
+        /// The namespace of the OPC 10000-21 Onboarding companion model, which the two
+        /// Method NodeIds are created in - see <see cref="CreateTicketMethod"/>. Spelled
+        /// out because the generated model constants are not part of every package version
+        /// this sample builds against.
+        /// </summary>
+        public const string OnboardingNamespaceUri = "http://opcfoundation.org/UA/Onboarding/";
+
+        /// <summary>
         /// BrowseName of the registrar administration Object, the node a client passes to
         /// <c>OnboardingClient</c>.
         /// </summary>
         public const string RegistrarBrowseName = "DeviceRegistrarAdmin";
+
+        /// <summary>
+        /// The type-declaration MethodIds of <c>DeviceRegistrarAdminType</c> in the
+        /// Onboarding companion model (<c>DeviceRegistrarAdminType_RegisterTickets</c> and
+        /// <c>DeviceRegistrarAdminType_UnregisterTickets</c>), spelled out because the
+        /// generated model constants are not part of every package version this sample
+        /// builds against.
+        /// </summary>
+        private const uint kRegisterTicketsTypeMethodId = 1176;
+        private const uint kUnregisterTicketsTypeMethodId = 1179;
 
         private readonly ITicketStore m_ticketStore;
 
@@ -89,10 +107,16 @@ namespace Opc.Ua.Gds.Server
             IServerInternal server,
             ApplicationConfiguration configuration,
             ITicketStore ticketStore)
-            : base(server, configuration, NamespaceUri)
+            : base(server, configuration, NamespaceUri, OnboardingNamespaceUri)
         {
             m_ticketStore = ticketStore ?? throw new ArgumentNullException(nameof(ticketStore));
         }
+
+        /// <summary>
+        /// The server table index of the Part 21 Onboarding namespace.
+        /// </summary>
+        private ushort OnboardingNamespaceIndex
+            => (ushort)SystemContext.NamespaceUris.GetIndex(OnboardingNamespaceUri);
 
         /// <inheritdoc/>
         public override async ValueTask CreateAddressSpaceAsync(
@@ -110,8 +134,14 @@ namespace Opc.Ua.Gds.Server
             };
             #pragma warning restore CA2000
 
-            MethodState register = CreateTicketMethod(registrar, "RegisterTickets");
-            MethodState unregister = CreateTicketMethod(registrar, "UnregisterTickets");
+            MethodState register = CreateTicketMethod(
+                registrar,
+                "RegisterTickets",
+                kRegisterTicketsTypeMethodId);
+            MethodState unregister = CreateTicketMethod(
+                registrar,
+                "UnregisterTickets",
+                kUnregisterTicketsTypeMethodId);
 
             registrar.AddChild(register);
             registrar.AddChild(unregister);
@@ -139,9 +169,14 @@ namespace Opc.Ua.Gds.Server
         /// </summary>
         /// <remarks>
         /// <para>
-        /// Two details are dictated by the SDK rather than by Part 21. The BrowseNames are
-        /// created in namespace 0, because <c>OnboardingClient</c> resolves the two Methods
-        /// with an ns=0 browse path and finds nothing otherwise. And the <c>Tickets</c>
+        /// Three details are dictated by the SDK rather than by Part 21, and they let both
+        /// client generations call the Methods. The NodeId is the type-declaration MethodId
+        /// of the Onboarding companion model, because the current generated
+        /// <c>OnboardingClient</c> calls that id on the wrapped instance directly - which
+        /// OPC UA Part 4 permits - and this hand-built registrar has no instantiated type to
+        /// answer for it otherwise. The BrowseName stays in namespace 0, because the earlier
+        /// <c>OnboardingClient</c> generation resolves the Methods with an ns=0 browse path.
+        /// And the <c>Tickets</c>
         /// argument is declared as a <c>ByteString</c> array rather than as the Part 21
         /// <c>EncodedTicket</c> alias: <c>MethodState</c> type-checks every input argument
         /// against the declared DataType, and ns=0 models <c>EncodedTicket</c> with
@@ -149,11 +184,11 @@ namespace Opc.Ua.Gds.Server
         /// actually exchange would be rejected with <c>Bad_TypeMismatch</c>.
         /// </para>
         /// </remarks>
-        private MethodState CreateTicketMethod(NodeState parent, string name)
+        private MethodState CreateTicketMethod(NodeState parent, string name, uint typeMethodId)
         {
             #pragma warning disable CA2000 // Justification: Node ownership is transferred to the server address space.
             var method = new MethodState(parent) {
-                NodeId = new NodeId(name, NamespaceIndex),
+                NodeId = new NodeId(typeMethodId, OnboardingNamespaceIndex),
                 BrowseName = new QualifiedName(name),
                 DisplayName = new LocalizedText(name),
                 ReferenceTypeId = ReferenceTypeIds.HasComponent,


### PR DESCRIPTION
## Proposed changes

The generated `OnboardingClient` changed how it reaches `RegisterTickets`/`UnregisterTickets` after the `2.0.0-preview.4` cut: it now calls the **type-declaration MethodId** of the Onboarding companion model on the wrapped instance directly (which OPC UA Part 4 §5.12.2.2 permits), and only falls back to a browse path **qualified with the Onboarding namespace**. The hand-built registrar of the GDS sample carries its Methods under sample-namespace NodeIds with **ns=0 BrowseNames** - the contract of the earlier client generation - so against the current GitHub Packages builds (verified on `2.0.280.50326-preview`) every ticket call answers `BadMethodInvalid`. On preview.4 it still works, which is why CI does not show it yet; the break surfaces with the next package bump.

The registrar now serves **both generations with the same two nodes**:

- the Method **NodeIds are the type-declaration ids** of the companion model (`DeviceRegistrarAdminType_RegisterTickets` = 1176, `DeviceRegistrarAdminType_UnregisterTickets` = 1179, in the Onboarding namespace, which the node manager brings into the server table) - so the current client's direct call lands with no fallback roundtrip, and
- the **BrowseNames stay in namespace 0** - which the earlier client generation's browse resolution expects.

The namespace URI and the two ids are spelled out as constants because the generated model constants (`Opc.Ua.Onboarding.*`) are not part of the preview.4 packages this repository builds against.

Verified on **both** package generations: at `2.0.0-preview.4` (this branch as-is) and at `2.0.280.50326-preview` (the same file on the #808 branch) the GDS client test registers and unregisters its onboarding ticket; the GDS tier 1 tests stay green.

Extracted from #808 so the fix is in master independently of the feed switch; #808 carries the identical file.

## Related Issues

- Extracted from #808; pre-empts the GDS ticket-call break the next package bump would surface

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines.
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

The alternative - qualifying the BrowseNames with the Onboarding namespace to satisfy the new client's fallback - was tried first and breaks the preview.4 client, whose browse resolution expects ns=0 names. Serving the type-declaration ids directly is both backward compatible and one roundtrip cheaper for the new client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
