### PR TITLE
Add sub state machines and the materialized Part 16 model to the StateMachines sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ These paired client/server samples each demonstrate a specific OPC UA feature se
 | [RoleManagement Client](Workshop/RoleManagement/Client) | **Client** | Connects as different accounts to see how the address space and the permissions change, and manages the RoleSet of the server. |
 | [SimpleEvents Server](Workshop/SimpleEvents/Server) | **Server** | Generates simple OPC UA events to demonstrate event subscriptions. |
 | [SimpleEvents Client](Workshop/SimpleEvents/Client) | **Client** | Subscribes to and displays simple events from an events server. |
-| [StateMachines Server](Workshop/StateMachines/Server) | **Server** | Demonstrates OPC UA Part 16 state machines: one declared with the fluent `StateMachineBuilder` (states, transitions, causes, guards, timed transitions) and the standard `ProgramStateMachineType` with behaviour attached to it. |
-| [StateMachines Client](Workshop/StateMachines/Client) | **Client** | Drives both state machines of a StateMachines server and streams their transitions as they happen. |
+| [StateMachines Server](Workshop/StateMachines/Server) | **Server** | Demonstrates OPC UA Part 16 state machines: one declared with the fluent `StateMachineBuilder` (states, transitions, causes, guards, timed transitions and a sub state machine below one of its states) and the standard `ProgramStateMachineType` with behaviour attached to it. |
+| [StateMachines Client](Workshop/StateMachines/Client) | **Client** | Drives both state machines of a StateMachines server, reads the states and transitions each of them declares, and streams the transitions of a machine and of its sub state machine as they happen. |
 | [UserAuthentication Server](Workshop/UserAuthentication/Server) | **Server** | Demonstrates OPC UA user authentication with username/password and certificate-based identity tokens. |
 | [UserAuthentication Client](Workshop/UserAuthentication/Client) | **Client** | Connects using different user identity tokens (anonymous, username, certificate) to a UserAuthentication server. |
 | [Views Server](Workshop/Views/Server) | **Server** | Demonstrates OPC UA Views — subsets of the address space exposed as named views. |

--- a/Tests/SampleClients.Tests/WorkshopClientSubscriptionTests.cs
+++ b/Tests/SampleClients.Tests/WorkshopClientSubscriptionTests.cs
@@ -365,6 +365,56 @@ namespace Opc.Ua.Samples.Tests
                 Is.True,
                 "Start is declared for Idle, so the client has to offer it once the machine " +
                 "has been powered on.");
+
+            // the client also reads the model of the machine - a row per state and per
+            // transition - which a server materializes only if it exposes AvailableStates and
+            // AvailableTransitions.
+            Assert.That(
+                HasRows(form, "ModelLV"),
+                Is.True,
+                "The StateMachines client did not read the states and transitions of the " +
+                "machine, so the server does not publish them.");
+
+            // Running has a machine of its own below it, which is suspended until the parent
+            // gets there: the client offers its cause only once it is active.
+            var startBatch = (Button)WinFormsHarness.FindControl(form, "StartBatchBTN");
+
+            Assert.That(
+                startBatch,
+                Is.Not.Null,
+                "The StateMachines client no longer has a 'StartBatchBTN'. Rename it here too.");
+
+            Assert.That(
+                startBatch.Enabled,
+                Is.False,
+                "The sub state machine is not active while the machine is Idle, so none of " +
+                "its causes may be offered.");
+
+            SampleFormDriver.TryInvokeHandler(form, "OperationCauseBTN_ClickAsync", start);
+
+            bool producing = await WaitAsync(() => startBatch.Enabled, ct).ConfigureAwait(true);
+
+            Assert.That(
+                producing,
+                Is.True,
+                "Entering Running has to activate the sub state machine, and the client has " +
+                "to offer the cause of the machine it activated.");
+
+            Control production = WinFormsHarness.FindControl(form, "ProductionStateTB");
+
+            Assert.That(
+                production,
+                Is.Not.Null,
+                "The StateMachines client no longer has a 'ProductionStateTB'. Rename it here too.");
+
+            bool loading = await WaitAsync(() => production.Text == "Loading", ct)
+                .ConfigureAwait(true);
+
+            Assert.That(
+                loading,
+                Is.True,
+                "The client has to show the state of the sub state machine, which starts over " +
+                $"in Loading whenever the parent enters Running. It showed '{production.Text}'.");
         }
 
         /// <summary>

--- a/Tests/SampleNodeManagers.Tests/StateMachinesNodeManagerTests.cs
+++ b/Tests/SampleNodeManagers.Tests/StateMachinesNodeManagerTests.cs
@@ -117,12 +117,16 @@ namespace Opc.Ua.Samples.Tests
                     "The machine object lost one of its children.");
 
                 // CurrentState is what a client reads, LastTransition what it subscribes to,
-                // and the six methods are the causes of the declared transitions.
+                // the six methods are the causes of the declared transitions, the two
+                // Available* properties list the model of the machine, and Production is the
+                // machine which runs below the Running state.
                 Assert.That(
                     operationChildren,
                     Is.SupersetOf(new[] {
                         "CurrentState", "LastTransition",
                         "PowerOn", "PowerOff", "Start", "Stop", "Fault", "Reset",
+                        "AvailableStates", "AvailableTransitions",
+                        "Production",
                     }),
                     "The Operation state machine lost a child.");
 
@@ -159,6 +163,310 @@ namespace Opc.Ua.Samples.Tests
                     Is.EqualTo(offNode),
                     "CurrentState/Id has to name the state node of the machine's own namespace.");
             });
+        }
+
+        /// <summary>
+        /// Every state and every transition the sample declared is a node a client can browse
+        /// to, and the machine lists them through the two optional Available properties.
+        /// </summary>
+        /// <remarks>
+        /// A machine which materializes none of them can only be read: <c>CurrentState/Id</c>
+        /// names a node which does not exist, <c>GetAvailableStatesAsync</c> and
+        /// <c>GetAvailableTransitionsAsync</c> answer nothing, and a state has nowhere to hang
+        /// a sub state machine off. The builder mints the nodes from the declaration, so the
+        /// sample declares its machine once and serves the whole Part 16 model of it.
+        /// </remarks>
+        [Test]
+        [CancelAfter(kTimeout)]
+        public async Task OperationMachineMaterializesItsStatesAndTransitions(CancellationToken ct)
+        {
+            NodeId operationId = await OperationNodeAsync(ct).ConfigureAwait(false);
+
+            IReadOnlyList<NodeId> availableStates = await ReadNodeIdsAsync(
+                operationId,
+                BrowseNames.AvailableStates,
+                ct).ConfigureAwait(false);
+
+            IReadOnlyList<NodeId> availableTransitions = await ReadNodeIdsAsync(
+                operationId,
+                BrowseNames.AvailableTransitions,
+                ct).ConfigureAwait(false);
+
+            // the declared model, in declaration order, and the number each element carries
+            var states = new (string Name, uint Number)[] {
+                ("Off", StateMachinesNodeManager.OffState),
+                ("Idle", StateMachinesNodeManager.IdleState),
+                ("Running", StateMachinesNodeManager.RunningState),
+                ("Faulted", StateMachinesNodeManager.FaultedState),
+            };
+
+            var transitions = new (string Name, uint Number)[] {
+                ("OffToIdle", StateMachinesNodeManager.OffToIdleTransition),
+                ("IdleToOff", StateMachinesNodeManager.IdleToOffTransition),
+                ("IdleToRunning", StateMachinesNodeManager.IdleToRunningTransition),
+                ("RunningToIdle", StateMachinesNodeManager.RunningToIdleTransition),
+                ("RunningToFaulted", StateMachinesNodeManager.RunningToFaultedTransition),
+                ("FaultedToIdle", StateMachinesNodeManager.FaultedToIdleTransition),
+            };
+
+            await AssertElementsAsync(
+                operationId,
+                availableStates,
+                states,
+                BrowseNames.StateNumber,
+                BrowseNames.AvailableStates,
+                ct).ConfigureAwait(false);
+
+            await AssertElementsAsync(
+                operationId,
+                availableTransitions,
+                transitions,
+                BrowseNames.TransitionNumber,
+                BrowseNames.AvailableTransitions,
+                ct).ConfigureAwait(false);
+
+            // OPC 10000-16 §4.4.10: the state a machine activates into is an InitialStateType,
+            // which is how a client tells it apart from the other states.
+            NodeId offNode = await OperationStateNodeAsync("Off", ct).ConfigureAwait(false);
+            NodeId idleNode = await OperationStateNodeAsync("Idle", ct).ConfigureAwait(false);
+
+            NodeId offType = await SessionOps
+                .GetTypeDefinitionAsync(Session, offNode, ct).ConfigureAwait(false);
+            NodeId idleType = await SessionOps
+                .GetTypeDefinitionAsync(Session, idleNode, ct).ConfigureAwait(false);
+
+            Assert.Multiple(() => {
+                Assert.That(
+                    offType,
+                    Is.EqualTo(ObjectTypeIds.InitialStateType),
+                    "The initial state has to be an InitialStateType.");
+
+                Assert.That(
+                    idleType,
+                    Is.EqualTo(ObjectTypeIds.StateType),
+                    "Every other state is a StateType.");
+            });
+        }
+
+        /// <summary>
+        /// A transition node names the two states it runs between, the event it reports and
+        /// the method which causes it, the way OPC 10000-16 §4.4.11 asks for.
+        /// </summary>
+        /// <remarks>
+        /// This is what a client needs to draw the machine without knowing it: the states come
+        /// from AvailableStates, and the transitions between them from the FromState / ToState
+        /// references of the nodes AvailableTransitions names. HasCause adds which method call
+        /// takes each of them, which is more than the Executable attribute says - that one only
+        /// answers for the state the machine is in right now.
+        /// </remarks>
+        [Test]
+        [CancelAfter(kTimeout)]
+        public async Task TransitionNodesCarryTheirEndpointsCauseAndEffect(CancellationToken ct)
+        {
+            NodeId operationId = await OperationNodeAsync(ct).ConfigureAwait(false);
+            NodeId idleToRunning = await ChildAsync(operationId, "IdleToRunning", ct)
+                .ConfigureAwait(false);
+
+            NodeId idleNode = await OperationStateNodeAsync("Idle", ct).ConfigureAwait(false);
+            NodeId runningNode = await OperationStateNodeAsync("Running", ct).ConfigureAwait(false);
+            NodeId startMethod = await ChildAsync(operationId, "Start", ct).ConfigureAwait(false);
+
+            IReadOnlyList<NodeId> fromState = await TargetsAsync(
+                idleToRunning, ReferenceTypeIds.FromState, ct).ConfigureAwait(false);
+            IReadOnlyList<NodeId> toState = await TargetsAsync(
+                idleToRunning, ReferenceTypeIds.ToState, ct).ConfigureAwait(false);
+            IReadOnlyList<NodeId> hasCause = await TargetsAsync(
+                idleToRunning, ReferenceTypeIds.HasCause, ct).ConfigureAwait(false);
+            IReadOnlyList<NodeId> hasEffect = await TargetsAsync(
+                idleToRunning, ReferenceTypeIds.HasEffect, ct).ConfigureAwait(false);
+
+            Assert.Multiple(() => {
+                Assert.That(
+                    fromState,
+                    Is.EqualTo(new[] { idleNode }),
+                    "IdleToRunning has to start at the Idle state node.");
+                Assert.That(
+                    toState,
+                    Is.EqualTo(new[] { runningNode }),
+                    "IdleToRunning has to end at the Running state node.");
+                Assert.That(
+                    hasCause,
+                    Is.EqualTo(new[] { startMethod }),
+                    "The cause of IdleToRunning is the Start method the sample bound to it.");
+                Assert.That(
+                    hasEffect,
+                    Is.EqualTo(new[] { ObjectTypeIds.TransitionEventType }),
+                    "A transition reports a TransitionEventType, and says so with HasEffect.");
+            });
+        }
+
+        /// <summary>
+        /// The Running state has a machine of its own below it, referenced the way OPC
+        /// 10000-16 §4.4.16 asks for: from the state node rather than from the machine.
+        /// </summary>
+        [Test]
+        [CancelAfter(kTimeout)]
+        public async Task RunningStateOwnsTheProductionSubStateMachine(CancellationToken ct)
+        {
+            NodeId operationId = await OperationNodeAsync(ct).ConfigureAwait(false);
+            NodeId runningNode = await OperationStateNodeAsync("Running", ct).ConfigureAwait(false);
+            NodeId productionId = await ProductionNodeAsync(ct).ConfigureAwait(false);
+
+            IReadOnlyList<NodeId> fromState = await TargetsAsync(
+                runningNode, ReferenceTypeIds.HasSubStateMachine, ct).ConfigureAwait(false);
+            IReadOnlyList<NodeId> fromMachine = await TargetsAsync(
+                operationId, ReferenceTypeIds.HasSubStateMachine, ct).ConfigureAwait(false);
+
+            IReadOnlyList<string> productionChildren = await BrowseNamesAsync(productionId, ct)
+                .ConfigureAwait(false);
+
+            await ReportAsync("Production", productionChildren).ConfigureAwait(false);
+
+            Assert.Multiple(() => {
+                Assert.That(
+                    fromState,
+                    Is.EqualTo(new[] { productionId }),
+                    "The sub state machine hangs off the state it belongs to.");
+
+                Assert.That(
+                    fromMachine,
+                    Is.Empty,
+                    "A sub state machine is not referenced from the machine root: a client " +
+                    "which browsed it there could not tell which state it belongs to.");
+
+                // the child is a machine like any other: its own states, its own transitions,
+                // its own cause method and the two variables which report where it is.
+                Assert.That(
+                    productionChildren,
+                    Is.SupersetOf(new[] {
+                        "CurrentState", "LastTransition",
+                        "Loading", "Processing", "Unloading",
+                        "LoadingToProcessing", "ProcessingToUnloading", "UnloadingToLoading",
+                        "AvailableStates", "AvailableTransitions",
+                        "StartBatch",
+                    }),
+                    "The Production state machine lost a child.");
+            });
+        }
+
+        /// <summary>
+        /// The Production machine only exists while the Operation machine is Running: outside
+        /// of it there is no state to read and no cause to call.
+        /// </summary>
+        /// <remarks>
+        /// OPC 10000-16 §4.4.6 has an inactive sub state machine report its state variables
+        /// with <see cref="StatusCodes.BadStateNotActive"/> rather than with a stale value, so
+        /// that a client cannot mistake where the child stopped for where it is. The framework
+        /// applies it from the parent's transitions - the sample declares which state the child
+        /// belongs to and writes none of it.
+        /// </remarks>
+        [Test]
+        [CancelAfter(kTimeout)]
+        public async Task ProductionMachineIsNotActiveWhileTheMachineIsNotRunning(CancellationToken ct)
+        {
+            // the fixture left the Operation machine in Off, which is not the state the
+            // Production machine belongs to
+            DataValue suspended = await ReadProductionStateAsync(ct).ConfigureAwait(false);
+            CallMethodResult refused = await CallStartBatchRawAsync(ct).ConfigureAwait(false);
+
+            await TestContext.Out
+                .WriteLineAsync(
+                    $"Production/CurrentState while Off -> {suspended.StatusCode}, " +
+                    $"StartBatch() -> {refused.StatusCode}")
+                .ConfigureAwait(false);
+
+            Assert.Multiple(() => {
+                Assert.That(
+                    suspended.StatusCode,
+                    Is.EqualTo((StatusCode)StatusCodes.BadStateNotActive),
+                    "The state of a suspended sub state machine has to read Bad_StateNotActive.");
+
+                Assert.That(
+                    refused.StatusCode,
+                    Is.EqualTo((StatusCode)StatusCodes.BadNotExecutable),
+                    "A cause of a suspended sub state machine must not be executable.");
+            });
+
+            await CallOperationAsync(StateMachinesNodeManager.PowerOnCause, ct).ConfigureAwait(false);
+            await CallOperationAsync(StateMachinesNodeManager.StartCause, ct).ConfigureAwait(false);
+
+            DataValue active = await ReadProductionStateAsync(ct).ConfigureAwait(false);
+
+            Assert.Multiple(() => {
+                Assert.That(
+                    StatusCode.IsGood(active.StatusCode),
+                    Is.True,
+                    $"Entering Running has to activate the child: {active.StatusCode}");
+
+                Assert.That(
+                    StateName(active),
+                    Is.EqualTo("Loading"),
+                    "An activated sub state machine enters the state it declared as its initial one.");
+            });
+
+            await CallOperationAsync(StateMachinesNodeManager.StopCause, ct).ConfigureAwait(false);
+
+            Assert.That(
+                (await ReadProductionStateAsync(ct).ConfigureAwait(false)).StatusCode,
+                Is.EqualTo((StatusCode)StatusCodes.BadStateNotActive),
+                "Leaving Running has to suspend the child again.");
+        }
+
+        /// <summary>
+        /// The Production machine runs a batch of its own while the Operation machine stays in
+        /// one state, and starts over when the parent leaves Running and comes back.
+        /// </summary>
+        [Test]
+        [CancelAfter(kTimeout)]
+        public async Task ProductionMachineRunsABatchAndStartsOverOnReentry(CancellationToken ct)
+        {
+            await CallOperationAsync(StateMachinesNodeManager.PowerOnCause, ct).ConfigureAwait(false);
+            await CallOperationAsync(StateMachinesNodeManager.StartCause, ct).ConfigureAwait(false);
+
+            await CallStartBatchAsync(ct).ConfigureAwait(false);
+
+            Assert.That(
+                await ReadProductionStateNameAsync(ct).ConfigureAwait(false),
+                Is.EqualTo("Processing"),
+                "StartBatch has to move the child out of Loading.");
+
+            // the rest of the batch is the child's own business: two timed transitions carry it
+            // through unloading and back to Loading while the parent stays in Running.
+            string unloading = await Poll.UntilAsync(
+                token => ReadProductionStateNameAsync(token),
+                state => state == "Unloading",
+                "the batch to be processed",
+                timeout: StateMachinesNodeManager.BatchDuration + TimeSpan.FromSeconds(20),
+                ct: ct).ConfigureAwait(false);
+
+            string loading = await Poll.UntilAsync(
+                token => ReadProductionStateNameAsync(token),
+                state => state == "Loading",
+                "the batch to be unloaded",
+                timeout: StateMachinesNodeManager.UnloadDuration + TimeSpan.FromSeconds(20),
+                ct: ct).ConfigureAwait(false);
+
+            Assert.Multiple(() => {
+                Assert.That(unloading, Is.EqualTo("Unloading"));
+                Assert.That(loading, Is.EqualTo("Loading"));
+            });
+
+            // the parent stays where it is through all of that
+            Assert.That(
+                await ReadOperationStateNameAsync(ct).ConfigureAwait(false),
+                Is.EqualTo("Running"),
+                "A transition of the child must not move the parent.");
+
+            // and a run which is interrupted starts over rather than resuming: that is what
+            // the sample asked for with preserveOnReentry: false.
+            await CallStartBatchAsync(ct).ConfigureAwait(false);
+            await CallOperationAsync(StateMachinesNodeManager.StopCause, ct).ConfigureAwait(false);
+            await CallOperationAsync(StateMachinesNodeManager.StartCause, ct).ConfigureAwait(false);
+
+            Assert.That(
+                await ReadProductionStateNameAsync(ct).ConfigureAwait(false),
+                Is.EqualTo("Loading"),
+                "The child has to start over when the parent re-enters Running.");
         }
 
         /// <summary>
@@ -495,6 +803,120 @@ namespace Opc.Ua.Samples.Tests
             return ResolveAsync(ct, Machine, Operation);
         }
 
+        /// <summary>
+        /// The sub state machine which runs below the Running state.
+        /// </summary>
+        private async Task<NodeId> ProductionNodeAsync(CancellationToken ct)
+        {
+            NodeId operationId = await OperationNodeAsync(ct).ConfigureAwait(false);
+
+            return await ChildAsync(operationId, "Production", ct).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Reads a NodeId array property of a node - AvailableStates or AvailableTransitions.
+        /// </summary>
+        private async Task<IReadOnlyList<NodeId>> ReadNodeIdsAsync(
+            NodeId parent,
+            string browseName,
+            CancellationToken ct)
+        {
+            NodeId listId = await ChildAsync(parent, browseName, ct).ConfigureAwait(false);
+
+            DataValue value = await SessionOps.ReadValueAsync(Session, listId, ct)
+                .ConfigureAwait(false);
+
+            Assert.That(
+                StatusCode.IsGood(value.StatusCode),
+                Is.True,
+                $"Reading {browseName} failed: {value.StatusCode}");
+
+            return value.WrappedValue.TryGetValue(out ArrayOf<NodeId> nodes)
+                ? nodes.ToArray()
+                : [];
+        }
+
+        /// <summary>
+        /// Holds the states or the transitions of a machine to what the sample declared: the
+        /// Available property lists exactly the nodes below the machine, in declaration order,
+        /// and each of them carries the number the sample gave it.
+        /// </summary>
+        private async Task AssertElementsAsync(
+            NodeId machineId,
+            IReadOnlyList<NodeId> available,
+            IReadOnlyList<(string Name, uint Number)> declared,
+            string numberBrowseName,
+            string what,
+            CancellationToken ct)
+        {
+            var browsed = new List<NodeId>(declared.Count);
+            var numbers = new List<uint>(declared.Count);
+
+            foreach ((string name, uint _) in declared)
+            {
+                NodeId elementId = await ChildAsync(machineId, name, ct).ConfigureAwait(false);
+
+                browsed.Add(elementId);
+                numbers.Add(await ReadElementNumberAsync(elementId, numberBrowseName, ct)
+                    .ConfigureAwait(false));
+            }
+
+            await ReportAsync(
+                what,
+                declared.Select((element, index) => $"{element.Name}={numbers[index]}"))
+                .ConfigureAwait(false);
+
+            Assert.Multiple(() => {
+                Assert.That(
+                    available,
+                    Is.EqualTo(browsed),
+                    $"{what} has to list the nodes of the machine, in declaration order.");
+
+                Assert.That(
+                    numbers,
+                    Is.EqualTo(declared.Select(element => element.Number)),
+                    $"Every node has to carry its {numberBrowseName}.");
+            });
+        }
+
+        private async Task<uint> ReadElementNumberAsync(
+            NodeId elementId,
+            string numberBrowseName,
+            CancellationToken ct)
+        {
+            NodeId numberId = await ChildAsync(elementId, numberBrowseName, ct)
+                .ConfigureAwait(false);
+
+            DataValue value = await SessionOps.ReadValueAsync(Session, numberId, ct)
+                .ConfigureAwait(false);
+
+            return value.WrappedValue.ConvertTo(BuiltInType.UInt32).TryGetValue(out uint number)
+                ? number
+                : 0;
+        }
+
+        /// <summary>
+        /// The nodes one non hierarchical reference of a node points at.
+        /// </summary>
+        private async Task<IReadOnlyList<NodeId>> TargetsAsync(
+            NodeId nodeId,
+            NodeId referenceTypeId,
+            CancellationToken ct)
+        {
+            IReadOnlyList<ReferenceDescription> references = await SessionOps
+                .BrowseAsync(
+                    Session,
+                    nodeId,
+                    ct,
+                    referenceTypeId: referenceTypeId,
+                    includeSubtypes: false)
+                .ConfigureAwait(false);
+
+            return references
+                .Select(reference => ExpandedNodeId.ToNodeId(reference.NodeId, Session.NamespaceUris))
+                .ToArray();
+        }
+
         private Task<NodeId> ProgramNodeAsync(CancellationToken ct)
         {
             return ResolveAsync(ct, Machine, Program);
@@ -520,6 +942,29 @@ namespace Opc.Ua.Samples.Tests
                 .ConfigureAwait(false);
 
             return value.WrappedValue.TryGetValue(out LocalizedText text) ? text.Text : null;
+        }
+
+        /// <summary>
+        /// Reads CurrentState of the Production machine, status code and all: while the child
+        /// is suspended the status is what carries the answer.
+        /// </summary>
+        private async Task<DataValue> ReadProductionStateAsync(CancellationToken ct)
+        {
+            NodeId productionId = await ProductionNodeAsync(ct).ConfigureAwait(false);
+            NodeId stateId = await ChildAsync(productionId, BrowseNames.CurrentState, ct)
+                .ConfigureAwait(false);
+
+            return await SessionOps.ReadValueAsync(Session, stateId, ct).ConfigureAwait(false);
+        }
+
+        private async Task<string> ReadProductionStateNameAsync(CancellationToken ct)
+        {
+            return StateName(await ReadProductionStateAsync(ct).ConfigureAwait(false));
+        }
+
+        private static string StateName(DataValue state)
+        {
+            return state.WrappedValue.TryGetValue(out LocalizedText text) ? text.Text : null;
         }
 
         private async Task<NodeId> ReadOperationStateIdAsync(CancellationToken ct)
@@ -631,6 +1076,39 @@ namespace Opc.Ua.Samples.Tests
                 StatusCode.IsGood(result.StatusCode),
                 Is.True,
                 $"Calling the cause {causeId} failed: {result.StatusCode}");
+        }
+
+        /// <summary>
+        /// Calls the cause of the Production machine and reports the result.
+        /// </summary>
+        /// <remarks>
+        /// The method belongs to the sub state machine rather than to the Operation machine,
+        /// so it is called on the child object: Part 4 has the object of a Call name the node
+        /// the method is a child of.
+        /// </remarks>
+        private async Task<CallMethodResult> CallStartBatchRawAsync(CancellationToken ct)
+        {
+            NodeId productionId = await ProductionNodeAsync(ct).ConfigureAwait(false);
+
+            return await SessionOps
+                .CallAsync(
+                    Session,
+                    productionId,
+                    new NodeId(
+                        StateMachinesNodeManager.StartBatchCause,
+                        NamespaceIndex(StateMachinesNamespace)),
+                    ct)
+                .ConfigureAwait(false);
+        }
+
+        private async Task CallStartBatchAsync(CancellationToken ct)
+        {
+            CallMethodResult result = await CallStartBatchRawAsync(ct).ConfigureAwait(false);
+
+            Assert.That(
+                StatusCode.IsGood(result.StatusCode),
+                Is.True,
+                $"Calling StartBatch failed: {result.StatusCode}");
         }
 
         /// <summary>

--- a/Workshop/StateMachines/Client/MainForm.Designer.cs
+++ b/Workshop/StateMachines/Client/MainForm.Designer.cs
@@ -71,6 +71,9 @@ namespace Quickstarts.StateMachines.Client
             this.OperationStateTB = new System.Windows.Forms.TextBox();
             this.OperationTransitionLB = new System.Windows.Forms.Label();
             this.OperationTransitionTB = new System.Windows.Forms.TextBox();
+            this.ProductionStateLB = new System.Windows.Forms.Label();
+            this.ProductionStateTB = new System.Windows.Forms.TextBox();
+            this.StartBatchBTN = new System.Windows.Forms.Button();
             this.InterlockCB = new System.Windows.Forms.CheckBox();
             this.PowerOnBTN = new System.Windows.Forms.Button();
             this.PowerOffBTN = new System.Windows.Forms.Button();
@@ -93,6 +96,12 @@ namespace Quickstarts.StateMachines.Client
             this.MachineCH = new System.Windows.Forms.ColumnHeader();
             this.StateCH = new System.Windows.Forms.ColumnHeader();
             this.TransitionCH = new System.Windows.Forms.ColumnHeader();
+            this.ModelLV = new System.Windows.Forms.ListView();
+            this.KindCH = new System.Windows.Forms.ColumnHeader();
+            this.ElementCH = new System.Windows.Forms.ColumnHeader();
+            this.NumberCH = new System.Windows.Forms.ColumnHeader();
+            this.ElementNodeCH = new System.Windows.Forms.ColumnHeader();
+            this.SubMachineCH = new System.Windows.Forms.ColumnHeader();
             this.ConnectServerCTRL = new Opc.Ua.Client.Controls.ConnectServerCtrl();
             this.clientHeaderBranding1 = new Opc.Ua.Client.Controls.HeaderBranding();
             this.MenuBar.SuspendLayout();
@@ -167,13 +176,14 @@ namespace Quickstarts.StateMachines.Client
             // MainPN
             //
             this.MainPN.Controls.Add(this.TransitionsLV);
+            this.MainPN.Controls.Add(this.ModelLV);
             this.MainPN.Controls.Add(this.ProgramGB);
             this.MainPN.Controls.Add(this.OperationGB);
             this.MainPN.Dock = System.Windows.Forms.DockStyle.Fill;
             this.MainPN.Location = new System.Drawing.Point(0, 122);
             this.MainPN.Name = "MainPN";
             this.MainPN.Padding = new System.Windows.Forms.Padding(2, 2, 2, 0);
-            this.MainPN.Size = new System.Drawing.Size(884, 402);
+            this.MainPN.Size = new System.Drawing.Size(884, 496);
             this.MainPN.TabIndex = 3;
             //
             // OperationGB
@@ -185,13 +195,16 @@ namespace Quickstarts.StateMachines.Client
             this.OperationGB.Controls.Add(this.PowerOffBTN);
             this.OperationGB.Controls.Add(this.PowerOnBTN);
             this.OperationGB.Controls.Add(this.InterlockCB);
+            this.OperationGB.Controls.Add(this.StartBatchBTN);
+            this.OperationGB.Controls.Add(this.ProductionStateTB);
+            this.OperationGB.Controls.Add(this.ProductionStateLB);
             this.OperationGB.Controls.Add(this.OperationTransitionTB);
             this.OperationGB.Controls.Add(this.OperationTransitionLB);
             this.OperationGB.Controls.Add(this.OperationStateTB);
             this.OperationGB.Controls.Add(this.OperationStateLB);
             this.OperationGB.Location = new System.Drawing.Point(8, 8);
             this.OperationGB.Name = "OperationGB";
-            this.OperationGB.Size = new System.Drawing.Size(430, 172);
+            this.OperationGB.Size = new System.Drawing.Size(430, 190);
             this.OperationGB.TabIndex = 1;
             this.OperationGB.TabStop = false;
             this.OperationGB.Text = "Operation - declared with the builder";
@@ -230,16 +243,44 @@ namespace Quickstarts.StateMachines.Client
             this.OperationTransitionTB.Size = new System.Drawing.Size(150, 20);
             this.OperationTransitionTB.TabIndex = 3;
             //
+            // ProductionStateLB
+            //
+            this.ProductionStateLB.AutoSize = true;
+            this.ProductionStateLB.Location = new System.Drawing.Point(12, 78);
+            this.ProductionStateLB.Name = "ProductionStateLB";
+            this.ProductionStateLB.Size = new System.Drawing.Size(85, 13);
+            this.ProductionStateLB.TabIndex = 4;
+            this.ProductionStateLB.Text = "Production state";
+            //
+            // ProductionStateTB
+            //
+            this.ProductionStateTB.Location = new System.Drawing.Point(110, 75);
+            this.ProductionStateTB.Name = "ProductionStateTB";
+            this.ProductionStateTB.ReadOnly = true;
+            this.ProductionStateTB.Size = new System.Drawing.Size(150, 20);
+            this.ProductionStateTB.TabIndex = 5;
+            //
+            // StartBatchBTN
+            //
+            this.StartBatchBTN.Enabled = false;
+            this.StartBatchBTN.Location = new System.Drawing.Point(270, 73);
+            this.StartBatchBTN.Name = "StartBatchBTN";
+            this.StartBatchBTN.Size = new System.Drawing.Size(90, 23);
+            this.StartBatchBTN.TabIndex = 6;
+            this.StartBatchBTN.Text = "StartBatch";
+            this.StartBatchBTN.UseVisualStyleBackColor = true;
+            this.StartBatchBTN.Click += new System.EventHandler(this.StartBatchBTN_ClickAsync);
+            //
             // InterlockCB
             //
             this.InterlockCB.AutoSize = true;
             this.InterlockCB.Checked = true;
             this.InterlockCB.CheckState = System.Windows.Forms.CheckState.Checked;
             this.InterlockCB.Enabled = false;
-            this.InterlockCB.Location = new System.Drawing.Point(15, 79);
+            this.InterlockCB.Location = new System.Drawing.Point(15, 104);
             this.InterlockCB.Name = "InterlockCB";
             this.InterlockCB.Size = new System.Drawing.Size(200, 17);
-            this.InterlockCB.TabIndex = 4;
+            this.InterlockCB.TabIndex = 7;
             this.InterlockCB.Text = "Safety interlock clear (guards Start)";
             this.InterlockCB.UseVisualStyleBackColor = true;
             this.InterlockCB.CheckedChanged += new System.EventHandler(this.InterlockCB_CheckedChangedAsync);
@@ -247,10 +288,10 @@ namespace Quickstarts.StateMachines.Client
             // PowerOnBTN
             //
             this.PowerOnBTN.Enabled = false;
-            this.PowerOnBTN.Location = new System.Drawing.Point(15, 106);
+            this.PowerOnBTN.Location = new System.Drawing.Point(15, 130);
             this.PowerOnBTN.Name = "PowerOnBTN";
             this.PowerOnBTN.Size = new System.Drawing.Size(75, 23);
-            this.PowerOnBTN.TabIndex = 5;
+            this.PowerOnBTN.TabIndex = 8;
             this.PowerOnBTN.Text = "PowerOn";
             this.PowerOnBTN.UseVisualStyleBackColor = true;
             this.PowerOnBTN.Click += new System.EventHandler(this.OperationCauseBTN_ClickAsync);
@@ -258,10 +299,10 @@ namespace Quickstarts.StateMachines.Client
             // PowerOffBTN
             //
             this.PowerOffBTN.Enabled = false;
-            this.PowerOffBTN.Location = new System.Drawing.Point(96, 106);
+            this.PowerOffBTN.Location = new System.Drawing.Point(96, 130);
             this.PowerOffBTN.Name = "PowerOffBTN";
             this.PowerOffBTN.Size = new System.Drawing.Size(75, 23);
-            this.PowerOffBTN.TabIndex = 6;
+            this.PowerOffBTN.TabIndex = 9;
             this.PowerOffBTN.Text = "PowerOff";
             this.PowerOffBTN.UseVisualStyleBackColor = true;
             this.PowerOffBTN.Click += new System.EventHandler(this.OperationCauseBTN_ClickAsync);
@@ -269,10 +310,10 @@ namespace Quickstarts.StateMachines.Client
             // StartBTN
             //
             this.StartBTN.Enabled = false;
-            this.StartBTN.Location = new System.Drawing.Point(177, 106);
+            this.StartBTN.Location = new System.Drawing.Point(177, 130);
             this.StartBTN.Name = "StartBTN";
             this.StartBTN.Size = new System.Drawing.Size(75, 23);
-            this.StartBTN.TabIndex = 7;
+            this.StartBTN.TabIndex = 10;
             this.StartBTN.Text = "Start";
             this.StartBTN.UseVisualStyleBackColor = true;
             this.StartBTN.Click += new System.EventHandler(this.OperationCauseBTN_ClickAsync);
@@ -280,10 +321,10 @@ namespace Quickstarts.StateMachines.Client
             // StopBTN
             //
             this.StopBTN.Enabled = false;
-            this.StopBTN.Location = new System.Drawing.Point(15, 135);
+            this.StopBTN.Location = new System.Drawing.Point(15, 159);
             this.StopBTN.Name = "StopBTN";
             this.StopBTN.Size = new System.Drawing.Size(75, 23);
-            this.StopBTN.TabIndex = 8;
+            this.StopBTN.TabIndex = 11;
             this.StopBTN.Text = "Stop";
             this.StopBTN.UseVisualStyleBackColor = true;
             this.StopBTN.Click += new System.EventHandler(this.OperationCauseBTN_ClickAsync);
@@ -291,10 +332,10 @@ namespace Quickstarts.StateMachines.Client
             // FaultBTN
             //
             this.FaultBTN.Enabled = false;
-            this.FaultBTN.Location = new System.Drawing.Point(96, 135);
+            this.FaultBTN.Location = new System.Drawing.Point(96, 159);
             this.FaultBTN.Name = "FaultBTN";
             this.FaultBTN.Size = new System.Drawing.Size(75, 23);
-            this.FaultBTN.TabIndex = 9;
+            this.FaultBTN.TabIndex = 12;
             this.FaultBTN.Text = "Fault";
             this.FaultBTN.UseVisualStyleBackColor = true;
             this.FaultBTN.Click += new System.EventHandler(this.OperationCauseBTN_ClickAsync);
@@ -302,10 +343,10 @@ namespace Quickstarts.StateMachines.Client
             // ResetBTN
             //
             this.ResetBTN.Enabled = false;
-            this.ResetBTN.Location = new System.Drawing.Point(177, 135);
+            this.ResetBTN.Location = new System.Drawing.Point(177, 159);
             this.ResetBTN.Name = "ResetBTN";
             this.ResetBTN.Size = new System.Drawing.Size(75, 23);
-            this.ResetBTN.TabIndex = 10;
+            this.ResetBTN.TabIndex = 13;
             this.ResetBTN.Text = "Reset";
             this.ResetBTN.UseVisualStyleBackColor = true;
             this.ResetBTN.Click += new System.EventHandler(this.OperationCauseBTN_ClickAsync);
@@ -323,7 +364,7 @@ namespace Quickstarts.StateMachines.Client
             this.ProgramGB.Controls.Add(this.ProgramStateLB);
             this.ProgramGB.Location = new System.Drawing.Point(446, 8);
             this.ProgramGB.Name = "ProgramGB";
-            this.ProgramGB.Size = new System.Drawing.Size(430, 172);
+            this.ProgramGB.Size = new System.Drawing.Size(430, 190);
             this.ProgramGB.TabIndex = 2;
             this.ProgramGB.TabStop = false;
             this.ProgramGB.Text = "Program - the state machine of OPC 10000-10";
@@ -428,10 +469,10 @@ namespace Quickstarts.StateMachines.Client
             this.StateCH,
             this.TransitionCH});
             this.TransitionsLV.FullRowSelect = true;
-            this.TransitionsLV.Location = new System.Drawing.Point(8, 190);
+            this.TransitionsLV.Location = new System.Drawing.Point(8, 326);
             this.TransitionsLV.Name = "TransitionsLV";
-            this.TransitionsLV.Size = new System.Drawing.Size(868, 202);
-            this.TransitionsLV.TabIndex = 3;
+            this.TransitionsLV.Size = new System.Drawing.Size(868, 158);
+            this.TransitionsLV.TabIndex = 4;
             this.TransitionsLV.UseCompatibleStateImageBehavior = false;
             this.TransitionsLV.View = System.Windows.Forms.View.Details;
             //
@@ -454,6 +495,50 @@ namespace Quickstarts.StateMachines.Client
             //
             this.TransitionCH.Text = "Last transition";
             this.TransitionCH.Width = 340;
+            //
+            // ModelLV
+            //
+            this.ModelLV.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top
+            | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.ModelLV.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.KindCH,
+            this.ElementCH,
+            this.NumberCH,
+            this.ElementNodeCH,
+            this.SubMachineCH});
+            this.ModelLV.FullRowSelect = true;
+            this.ModelLV.Location = new System.Drawing.Point(8, 206);
+            this.ModelLV.Name = "ModelLV";
+            this.ModelLV.Size = new System.Drawing.Size(868, 112);
+            this.ModelLV.TabIndex = 3;
+            this.ModelLV.UseCompatibleStateImageBehavior = false;
+            this.ModelLV.View = System.Windows.Forms.View.Details;
+            //
+            // KindCH
+            //
+            this.KindCH.Text = "Element";
+            this.KindCH.Width = 80;
+            //
+            // ElementCH
+            //
+            this.ElementCH.Text = "Name";
+            this.ElementCH.Width = 170;
+            //
+            // NumberCH
+            //
+            this.NumberCH.Text = "Number";
+            this.NumberCH.Width = 70;
+            //
+            // ElementNodeCH
+            //
+            this.ElementNodeCH.Text = "NodeId";
+            this.ElementNodeCH.Width = 350;
+            //
+            // SubMachineCH
+            //
+            this.SubMachineCH.Text = "Sub state machine";
+            this.SubMachineCH.Width = 180;
             //
             // ConnectServerCTRL
             //
@@ -490,7 +575,7 @@ namespace Quickstarts.StateMachines.Client
             //
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(884, 546);
+            this.ClientSize = new System.Drawing.Size(884, 640);
             this.Controls.Add(this.MainPN);
             this.Controls.Add(this.ConnectServerCTRL);
             this.Controls.Add(this.StatusBar);
@@ -528,6 +613,9 @@ namespace Quickstarts.StateMachines.Client
         private System.Windows.Forms.TextBox OperationStateTB;
         private System.Windows.Forms.Label OperationTransitionLB;
         private System.Windows.Forms.TextBox OperationTransitionTB;
+        private System.Windows.Forms.Label ProductionStateLB;
+        private System.Windows.Forms.TextBox ProductionStateTB;
+        private System.Windows.Forms.Button StartBatchBTN;
         private System.Windows.Forms.CheckBox InterlockCB;
         private System.Windows.Forms.Button PowerOnBTN;
         private System.Windows.Forms.Button PowerOffBTN;
@@ -550,6 +638,12 @@ namespace Quickstarts.StateMachines.Client
         private System.Windows.Forms.ColumnHeader MachineCH;
         private System.Windows.Forms.ColumnHeader StateCH;
         private System.Windows.Forms.ColumnHeader TransitionCH;
+        private System.Windows.Forms.ListView ModelLV;
+        private System.Windows.Forms.ColumnHeader KindCH;
+        private System.Windows.Forms.ColumnHeader ElementCH;
+        private System.Windows.Forms.ColumnHeader NumberCH;
+        private System.Windows.Forms.ColumnHeader ElementNodeCH;
+        private System.Windows.Forms.ColumnHeader SubMachineCH;
         private Opc.Ua.Client.Controls.ConnectServerCtrl ConnectServerCTRL;
         private Opc.Ua.Client.Controls.HeaderBranding clientHeaderBranding1;
     }

--- a/Workshop/StateMachines/Client/MainForm.cs
+++ b/Workshop/StateMachines/Client/MainForm.cs
@@ -62,6 +62,15 @@ namespace Quickstarts.StateMachines.Client
     /// source generated <see cref="ProgramStateMachineTypeClient"/> proxy exposes its causes
     /// as <c>StartAsync</c>, <c>SuspendAsync</c> and so on.
     /// </para>
+    /// <para>
+    /// The vendor machine is also hierarchical, and the window shows the two halves of that.
+    /// <c>GetAvailableStatesAsync</c> and <c>GetAvailableTransitionsAsync</c> read the model a
+    /// Part 16 machine publishes - a node per state and per transition, each with its number -
+    /// and <c>GetSubStateMachineAsync</c> follows the <c>HasSubStateMachine</c> reference of a
+    /// state node to the machine which runs while the parent is in it.
+    /// <c>ObserveEffectiveStateAsync</c> then streams both machines at once, so a transition
+    /// of either is reported as one combined snapshot.
+    /// </para>
     /// </remarks>
     public partial class MainForm : Form
     {
@@ -108,9 +117,17 @@ namespace Quickstarts.StateMachines.Client
         private CancellationTokenSource m_cts;
         private FiniteStateMachineTypeClient m_operation;
         private ProgramStateMachineTypeClient m_program;
+
+        /// <summary>
+        /// The machine which runs below one of the states of the Operation machine, found
+        /// through the HasSubStateMachine reference of that state rather than by name.
+        /// </summary>
+        private FiniteStateMachineTypeClient m_production;
+
         private NodeId m_interlockNode;
         private readonly Dictionary<Button, NodeId> m_causes = new();
         private readonly Dictionary<Button, NodeId> m_programCauses = new();
+        private readonly Dictionary<Button, NodeId> m_productionCauses = new();
         private bool m_updatingInterlock;
         #endregion
 
@@ -289,9 +306,15 @@ namespace Quickstarts.StateMachines.Client
 
             await ResolveProgramCausesAsync(ct);
 
+            // what the Operation machine is made of, and which of its states has a machine of
+            // its own below it. That is where m_production comes from.
+            await ShowMachineModelAsync(ct);
+            await ResolveProductionCauseAsync(ct);
+
             // where the machines are right now, before anything moves them.
             ShowSnapshot(kOperation, await m_operation.GetCurrentFiniteStateAsync(ct), append: false);
             ShowSnapshot(kProgram, await m_program.GetCurrentFiniteStateAsync(ct), append: false);
+            await ShowProductionAsync(null, ct);
             await ReadInterlockAsync(ct);
 
             // the streaming subscription lives as long as the connection: the underlying OPC
@@ -308,8 +331,20 @@ namespace Quickstarts.StateMachines.Client
 
             // nothing is awaited here on purpose: both enumerations run for as long as the
             // client is connected, and cancelling the token is what unsubscribes them.
-            _ = PumpTransitionsAsync(kOperation, m_operation, m_cts.Token);
-            _ = PumpTransitionsAsync(kProgram, m_program, m_cts.Token);
+            //
+            // The Operation machine is watched through ObserveEffectiveStateAsync, which
+            // subscribes to the machine and to the sub state machines of its states at once
+            // and reports a transition of any of them; the Program machine has no sub state
+            // machine, so watching it as one machine is all there is to do.
+            _ = PumpTransitionsAsync(
+                kOperation,
+                m_operation.ObserveEffectiveStateAsync(m_streaming, m_telemetry, null, m_cts.Token),
+                m_cts.Token);
+
+            _ = PumpTransitionsAsync(
+                kProgram,
+                m_program.ObserveFiniteTransitionsAsync(m_streaming, null, m_cts.Token),
+                m_cts.Token);
 
             EnableControls(true);
 
@@ -354,6 +389,140 @@ namespace Quickstarts.StateMachines.Client
         }
 
         /// <summary>
+        /// Shows what the Operation machine is made of, and finds its sub state machine.
+        /// </summary>
+        /// <remarks>
+        /// Nothing here is browsed by hand. A Part 16 machine publishes its own model through
+        /// the optional <c>AvailableStates</c> and <c>AvailableTransitions</c> properties,
+        /// which name one node per state and per transition, and the two Get methods read them
+        /// together with the number each node carries. A server which materializes none of
+        /// them answers with nothing, and this list stays empty instead of the client falling
+        /// back to guessing what the machine can do.
+        /// </remarks>
+        private async Task ShowMachineModelAsync(CancellationToken ct)
+        {
+            ModelLV.Items.Clear();
+            m_production = null;
+
+            IReadOnlyList<FiniteStateInfo> states = await m_operation
+                .GetAvailableStatesAsync(ct);
+
+            IReadOnlyList<FiniteTransitionInfo> transitions = await m_operation
+                .GetAvailableTransitionsAsync(ct);
+
+            foreach (FiniteStateInfo state in states)
+            {
+                // OPC 10000-16 §4.4.16 hangs HasSubStateMachine off the state node rather than
+                // off the machine, because a machine can have one per state. So a client looks
+                // for it there, with the NodeId AvailableStates just gave it.
+                FiniteStateMachineTypeClient subMachine = await m_operation
+                    .GetSubStateMachineAsync(state.NodeId, m_telemetry, ct);
+
+                string subMachineName = string.Empty;
+
+                if (subMachine != null)
+                {
+                    subMachineName = await ReadBrowseNameAsync(subMachine.ObjectId, ct);
+
+                    // the sample's server declares exactly one, below its Running state.
+                    m_production = subMachine;
+                }
+
+                AddModelItem("State", state.BrowseName, state.StateNumber, state.NodeId, subMachineName);
+            }
+
+            foreach (FiniteTransitionInfo transition in transitions)
+            {
+                AddModelItem(
+                    "Transition",
+                    transition.BrowseName,
+                    transition.TransitionNumber,
+                    transition.NodeId,
+                    string.Empty);
+            }
+        }
+
+        /// <summary>
+        /// Adds one state or transition of the machine to the model list.
+        /// </summary>
+        private void AddModelItem(
+            string kind,
+            QualifiedName browseName,
+            uint number,
+            NodeId nodeId,
+            string subMachine)
+        {
+            var item = new ListViewItem(kind);
+
+            item.SubItems.Add(browseName.Name ?? string.Empty);
+            item.SubItems.Add(number.ToString(CultureInfo.CurrentCulture));
+
+            // the NodeId is worth showing: it is what CurrentState/Id and LastTransition/Id
+            // answer with, and a machine which materializes no nodes has nothing to put here.
+            item.SubItems.Add(nodeId.ToString());
+            item.SubItems.Add(subMachine);
+
+            ModelLV.Items.Add(item);
+        }
+
+        /// <summary>
+        /// Resolves the cause of the sub state machine, if the server has one.
+        /// </summary>
+        /// <remarks>
+        /// A sub state machine has causes of its own, and they are methods of the child rather
+        /// than of the machine the client started from.
+        /// </remarks>
+        private async Task ResolveProductionCauseAsync(CancellationToken ct)
+        {
+            m_productionCauses.Clear();
+
+            if (m_production == null)
+            {
+                return;
+            }
+
+            var wellKnownNamespaceUris = new NamespaceTable();
+            wellKnownNamespaceUris.Append(Namespaces.StateMachines);
+
+            List<NodeId> nodes = await ClientUtils.TranslateBrowsePathsAsync(
+                m_session,
+                m_production.ObjectId,
+                wellKnownNamespaceUris,
+                ct,
+                "1:StartBatch");
+
+            if (nodes.Count > 0 && !nodes[0].IsNull)
+            {
+                m_productionCauses[StartBatchBTN] = nodes[0];
+            }
+        }
+
+        /// <summary>
+        /// The browse name of a node, as text.
+        /// </summary>
+        private async Task<string> ReadBrowseNameAsync(NodeId nodeId, CancellationToken ct)
+        {
+            var nodesToRead = new[] {
+                new ReadValueId { NodeId = nodeId, AttributeId = Attributes.BrowseName },
+            }.ToArrayOf();
+
+            ReadResponse response = await m_session.ReadAsync(
+                null,
+                0,
+                TimestampsToReturn.Neither,
+                nodesToRead,
+                ct);
+
+            List<DataValue> results = response.Results.ToList();
+
+            ClientBase.ValidateResponse(results, nodesToRead.ToArray());
+
+            return results[0].WrappedValue.TryGetValue(out QualifiedName browseName)
+                ? browseName.Name
+                : string.Empty;
+        }
+
+        /// <summary>
         /// Offers only the causes which apply to the state each machine is in right now.
         /// </summary>
         /// <remarks>
@@ -363,12 +532,15 @@ namespace Quickstarts.StateMachines.Client
         /// <c>Executable</c> and <c>UserExecutable</c> attributes of the method nodes, which
         /// the sample server answers from <c>IsCausePermitted</c>. Reading them after every
         /// transition keeps the buttons in step with the machine, and keeps this client
-        /// correct if the server ever changes its state table.
+        /// correct if the server ever changes its state table. The cause of the sub state
+        /// machine is answered the same way, and applies in none of its states while the
+        /// machine is suspended.
         /// </remarks>
         private async Task RefreshPermittedCausesAsync(CancellationToken ct = default)
         {
             List<KeyValuePair<Button, NodeId>> causes = m_causes
                 .Concat(m_programCauses)
+                .Concat(m_productionCauses)
                 .ToList();
 
             if (m_session == null || causes.Count == 0)
@@ -407,22 +579,20 @@ namespace Quickstarts.StateMachines.Client
         /// Reports every transition of one state machine until the client disconnects.
         /// </summary>
         /// <remarks>
-        /// <c>ObserveFiniteTransitionsAsync</c> subscribes to <c>CurrentState/Id</c> and yields
-        /// a snapshot of the state and the transition variables per change, so the window sees
-        /// consistent data per transition and never has to assemble it from single values.
+        /// Both streams subscribe to <c>CurrentState/Id</c> and yield a snapshot of the state
+        /// and the transition variables per change, so the window sees consistent data per
+        /// transition and never has to assemble it from single values. The effective state
+        /// stream of a hierarchical machine yields the same snapshot with the state of the
+        /// active sub state machine attached to it.
         /// </remarks>
         private async Task PumpTransitionsAsync(
             string name,
-            FiniteStateMachineTypeClient stateMachine,
+            IAsyncEnumerable<FiniteStateSnapshot> snapshots,
             CancellationToken ct)
         {
-            IStreamingSubscription streaming = m_streaming;
-
             try
             {
-                await foreach (FiniteStateSnapshot snapshot in stateMachine
-                    .ObserveFiniteTransitionsAsync(streaming, null, ct)
-                    .ConfigureAwait(false))
+                await foreach (FiniteStateSnapshot snapshot in snapshots.ConfigureAwait(false))
                 {
                     if (ct.IsCancellationRequested || IsDisposed)
                     {
@@ -469,8 +639,10 @@ namespace Quickstarts.StateMachines.Client
             m_cts = null;
             m_operation = null;
             m_program = null;
+            m_production = null;
             m_causes.Clear();
             m_programCauses.Clear();
+            m_productionCauses.Clear();
 
             if (cts != null)
             {
@@ -524,6 +696,36 @@ namespace Quickstarts.StateMachines.Client
                 // here rather than waiting for the transition to come back on the stream: the
                 // buttons then follow the user's own action immediately.
                 await RefreshPermittedCausesAsync();
+            }
+            catch (Exception exception)
+            {
+                ClientUtils.HandleException(m_telemetry, this.Text, exception);
+            }
+        }
+
+        /// <summary>
+        /// Starts a batch of the sub state machine.
+        /// </summary>
+        /// <remarks>
+        /// The cause belongs to the machine below the Running state, so the call names that
+        /// object: the parent knows nothing about the methods of its child. Which is also why
+        /// the button is only offered while the child is active - a suspended sub state
+        /// machine reports none of its causes as executable.
+        /// </remarks>
+        private async void StartBatchBTN_ClickAsync(object sender, EventArgs e)
+        {
+            try
+            {
+                if (m_session == null || m_production == null ||
+                    !m_productionCauses.TryGetValue(StartBatchBTN, out NodeId methodId))
+                {
+                    return;
+                }
+
+                await m_session.CallAsync(m_production.ObjectId, methodId, default);
+
+                await RefreshPermittedCausesAsync();
+                await ShowProductionAsync(null);
             }
             catch (Exception exception)
             {
@@ -670,6 +872,11 @@ namespace Quickstarts.StateMachines.Client
             {
                 ShowSnapshot(name, snapshot, append: true);
 
+                if (name == kOperation)
+                {
+                    await ShowProductionAsync(snapshot.SubMachine);
+                }
+
                 await RefreshPermittedCausesAsync();
             }
             catch (Exception exception)
@@ -698,6 +905,14 @@ namespace Quickstarts.StateMachines.Client
             {
                 OperationStateTB.Text = state;
                 OperationTransitionTB.Text = transition;
+
+                // where a hierarchical machine is, is both states at once: the row records
+                // them together, so a transition of the child is not mistaken for one of the
+                // parent standing still.
+                if (snapshot.SubMachine != null)
+                {
+                    state = $"{state} / {DescribeSubMachine(snapshot.SubMachine)}";
+                }
             }
             else
             {
@@ -722,6 +937,48 @@ namespace Quickstarts.StateMachines.Client
         }
 
         /// <summary>
+        /// Shows where the sub state machine of the Operation machine is.
+        /// </summary>
+        /// <remarks>
+        /// The effective state stream only carries the child while the parent is in the state
+        /// the child belongs to, and drops what a child reports while the parent is elsewhere -
+        /// otherwise a machine which is not running would appear to be producing. So a yield
+        /// without a sub machine is the moment to ask the child itself, which is also what
+        /// answers <c>Bad_StateNotActive</c> while it is suspended.
+        /// </remarks>
+        private async Task ShowProductionAsync(
+            FiniteStateSnapshot fromStream,
+            CancellationToken ct = default)
+        {
+            if (m_production == null)
+            {
+                ProductionStateTB.Text = "(no sub state machine)";
+                return;
+            }
+
+            FiniteStateSnapshot snapshot = fromStream
+                ?? await m_production.GetCurrentFiniteStateAsync(ct);
+
+            ProductionStateTB.Text = DescribeSubMachine(snapshot);
+        }
+
+        /// <summary>
+        /// The state of a sub state machine, or why there is none to report.
+        /// </summary>
+        private static string DescribeSubMachine(FiniteStateSnapshot snapshot)
+        {
+            // OPC 10000-16 §4.4.6: a suspended sub state machine reports its state variables
+            // with Bad_StateNotActive rather than with the state it stopped in, so the status
+            // is the answer and the value below it means nothing.
+            if (StatusCode.IsBad(snapshot.Status))
+            {
+                return $"({snapshot.Status})";
+            }
+
+            return snapshot.CurrentState.Text ?? string.Empty;
+        }
+
+        /// <summary>
         /// Enables the controls which need a session.
         /// </summary>
         private void EnableControls(bool enabled)
@@ -734,6 +991,9 @@ namespace Quickstarts.StateMachines.Client
             StopBTN.Enabled = enabled;
             FaultBTN.Enabled = enabled;
             ResetBTN.Enabled = enabled;
+
+            // only a server which has a sub state machine has a cause to offer for it
+            StartBatchBTN.Enabled = enabled && m_productionCauses.Count > 0;
 
             ProgramStartBTN.Enabled = enabled;
             ProgramSuspendBTN.Enabled = enabled;

--- a/Workshop/StateMachines/Server/StateMachinesNodeManager.cs
+++ b/Workshop/StateMachines/Server/StateMachinesNodeManager.cs
@@ -147,6 +147,13 @@ namespace Quickstarts.StateMachines.Server
         /// <summary>The Reset method, and the id of the cause it triggers.</summary>
         public const uint ResetCause = 106;
 
+        /// <summary>
+        /// The StartBatch method of the Production machine, and the id of the cause it
+        /// triggers. A sub state machine has causes of its own, and they are numbered from
+        /// the same range: the cause id is the numeric identifier of the method node.
+        /// </summary>
+        public const uint StartBatchCause = 111;
+
         // The states and transitions of the Operation machine. They are numbered from a range
         // of their own: the framework materializes a node per state and per transition, and
         // the number becomes its StateNumber or TransitionNumber, so a state id which is also
@@ -181,6 +188,29 @@ namespace Quickstarts.StateMachines.Server
 
         /// <summary>Faulted to Idle, caused by Reset or by the automatic reset.</summary>
         public const uint FaultedToIdleTransition = 2006;
+
+        // The states and transitions of the Production machine, which runs below the Running
+        // state of the Operation machine. They are numbered from a range of their own, but
+        // only for the reader: a sub state machine has its own state and transition tables,
+        // so the numbers would not collide with the ones above even if they were reused.
+
+        /// <summary>Material for the next batch is being loaded.</summary>
+        public const uint LoadingState = 3001;
+
+        /// <summary>The batch is being processed.</summary>
+        public const uint ProcessingState = 3002;
+
+        /// <summary>The finished batch is being taken out.</summary>
+        public const uint UnloadingState = 3003;
+
+        /// <summary>Loading to Processing, caused by StartBatch.</summary>
+        public const uint LoadingToProcessingTransition = 4001;
+
+        /// <summary>Processing to Unloading, taken when the batch is done.</summary>
+        public const uint ProcessingToUnloadingTransition = 4002;
+
+        /// <summary>Unloading to Loading, taken when the batch has been taken out.</summary>
+        public const uint UnloadingToLoadingTransition = 4003;
         #endregion
 
         #region Timings
@@ -193,6 +223,16 @@ namespace Quickstarts.StateMachines.Server
         /// How long the Program machine runs before it completes on its own.
         /// </summary>
         public static readonly TimeSpan ProgramRunDuration = TimeSpan.FromSeconds(15);
+
+        /// <summary>
+        /// How long a batch of the Production machine takes once it was started.
+        /// </summary>
+        public static readonly TimeSpan BatchDuration = TimeSpan.FromSeconds(5);
+
+        /// <summary>
+        /// How long the Production machine takes to unload a finished batch.
+        /// </summary>
+        public static readonly TimeSpan UnloadDuration = TimeSpan.FromSeconds(3);
         #endregion
 
         #region Constructors
@@ -333,11 +373,24 @@ namespace Quickstarts.StateMachines.Server
         /// Builds the Operation machine, which has no type definition of its own.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// Everything the machine is, is in this one chain: the states, the transitions
-        /// between them, which method call causes which transition, and the behaviour which
-        /// hangs off entering and leaving a state. The builder freezes the definition as soon
-        /// as the first lifecycle method is called - <c>WithInitialState</c> below - and
-        /// creates the node in the address space at that point.
+        /// between them, which method call causes which transition, the behaviour which hangs
+        /// off entering and leaving a state, and the machine which runs below one of the
+        /// states. The builder freezes the definition as soon as the first lifecycle method
+        /// is called - <c>WithInitialState</c> below - and creates the node in the address
+        /// space at that point.
+        /// </para>
+        /// <para>
+        /// Creating the node is also what materializes the Part 16 model of the machine: a
+        /// <c>StateType</c> node per state carrying its <c>StateNumber</c>, a
+        /// <c>TransitionType</c> node per transition carrying its <c>TransitionNumber</c> and
+        /// the §4.4.11 <c>FromState</c> / <c>ToState</c> / <c>HasEffect</c> references, the
+        /// <c>HasCause</c> reference each <c>WithCause</c> adds, and the <c>AvailableStates</c>
+        /// / <c>AvailableTransitions</c> properties which list them. That is what lets
+        /// <c>CurrentState/Id</c> name a node a client can browse to, instead of an identifier
+        /// which resolves to nothing.
+        /// </para>
         /// </remarks>
         private void CreateOperationStateMachine(BaseObjectState machine)
         {
@@ -432,7 +485,97 @@ namespace Quickstarts.StateMachines.Server
                     fromStateId: FaultedState,
                     timeout: AutomaticResetDelay,
                     transitionId: FaultedToIdleTransition,
-                    causeId: ResetCause);
+                    causeId: ResetCause)
+
+                // one of the four states has a machine of its own below it.
+                .WithSubStateMachine(
+                    parentStateId: RunningState,
+                    browseName: new QualifiedName("Production", NamespaceIndex),
+                    configure: ConfigureProductionStateMachine,
+
+                    // every run starts at the beginning: leaving Running takes the child back
+                    // to Loading. With preserveOnReentry: true it would come back where it
+                    // stopped instead, which is what a machine whose sub state survives a
+                    // pause - a tool changer, a heater - wants.
+                    preserveOnReentry: false);
+        }
+
+        /// <summary>
+        /// Declares the Production machine, which runs while the Operation machine is Running.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// OPC 10000-16 §5.2.3 nests machines through <c>HasSubStateMachine</c>, which is how
+        /// the standard alarms model <c>ExclusiveLimitAlarmType.LimitState</c>. The reference
+        /// hangs off the parent <i>state</i> node - Running - rather than off the machine, and
+        /// the child is a component of the parent machine, so a client which browses Operation
+        /// finds Production next to the states and reaches it from the Running state node.
+        /// </para>
+        /// <para>
+        /// The framework owns the lifecycle of the child: entering Running activates it and
+        /// resets it to its initial state, leaving Running suspends it. While it is suspended
+        /// its <c>CurrentState</c> and <c>LastTransition</c> read <c>Bad_StateNotActive</c>
+        /// (§4.4.6), its causes are not executable and a transition driven anyway is refused.
+        /// Nothing in this sample has to write that logic.
+        /// </para>
+        /// </remarks>
+        private void ConfigureProductionStateMachine(
+            StateMachineBuilder<FluentFiniteStateMachineState> production)
+        {
+            production
+                // the same call the parent makes, for the same reason: the child mints state
+                // and transition nodes of its own, and they belong in the namespace of the
+                // sample rather than in the OPC UA one the element namespace defaults to.
+                .UseElementNamespace(Namespaces.StateMachines)
+
+                .AddState(LoadingState, "Loading", isInitial: true)
+                .AddState(ProcessingState, "Processing")
+                .AddState(UnloadingState, "Unloading")
+
+                .AddTransition(
+                    LoadingToProcessingTransition,
+                    "LoadingToProcessing",
+                    from: LoadingState,
+                    to: ProcessingState)
+                .AddTransition(
+                    ProcessingToUnloadingTransition,
+                    "ProcessingToUnloading",
+                    from: ProcessingState,
+                    to: UnloadingState)
+                .AddTransition(
+                    UnloadingToLoadingTransition,
+                    "UnloadingToLoading",
+                    from: UnloadingState,
+                    to: LoadingState)
+
+                .OnCause(StartBatchCause, from: LoadingState, transition: LoadingToProcessingTransition);
+
+            // reading StateMachine freezes the definition and creates the child node, which is
+            // what the method has to be a child of before WithCause can find it. The declared
+            // initial state is not applied here: a sub state machine only enters it when its
+            // parent enters the state it hangs off.
+            FluentFiniteStateMachineState machine = production.StateMachine;
+
+            AddCauseMethod(machine, StartBatchCause, "StartBatch");
+
+            production
+                .WithCause(new NodeId(StartBatchCause, NamespaceIndex))
+
+                // the rest of the batch runs without anybody asking for it. Both timers are
+                // armed by the transition which enters their state, so a suspended child -
+                // which is not in any state at all - has none of them running.
+                .WithTimedTransition(
+                    fromStateId: ProcessingState,
+                    timeout: BatchDuration,
+                    transitionId: ProcessingToUnloadingTransition)
+                .WithTimedTransition(
+                    fromStateId: UnloadingState,
+                    timeout: UnloadDuration,
+                    transitionId: UnloadingToLoadingTransition)
+
+                .OnTransition(
+                    (context, stateMachine, fromState, toState)
+                        => LogTransition("Production", fromState, toState));
         }
 
         /// <summary>

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -476,7 +476,7 @@ the sample exists to show:
 | RoleManagement | signs in as an Operator and presses Reset | the server answered Good and the set point is back at its default - the case which motivated all of this | `RoleManagementClientTests` |
 | Sample | opens a session through the modal dialog | a `ManagedSession` on the V2 engine, and a filled browse tree | `SampleClientFormTests` |
 | SimpleEvents | connects | an event reaches the list | `WorkshopClientSubscriptionTests` |
-| StateMachines | powers the machine on and starts it | a transition of the machine it powered on reaches the list | `WorkshopClientSubscriptionTests` |
+| StateMachines | powers the machine on and starts it | a transition reaches the list, the states and transitions of the machine are listed, and the sub state machine of the Running state is active | `WorkshopClientSubscriptionTests` |
 | UserAuthentication | writes the log file path anonymously, then impersonates an unknown account | the write is refused with `BadUserAccessDenied` and the sample reports it; the refused impersonation leaves the session's identity alone | `SampleClientActionTests` |
 | Views | selects the engineering view and presses Change | the operations nodes are gone from the re-browse and the engineering ones are still there | `SampleClientActionTests` |
 


### PR DESCRIPTION
## Proposed changes

The StateMachines sample was written against `2.0.0-preview.2`, whose fluent builder materialized no state or transition nodes and could not usefully attach a sub state machine to a state. `2.0.0-preview.4` does both, so the two parts issue #829 deferred can now be built.

**Server** (`Workshop/StateMachines/Server/StateMachinesNodeManager.cs`)

- The `Operation` machine gains a `Production` sub state machine below its `Running` state, in the sample's own namespace: `Loading` (initial) → `Processing` → `Unloading` → `Loading`, with `StartBatch` as a cause of the child and the rest of the batch on the child's own timed transitions. The framework activates the child and resets it to `Loading` when the parent enters `Running` and suspends it when the parent leaves — declared with `preserveOnReentry: false`, and the remarks say what `true` would do instead.
- Everything else is what the builder now materializes on its own, so the server code did not grow for it: a `StateType` node per state carrying `StateNumber` (the initial one an `InitialStateType`), a `TransitionType` node per transition carrying `TransitionNumber` and the §4.4.11 `FromState` / `ToState` / `HasEffect` references, the `HasCause` reference each `WithCause` adds, and the `AvailableStates` / `AvailableTransitions` properties. `CurrentState/Id` now names a node a client can browse to.

**Client** (`Workshop/StateMachines/Client/MainForm.cs`)

- A model list, one row per state and per transition with its number and NodeId, read through `GetAvailableStatesAsync` / `GetAvailableTransitionsAsync` rather than browsed by hand.
- `GetSubStateMachineAsync` on each state node is how the client finds `Production` — off the state node per §4.4.16, not by browse name.
- The `Operation` machine is watched through `ObserveEffectiveStateAsync`, so a transition of the parent or of the child is reported as one combined snapshot and a row reads `Running / Processing`. The `Program` machine keeps `ObserveFiniteTransitionsAsync`, which is the contrast worth showing.
- A `Production state` field shows the child, including the `Bad_StateNotActive` it reports while suspended, and a `StartBatch` button is offered only while the child's cause is executable.

## Related Issues

- Fixes #829

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [x] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines.
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.

## Further comments

**Tests.** The existing browse shape assertion covers the new children of the machine. Five new cases in `StateMachinesNodeManagerTests` hold the sample to `AvailableStates` / `AvailableTransitions` listing exactly the nodes below the machine in declaration order with the declared numbers, to the `FromState` / `ToState` / `HasCause` / `HasEffect` references of a transition, to `HasSubStateMachine` hanging off the state node and *not* off the machine root, to `Bad_StateNotActive` and `Bad_NotExecutable` while the child is suspended, and to a batch running to completion on the child's timers and starting over when the parent re-enters `Running`. The tier 2 case in `WorkshopClientSubscriptionTests` now also checks the model list, the child's cause becoming executable once the machine is started, and the sub state the window shows.

Locally: `StateMachinesNodeManagerTests` 15/15, `WorkshopClientSubscriptionTests` 7/7, whole solution builds without new warnings.

**Two things a reviewer may want to know about the child machine.** Its cause method has to be added after reading `.StateMachine` inside `configure` — that read is what freezes the child and creates the node the method hangs on. And a child is activated through `SetState`, which runs no dispatcher synchronization, so no timed transition is armed out of the child's initial state; the child's first move is therefore a cause (`StartBatch`) and only the later transitions are timed. A timer left armed when the parent leaves is harmless: `DoTransition` is refused with `BadStateNotActive`, and after the reset the from-state no longer matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
